### PR TITLE
Update to SpinalHDL 1.5.0, refactor PMP plugin API

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/Makefile
+++ b/pythondata_cpu_vexriscv/verilog/Makefile
@@ -48,7 +48,7 @@ VexRiscv_LinuxNoDspFmax.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal --singleCycleMulDiv=false --relaxedPcCalculation=true --prediction=none --outputFile VexRiscv_LinuxNoDspFmax"
 
 VexRiscv_Secure.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --pmp true --csrPluginConfig secure --outputFile VexRiscv_Secure"
+	sbt compile "runMain vexriscv.GenCoreDefault --pmpRegions 16 --pmpGranularity 256 --csrPluginConfig secure --outputFile VexRiscv_Secure"
 
 VexRiscv_SecureDebug.v: $(SRC)
-	sbt compile "runMain vexriscv.GenCoreDefault --pmp true --csrPluginConfig secure -d --outputFile VexRiscv_SecureDebug"
+	sbt compile "runMain vexriscv.GenCoreDefault --pmpRegions 16 --pmpGranularity 256 --csrPluginConfig secure -d --outputFile VexRiscv_SecureDebug"

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -73,37 +73,37 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_165;
-  wire                _zz_166;
-  wire                _zz_167;
-  wire                _zz_168;
-  wire                _zz_169;
-  wire                _zz_170;
-  wire                _zz_171;
-  wire                _zz_172;
-  reg                 _zz_173;
-  wire                _zz_174;
-  wire       [31:0]   _zz_175;
-  wire                _zz_176;
-  wire       [31:0]   _zz_177;
-  reg                 _zz_178;
-  wire                _zz_179;
-  wire                _zz_180;
-  wire       [31:0]   _zz_181;
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  wire       [3:0]    _zz_190;
-  wire                _zz_191;
-  wire                _zz_192;
-  reg        [31:0]   _zz_193;
-  reg        [31:0]   _zz_194;
-  reg        [31:0]   _zz_195;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -126,6 +126,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -134,320 +135,267 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  wire                _zz_207;
-  wire                _zz_208;
-  wire       [1:0]    _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire                _zz_212;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire       [1:0]    _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire                _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire       [1:0]    _zz_228;
-  wire                _zz_229;
-  wire       [1:0]    _zz_230;
-  wire       [51:0]   _zz_231;
-  wire       [51:0]   _zz_232;
-  wire       [51:0]   _zz_233;
-  wire       [32:0]   _zz_234;
-  wire       [51:0]   _zz_235;
-  wire       [49:0]   _zz_236;
-  wire       [51:0]   _zz_237;
-  wire       [49:0]   _zz_238;
-  wire       [51:0]   _zz_239;
-  wire       [32:0]   _zz_240;
-  wire       [31:0]   _zz_241;
-  wire       [32:0]   _zz_242;
-  wire       [0:0]    _zz_243;
-  wire       [0:0]    _zz_244;
-  wire       [0:0]    _zz_245;
-  wire       [0:0]    _zz_246;
-  wire       [0:0]    _zz_247;
-  wire       [0:0]    _zz_248;
-  wire       [0:0]    _zz_249;
-  wire       [0:0]    _zz_250;
-  wire       [0:0]    _zz_251;
-  wire       [0:0]    _zz_252;
-  wire       [0:0]    _zz_253;
-  wire       [0:0]    _zz_254;
-  wire       [0:0]    _zz_255;
-  wire       [0:0]    _zz_256;
-  wire       [0:0]    _zz_257;
-  wire       [0:0]    _zz_258;
-  wire       [0:0]    _zz_259;
-  wire       [3:0]    _zz_260;
-  wire       [2:0]    _zz_261;
-  wire       [31:0]   _zz_262;
-  wire       [11:0]   _zz_263;
-  wire       [31:0]   _zz_264;
-  wire       [19:0]   _zz_265;
-  wire       [11:0]   _zz_266;
-  wire       [31:0]   _zz_267;
-  wire       [31:0]   _zz_268;
-  wire       [19:0]   _zz_269;
-  wire       [11:0]   _zz_270;
-  wire       [2:0]    _zz_271;
-  wire       [2:0]    _zz_272;
-  wire       [0:0]    _zz_273;
-  wire       [2:0]    _zz_274;
-  wire       [4:0]    _zz_275;
-  wire       [11:0]   _zz_276;
-  wire       [11:0]   _zz_277;
-  wire       [31:0]   _zz_278;
-  wire       [31:0]   _zz_279;
-  wire       [31:0]   _zz_280;
-  wire       [31:0]   _zz_281;
-  wire       [31:0]   _zz_282;
-  wire       [31:0]   _zz_283;
-  wire       [31:0]   _zz_284;
-  wire       [11:0]   _zz_285;
-  wire       [19:0]   _zz_286;
-  wire       [11:0]   _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [31:0]   _zz_289;
-  wire       [31:0]   _zz_290;
-  wire       [11:0]   _zz_291;
-  wire       [19:0]   _zz_292;
-  wire       [11:0]   _zz_293;
-  wire       [2:0]    _zz_294;
-  wire       [1:0]    _zz_295;
-  wire       [1:0]    _zz_296;
-  wire       [65:0]   _zz_297;
-  wire       [65:0]   _zz_298;
-  wire       [31:0]   _zz_299;
-  wire       [31:0]   _zz_300;
-  wire       [0:0]    _zz_301;
-  wire       [5:0]    _zz_302;
-  wire       [32:0]   _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [32:0]   _zz_306;
-  wire       [32:0]   _zz_307;
-  wire       [32:0]   _zz_308;
-  wire       [32:0]   _zz_309;
-  wire       [0:0]    _zz_310;
-  wire       [32:0]   _zz_311;
-  wire       [0:0]    _zz_312;
-  wire       [32:0]   _zz_313;
-  wire       [0:0]    _zz_314;
-  wire       [31:0]   _zz_315;
-  wire       [0:0]    _zz_316;
-  wire       [0:0]    _zz_317;
-  wire       [0:0]    _zz_318;
-  wire       [0:0]    _zz_319;
-  wire       [0:0]    _zz_320;
-  wire       [0:0]    _zz_321;
-  wire       [26:0]   _zz_322;
-  wire                _zz_323;
-  wire                _zz_324;
-  wire       [1:0]    _zz_325;
-  wire       [31:0]   _zz_326;
-  wire       [31:0]   _zz_327;
-  wire       [31:0]   _zz_328;
-  wire                _zz_329;
-  wire       [0:0]    _zz_330;
-  wire       [13:0]   _zz_331;
-  wire       [31:0]   _zz_332;
-  wire       [31:0]   _zz_333;
-  wire       [31:0]   _zz_334;
-  wire                _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [7:0]    _zz_337;
-  wire       [31:0]   _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire                _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [1:0]    _zz_343;
-  wire                _zz_344;
-  wire                _zz_345;
-  wire                _zz_346;
-  wire       [31:0]   _zz_347;
-  wire       [31:0]   _zz_348;
-  wire                _zz_349;
-  wire       [0:0]    _zz_350;
-  wire       [0:0]    _zz_351;
-  wire                _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [24:0]   _zz_354;
-  wire       [31:0]   _zz_355;
-  wire                _zz_356;
-  wire                _zz_357;
-  wire       [0:0]    _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [0:0]    _zz_360;
-  wire       [0:0]    _zz_361;
-  wire                _zz_362;
-  wire       [0:0]    _zz_363;
-  wire       [20:0]   _zz_364;
-  wire       [31:0]   _zz_365;
-  wire       [31:0]   _zz_366;
-  wire                _zz_367;
-  wire                _zz_368;
-  wire       [0:0]    _zz_369;
-  wire       [1:0]    _zz_370;
-  wire       [0:0]    _zz_371;
-  wire       [0:0]    _zz_372;
-  wire                _zz_373;
-  wire       [0:0]    _zz_374;
-  wire       [17:0]   _zz_375;
-  wire       [31:0]   _zz_376;
-  wire       [31:0]   _zz_377;
-  wire       [31:0]   _zz_378;
-  wire       [31:0]   _zz_379;
-  wire       [31:0]   _zz_380;
-  wire       [31:0]   _zz_381;
-  wire       [31:0]   _zz_382;
-  wire       [31:0]   _zz_383;
-  wire                _zz_384;
-  wire       [1:0]    _zz_385;
-  wire       [1:0]    _zz_386;
-  wire                _zz_387;
-  wire       [0:0]    _zz_388;
-  wire       [14:0]   _zz_389;
-  wire       [31:0]   _zz_390;
-  wire       [31:0]   _zz_391;
-  wire       [31:0]   _zz_392;
-  wire       [31:0]   _zz_393;
-  wire       [31:0]   _zz_394;
-  wire       [31:0]   _zz_395;
-  wire       [0:0]    _zz_396;
-  wire       [0:0]    _zz_397;
-  wire       [2:0]    _zz_398;
-  wire       [2:0]    _zz_399;
-  wire                _zz_400;
-  wire       [0:0]    _zz_401;
-  wire       [11:0]   _zz_402;
-  wire       [31:0]   _zz_403;
-  wire       [31:0]   _zz_404;
-  wire       [31:0]   _zz_405;
-  wire       [31:0]   _zz_406;
-  wire                _zz_407;
-  wire                _zz_408;
-  wire       [31:0]   _zz_409;
-  wire       [31:0]   _zz_410;
-  wire       [0:0]    _zz_411;
-  wire       [3:0]    _zz_412;
-  wire       [4:0]    _zz_413;
-  wire       [4:0]    _zz_414;
-  wire                _zz_415;
-  wire       [0:0]    _zz_416;
-  wire       [8:0]    _zz_417;
-  wire       [31:0]   _zz_418;
-  wire       [31:0]   _zz_419;
-  wire       [31:0]   _zz_420;
-  wire       [31:0]   _zz_421;
-  wire       [0:0]    _zz_422;
-  wire       [1:0]    _zz_423;
-  wire       [0:0]    _zz_424;
-  wire       [2:0]    _zz_425;
-  wire       [0:0]    _zz_426;
-  wire       [4:0]    _zz_427;
-  wire       [1:0]    _zz_428;
-  wire       [1:0]    _zz_429;
-  wire                _zz_430;
-  wire       [0:0]    _zz_431;
-  wire       [6:0]    _zz_432;
-  wire       [31:0]   _zz_433;
-  wire       [31:0]   _zz_434;
-  wire                _zz_435;
-  wire                _zz_436;
-  wire       [31:0]   _zz_437;
-  wire       [31:0]   _zz_438;
-  wire                _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [0:0]    _zz_441;
-  wire                _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [2:0]    _zz_444;
-  wire                _zz_445;
-  wire       [0:0]    _zz_446;
-  wire       [0:0]    _zz_447;
-  wire       [0:0]    _zz_448;
-  wire       [0:0]    _zz_449;
-  wire                _zz_450;
-  wire       [0:0]    _zz_451;
-  wire       [4:0]    _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire       [31:0]   _zz_458;
-  wire       [31:0]   _zz_459;
-  wire       [31:0]   _zz_460;
-  wire       [31:0]   _zz_461;
-  wire       [31:0]   _zz_462;
-  wire                _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [0:0]    _zz_465;
-  wire       [31:0]   _zz_466;
-  wire       [31:0]   _zz_467;
-  wire       [31:0]   _zz_468;
-  wire       [31:0]   _zz_469;
-  wire       [31:0]   _zz_470;
-  wire                _zz_471;
-  wire       [3:0]    _zz_472;
-  wire       [3:0]    _zz_473;
-  wire                _zz_474;
-  wire       [0:0]    _zz_475;
-  wire       [2:0]    _zz_476;
-  wire       [31:0]   _zz_477;
-  wire       [31:0]   _zz_478;
-  wire       [31:0]   _zz_479;
-  wire       [31:0]   _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire                _zz_483;
-  wire       [0:0]    _zz_484;
-  wire       [1:0]    _zz_485;
-  wire                _zz_486;
-  wire       [2:0]    _zz_487;
-  wire       [2:0]    _zz_488;
-  wire                _zz_489;
-  wire       [0:0]    _zz_490;
-  wire       [0:0]    _zz_491;
-  wire       [31:0]   _zz_492;
-  wire       [31:0]   _zz_493;
-  wire       [31:0]   _zz_494;
-  wire       [31:0]   _zz_495;
-  wire       [31:0]   _zz_496;
-  wire       [31:0]   _zz_497;
-  wire       [31:0]   _zz_498;
-  wire                _zz_499;
-  wire                _zz_500;
-  wire                _zz_501;
-  wire       [0:0]    _zz_502;
-  wire       [0:0]    _zz_503;
-  wire                _zz_504;
-  wire                _zz_505;
-  wire                _zz_506;
-  wire                _zz_507;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -458,8 +406,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
@@ -470,27 +418,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -499,17 +447,17 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -530,11 +478,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -542,10 +490,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -555,45 +503,45 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -612,10 +560,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -702,7 +650,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -736,6 +684,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -753,28 +706,34 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_54;
-  wire       [3:0]    _zz_55;
-  wire                _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -797,16 +756,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_62;
-  wire                _zz_63;
-  reg                 _zz_64;
-  wire                _zz_65;
-  reg                 _zz_66;
-  reg        [31:0]   _zz_67;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -814,22 +775,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_68;
-  reg        [18:0]   _zz_69;
-  wire                _zz_70;
-  reg        [10:0]   _zz_71;
-  wire                _zz_72;
-  reg        [18:0]   _zz_73;
-  reg                 _zz_74;
-  wire                _zz_75;
-  reg        [10:0]   _zz_76;
-  wire                _zz_77;
-  reg        [18:0]   _zz_78;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -837,7 +805,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_79;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -845,6 +813,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -852,7 +825,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -860,8 +833,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -869,38 +843,52 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_80;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_81;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_82;
-  reg        [31:0]   _zz_83;
-  wire                _zz_84;
-  reg        [31:0]   _zz_85;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [31:0]   _zz_86;
-  wire                _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
-  wire                _zz_90;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_91;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_92;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_93;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_94;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_96;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_97;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -908,52 +896,70 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_98;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_99;
-  reg        [31:0]   _zz_100;
-  wire                _zz_101;
-  reg        [19:0]   _zz_102;
-  wire                _zz_103;
-  reg        [19:0]   _zz_104;
-  reg        [31:0]   _zz_105;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_107;
-  reg                 _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
-  reg        [4:0]    _zz_111;
-  reg        [31:0]   _zz_112;
-  wire                _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire                _zz_118;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_119;
-  reg                 _zz_120;
-  reg                 _zz_121;
-  wire                _zz_122;
-  reg        [19:0]   _zz_123;
-  wire                _zz_124;
-  reg        [10:0]   _zz_125;
-  wire                _zz_126;
-  reg        [18:0]   _zz_127;
-  reg                 _zz_128;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_129;
-  reg        [19:0]   _zz_130;
-  wire                _zz_131;
-  reg        [10:0]   _zz_132;
-  wire                _zz_133;
-  reg        [18:0]   _zz_134;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -974,9 +980,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -989,40 +995,64 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_138;
-  wire                _zz_139;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1030,6 +1060,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1042,186 +1074,275 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_140;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  reg        [32:0]   _zz_144;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_145;
-  wire       [31:0]   _zz_146;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_49;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_50;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_51;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_54;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_55;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_57;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_147;
-  reg        [31:0]   _zz_148;
-  reg        [31:0]   _zz_149;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [2:0]    _zz_156;
-  reg                 _zz_157;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_158;
-  wire                _zz_159;
-  wire                _zz_160;
-  wire                _zz_161;
-  wire                _zz_162;
-  wire                _zz_163;
-  reg                 _zz_164;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_51_string;
-  reg [95:0] _zz_91_string;
-  reg [63:0] _zz_92_string;
-  reg [23:0] _zz_93_string;
-  reg [39:0] _zz_94_string;
-  reg [71:0] _zz_95_string;
-  reg [31:0] _zz_96_string;
-  reg [39:0] _zz_97_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1230,487 +1351,458 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_196 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_197 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_198 = 1'b1;
-  assign _zz_199 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_200 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_201 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_202 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_203 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_204 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_205 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_206 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_207 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_208 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_209 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_210 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_211 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_212 = (1'b0 || (! 1'b1));
-  assign _zz_213 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_214 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_215 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_216 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_217 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_218 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_219 = execute_INSTRUCTION[13 : 12];
-  assign _zz_220 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_221 = (! memory_arbitration_isStuck);
-  assign _zz_222 = (iBus_cmd_valid || (_zz_156 != 3'b000));
-  assign _zz_223 = (_zz_192 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_224 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_225 = ((_zz_135 && 1'b1) && (! 1'b0));
-  assign _zz_226 = ((_zz_136 && 1'b1) && (! 1'b0));
-  assign _zz_227 = ((_zz_137 && 1'b1) && (! 1'b0));
-  assign _zz_228 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_229 = execute_INSTRUCTION[13];
-  assign _zz_230 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_231 = ($signed(_zz_232) + $signed(_zz_237));
-  assign _zz_232 = ($signed(_zz_233) + $signed(_zz_235));
-  assign _zz_233 = 52'h0;
-  assign _zz_234 = {1'b0,memory_MUL_LL};
-  assign _zz_235 = {{19{_zz_234[32]}}, _zz_234};
-  assign _zz_236 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_237 = {{2{_zz_236[49]}}, _zz_236};
-  assign _zz_238 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_239 = {{2{_zz_238[49]}}, _zz_238};
-  assign _zz_240 = ($signed(_zz_242) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_241 = _zz_240[31 : 0];
-  assign _zz_242 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_243 = _zz_86[31 : 31];
-  assign _zz_244 = _zz_86[30 : 30];
-  assign _zz_245 = _zz_86[29 : 29];
-  assign _zz_246 = _zz_86[28 : 28];
-  assign _zz_247 = _zz_86[25 : 25];
-  assign _zz_248 = _zz_86[17 : 17];
-  assign _zz_249 = _zz_86[16 : 16];
-  assign _zz_250 = _zz_86[13 : 13];
-  assign _zz_251 = _zz_86[12 : 12];
-  assign _zz_252 = _zz_86[11 : 11];
-  assign _zz_253 = _zz_86[15 : 15];
-  assign _zz_254 = _zz_86[5 : 5];
-  assign _zz_255 = _zz_86[3 : 3];
-  assign _zz_256 = _zz_86[20 : 20];
-  assign _zz_257 = _zz_86[10 : 10];
-  assign _zz_258 = _zz_86[4 : 4];
-  assign _zz_259 = _zz_86[0 : 0];
-  assign _zz_260 = (_zz_54 - 4'b0001);
-  assign _zz_261 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_262 = {29'd0, _zz_261};
-  assign _zz_263 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_264 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_265 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_266 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_267 = {{_zz_71,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_268 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_269 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_270 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_271 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_272 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_273 = execute_SRC_LESS;
-  assign _zz_274 = 3'b100;
-  assign _zz_275 = execute_INSTRUCTION[19 : 15];
-  assign _zz_276 = execute_INSTRUCTION[31 : 20];
-  assign _zz_277 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_278 = ($signed(_zz_279) + $signed(_zz_282));
-  assign _zz_279 = ($signed(_zz_280) + $signed(_zz_281));
-  assign _zz_280 = execute_SRC1;
-  assign _zz_281 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_282 = (execute_SRC_USE_SUB_LESS ? _zz_283 : _zz_284);
-  assign _zz_283 = 32'h00000001;
-  assign _zz_284 = 32'h0;
-  assign _zz_285 = execute_INSTRUCTION[31 : 20];
-  assign _zz_286 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_287 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_288 = {_zz_123,execute_INSTRUCTION[31 : 20]};
-  assign _zz_289 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_290 = {{_zz_127,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_291 = execute_INSTRUCTION[31 : 20];
-  assign _zz_292 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_293 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_294 = 3'b100;
-  assign _zz_295 = (_zz_138 & (~ _zz_296));
-  assign _zz_296 = (_zz_138 - 2'b01);
-  assign _zz_297 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_298 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_299 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_300 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_301 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_302 = {5'd0, _zz_301};
-  assign _zz_303 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_304 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_305 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_306 = {_zz_140,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_307 = _zz_308;
-  assign _zz_308 = _zz_309;
-  assign _zz_309 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_311);
-  assign _zz_310 = memory_DivPlugin_div_needRevert;
-  assign _zz_311 = {32'd0, _zz_310};
-  assign _zz_312 = _zz_143;
-  assign _zz_313 = {32'd0, _zz_312};
-  assign _zz_314 = _zz_142;
-  assign _zz_315 = {31'd0, _zz_314};
-  assign _zz_316 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_317 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_318 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_319 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_320 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_321 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_322 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_323 = 1'b1;
-  assign _zz_324 = 1'b1;
-  assign _zz_325 = {_zz_58,_zz_57};
-  assign _zz_326 = 32'h0000107f;
-  assign _zz_327 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_328 = 32'h00002073;
-  assign _zz_329 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_330 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_331 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_332) == 32'h00000003),{(_zz_333 == _zz_334),{_zz_335,{_zz_336,_zz_337}}}}}};
-  assign _zz_332 = 32'h0000505f;
-  assign _zz_333 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_334 = 32'h00000063;
-  assign _zz_335 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_336 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_337 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_338) == 32'h00001013),{(_zz_339 == _zz_340),{_zz_341,{_zz_342,_zz_343}}}}}};
-  assign _zz_338 = 32'hfc00307f;
-  assign _zz_339 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_340 = 32'h00005033;
-  assign _zz_341 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_342 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_343 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_344 = decode_INSTRUCTION[31];
-  assign _zz_345 = decode_INSTRUCTION[31];
-  assign _zz_346 = decode_INSTRUCTION[7];
-  assign _zz_347 = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_348 = 32'h02004020;
-  assign _zz_349 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_350 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
-  assign _zz_351 = 1'b0;
-  assign _zz_352 = (((decode_INSTRUCTION & _zz_355) == 32'h10000050) != 1'b0);
-  assign _zz_353 = ({_zz_356,_zz_357} != 2'b00);
-  assign _zz_354 = {({_zz_358,_zz_359} != 2'b00),{(_zz_360 != _zz_361),{_zz_362,{_zz_363,_zz_364}}}};
-  assign _zz_355 = 32'h10403050;
-  assign _zz_356 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_357 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_358 = _zz_89;
-  assign _zz_359 = ((decode_INSTRUCTION & _zz_365) == 32'h00000004);
-  assign _zz_360 = ((decode_INSTRUCTION & _zz_366) == 32'h00000040);
-  assign _zz_361 = 1'b0;
-  assign _zz_362 = ({_zz_367,_zz_368} != 2'b00);
-  assign _zz_363 = ({_zz_369,_zz_370} != 3'b000);
-  assign _zz_364 = {(_zz_371 != _zz_372),{_zz_373,{_zz_374,_zz_375}}};
-  assign _zz_365 = 32'h0000001c;
-  assign _zz_366 = 32'h00000058;
-  assign _zz_367 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz_368 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz_369 = ((decode_INSTRUCTION & _zz_376) == 32'h40001010);
-  assign _zz_370 = {(_zz_377 == _zz_378),(_zz_379 == _zz_380)};
-  assign _zz_371 = ((decode_INSTRUCTION & _zz_381) == 32'h00000024);
-  assign _zz_372 = 1'b0;
-  assign _zz_373 = ((_zz_382 == _zz_383) != 1'b0);
-  assign _zz_374 = (_zz_384 != 1'b0);
-  assign _zz_375 = {(_zz_385 != _zz_386),{_zz_387,{_zz_388,_zz_389}}};
-  assign _zz_376 = 32'h40003054;
-  assign _zz_377 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_378 = 32'h00001010;
-  assign _zz_379 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_380 = 32'h00001010;
-  assign _zz_381 = 32'h00000064;
-  assign _zz_382 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_383 = 32'h00001000;
-  assign _zz_384 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_385 = {(_zz_390 == _zz_391),(_zz_392 == _zz_393)};
-  assign _zz_386 = 2'b00;
-  assign _zz_387 = ((_zz_394 == _zz_395) != 1'b0);
-  assign _zz_388 = ({_zz_396,_zz_397} != 2'b00);
-  assign _zz_389 = {(_zz_398 != _zz_399),{_zz_400,{_zz_401,_zz_402}}};
-  assign _zz_390 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_391 = 32'h00002000;
-  assign _zz_392 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_393 = 32'h00001000;
-  assign _zz_394 = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_395 = 32'h00004008;
-  assign _zz_396 = ((decode_INSTRUCTION & _zz_403) == 32'h00000020);
-  assign _zz_397 = ((decode_INSTRUCTION & _zz_404) == 32'h00000020);
-  assign _zz_398 = {(_zz_405 == _zz_406),{_zz_407,_zz_408}};
-  assign _zz_399 = 3'b000;
-  assign _zz_400 = ((_zz_409 == _zz_410) != 1'b0);
-  assign _zz_401 = ({_zz_411,_zz_412} != 5'h0);
-  assign _zz_402 = {(_zz_413 != _zz_414),{_zz_415,{_zz_416,_zz_417}}};
-  assign _zz_403 = 32'h00000034;
-  assign _zz_404 = 32'h00000064;
-  assign _zz_405 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_406 = 32'h00000040;
-  assign _zz_407 = ((decode_INSTRUCTION & _zz_418) == 32'h0);
-  assign _zz_408 = ((decode_INSTRUCTION & _zz_419) == 32'h00000040);
-  assign _zz_409 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_410 = 32'h00000020;
-  assign _zz_411 = (_zz_420 == _zz_421);
-  assign _zz_412 = {_zz_88,{_zz_422,_zz_423}};
-  assign _zz_413 = {_zz_88,{_zz_424,_zz_425}};
-  assign _zz_414 = 5'h0;
-  assign _zz_415 = ({_zz_426,_zz_427} != 6'h0);
-  assign _zz_416 = (_zz_428 != _zz_429);
-  assign _zz_417 = {_zz_430,{_zz_431,_zz_432}};
-  assign _zz_418 = 32'h00000038;
-  assign _zz_419 = 32'h00403040;
-  assign _zz_420 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_421 = 32'h00000040;
-  assign _zz_422 = (_zz_433 == _zz_434);
-  assign _zz_423 = {_zz_435,_zz_436};
-  assign _zz_424 = (_zz_437 == _zz_438);
-  assign _zz_425 = {_zz_439,{_zz_440,_zz_441}};
-  assign _zz_426 = _zz_89;
-  assign _zz_427 = {_zz_442,{_zz_443,_zz_444}};
-  assign _zz_428 = {_zz_88,_zz_445};
-  assign _zz_429 = 2'b00;
-  assign _zz_430 = ({_zz_446,_zz_447} != 2'b00);
-  assign _zz_431 = (_zz_448 != _zz_449);
-  assign _zz_432 = {_zz_450,{_zz_451,_zz_452}};
-  assign _zz_433 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_434 = 32'h00004020;
-  assign _zz_435 = ((decode_INSTRUCTION & _zz_453) == 32'h00000010);
-  assign _zz_436 = ((decode_INSTRUCTION & _zz_454) == 32'h00000020);
-  assign _zz_437 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_438 = 32'h00002010;
-  assign _zz_439 = ((decode_INSTRUCTION & _zz_455) == 32'h00000010);
-  assign _zz_440 = (_zz_456 == _zz_457);
-  assign _zz_441 = (_zz_458 == _zz_459);
-  assign _zz_442 = ((decode_INSTRUCTION & _zz_460) == 32'h00001010);
-  assign _zz_443 = (_zz_461 == _zz_462);
-  assign _zz_444 = {_zz_463,{_zz_464,_zz_465}};
-  assign _zz_445 = ((decode_INSTRUCTION & _zz_466) == 32'h00000020);
-  assign _zz_446 = _zz_88;
-  assign _zz_447 = (_zz_467 == _zz_468);
-  assign _zz_448 = (_zz_469 == _zz_470);
-  assign _zz_449 = 1'b0;
-  assign _zz_450 = (_zz_471 != 1'b0);
-  assign _zz_451 = (_zz_472 != _zz_473);
-  assign _zz_452 = {_zz_474,{_zz_475,_zz_476}};
-  assign _zz_453 = 32'h00000030;
-  assign _zz_454 = 32'h02000020;
-  assign _zz_455 = 32'h00001030;
-  assign _zz_456 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_457 = 32'h00002020;
-  assign _zz_458 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_459 = 32'h00000020;
-  assign _zz_460 = 32'h00001010;
-  assign _zz_461 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_462 = 32'h00002010;
-  assign _zz_463 = ((decode_INSTRUCTION & _zz_477) == 32'h00000010);
-  assign _zz_464 = (_zz_478 == _zz_479);
-  assign _zz_465 = (_zz_480 == _zz_481);
-  assign _zz_466 = 32'h00000070;
-  assign _zz_467 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_468 = 32'h0;
-  assign _zz_469 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_470 = 32'h00004010;
-  assign _zz_471 = ((decode_INSTRUCTION & _zz_482) == 32'h00002010);
-  assign _zz_472 = {_zz_483,{_zz_484,_zz_485}};
-  assign _zz_473 = 4'b0000;
-  assign _zz_474 = (_zz_486 != 1'b0);
-  assign _zz_475 = (_zz_487 != _zz_488);
-  assign _zz_476 = {_zz_489,{_zz_490,_zz_491}};
-  assign _zz_477 = 32'h00000050;
-  assign _zz_478 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_479 = 32'h00000004;
-  assign _zz_480 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_481 = 32'h0;
-  assign _zz_482 = 32'h00006014;
-  assign _zz_483 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz_484 = ((decode_INSTRUCTION & _zz_492) == 32'h0);
-  assign _zz_485 = {(_zz_493 == _zz_494),(_zz_495 == _zz_496)};
-  assign _zz_486 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_487 = {(_zz_497 == _zz_498),{_zz_499,_zz_500}};
-  assign _zz_488 = 3'b000;
-  assign _zz_489 = ({_zz_501,_zz_87} != 2'b00);
-  assign _zz_490 = ({_zz_502,_zz_503} != 2'b00);
-  assign _zz_491 = (_zz_504 != 1'b0);
-  assign _zz_492 = 32'h00000018;
-  assign _zz_493 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_494 = 32'h00002000;
-  assign _zz_495 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_496 = 32'h00001000;
-  assign _zz_497 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_498 = 32'h00000040;
-  assign _zz_499 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_500 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz_501 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_502 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_503 = _zz_87;
-  assign _zz_504 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_505 = execute_INSTRUCTION[31];
-  assign _zz_506 = execute_INSTRUCTION[31];
-  assign _zz_507 = execute_INSTRUCTION[7];
-  always @ (posedge clk) begin
-    if(_zz_323) begin
-      _zz_193 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_6) == 32'h10000050) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ({_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {({_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_12} != 2'b00),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_16),{_zz__zz_decode_IS_RS2_SIGNED_17,{_zz__zz_decode_IS_RS2_SIGNED_20,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h10403050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_15) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ({_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25),(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (_zz__zz_decode_IS_RS2_SIGNED_36 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(_zz__zz_decode_IS_RS2_SIGNED_38 != _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_52}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40),(_zz__zz_decode_IS_RS2_SIGNED_41 == _zz__zz_decode_IS_RS2_SIGNED_42)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ({_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_50} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = {(_zz__zz_decode_IS_RS2_SIGNED_53 != _zz__zz_decode_IS_RS2_SIGNED_60),{_zz__zz_decode_IS_RS2_SIGNED_61,{_zz__zz_decode_IS_RS2_SIGNED_64,_zz__zz_decode_IS_RS2_SIGNED_77}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00004008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = {(_zz__zz_decode_IS_RS2_SIGNED_54 == _zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_56,_zz__zz_decode_IS_RS2_SIGNED_58}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((_zz__zz_decode_IS_RS2_SIGNED_62 == _zz__zz_decode_IS_RS2_SIGNED_63) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ({_zz__zz_decode_IS_RS2_SIGNED_65,_zz__zz_decode_IS_RS2_SIGNED_68} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = {(_zz__zz_decode_IS_RS2_SIGNED_78 != _zz__zz_decode_IS_RS2_SIGNED_91),{_zz__zz_decode_IS_RS2_SIGNED_92,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_114}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_57) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (_zz__zz_decode_IS_RS2_SIGNED_66 == _zz__zz_decode_IS_RS2_SIGNED_67);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_69,_zz__zz_decode_IS_RS2_SIGNED_72}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_82}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = ({_zz__zz_decode_IS_RS2_SIGNED_93,_zz__zz_decode_IS_RS2_SIGNED_94} != 6'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 != _zz__zz_decode_IS_RS2_SIGNED_113);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_120,_zz__zz_decode_IS_RS2_SIGNED_125}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00000038;
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00403040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (_zz__zz_decode_IS_RS2_SIGNED_70 == _zz__zz_decode_IS_RS2_SIGNED_71);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = {_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_75};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = (_zz__zz_decode_IS_RS2_SIGNED_80 == _zz__zz_decode_IS_RS2_SIGNED_81);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = {_zz__zz_decode_IS_RS2_SIGNED_83,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz__zz_decode_IS_RS2_SIGNED_95,{_zz__zz_decode_IS_RS2_SIGNED_97,_zz__zz_decode_IS_RS2_SIGNED_100}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_111};
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = ({_zz__zz_decode_IS_RS2_SIGNED_116,_zz__zz_decode_IS_RS2_SIGNED_117} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (_zz__zz_decode_IS_RS2_SIGNED_121 != _zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {_zz__zz_decode_IS_RS2_SIGNED_126,{_zz__zz_decode_IS_RS2_SIGNED_129,_zz__zz_decode_IS_RS2_SIGNED_140}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_76) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_84) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (_zz__zz_decode_IS_RS2_SIGNED_89 == _zz__zz_decode_IS_RS2_SIGNED_90);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_96) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (_zz__zz_decode_IS_RS2_SIGNED_98 == _zz__zz_decode_IS_RS2_SIGNED_99);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {_zz__zz_decode_IS_RS2_SIGNED_101,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_112) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = (_zz__zz_decode_IS_RS2_SIGNED_118 == _zz__zz_decode_IS_RS2_SIGNED_119);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (_zz__zz_decode_IS_RS2_SIGNED_122 == _zz__zz_decode_IS_RS2_SIGNED_123);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (_zz__zz_decode_IS_RS2_SIGNED_127 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (_zz__zz_decode_IS_RS2_SIGNED_130 != _zz__zz_decode_IS_RS2_SIGNED_139);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {_zz__zz_decode_IS_RS2_SIGNED_141,{_zz__zz_decode_IS_RS2_SIGNED_143,_zz__zz_decode_IS_RS2_SIGNED_150}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (_zz__zz_decode_IS_RS2_SIGNED_107 == _zz__zz_decode_IS_RS2_SIGNED_108);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_128) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = {_zz__zz_decode_IS_RS2_SIGNED_131,{_zz__zz_decode_IS_RS2_SIGNED_132,_zz__zz_decode_IS_RS2_SIGNED_134}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 4'b0000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (_zz__zz_decode_IS_RS2_SIGNED_142 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (_zz__zz_decode_IS_RS2_SIGNED_144 != _zz__zz_decode_IS_RS2_SIGNED_149);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_156}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_133) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = {(_zz__zz_decode_IS_RS2_SIGNED_135 == _zz__zz_decode_IS_RS2_SIGNED_136),(_zz__zz_decode_IS_RS2_SIGNED_137 == _zz__zz_decode_IS_RS2_SIGNED_138)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = {(_zz__zz_decode_IS_RS2_SIGNED_145 == _zz__zz_decode_IS_RS2_SIGNED_146),{_zz__zz_decode_IS_RS2_SIGNED_147,_zz__zz_decode_IS_RS2_SIGNED_148}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = ({_zz__zz_decode_IS_RS2_SIGNED_152,_zz_decode_IS_RS2_SIGNED_1} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ({_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_155} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (_zz__zz_decode_IS_RS2_SIGNED_157 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00000018;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_324) begin
-      _zz_194 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_165                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_166                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_167                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_168                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_169                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_170                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_171                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_172                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_173                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_174                                            ), //i
-    .io_cpu_execute_address                    (_zz_175[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_81[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_176                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_177[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_178                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_179                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_180                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_181[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_182                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_183                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_184                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_185                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_186                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_187                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_188                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_189                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_190[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_191                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_192                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_325)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_195 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_195 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_195 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_195 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1722,131 +1814,131 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1859,30 +1951,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1894,27 +1986,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1927,30 +2019,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1962,11 +2054,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1978,11 +2070,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1994,11 +2086,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2011,48 +2103,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2065,12 +2157,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2083,12 +2175,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2100,87 +2192,87 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2193,72 +2285,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_91)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_91_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_91_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_91_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_91_string = "URS1        ";
-      default : _zz_91_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_92_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_92_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_92_string = "BITWISE ";
-      default : _zz_92_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_93_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_93_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_93_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_93_string = "PC ";
-      default : _zz_93_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_94_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_94_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_94_string = "AND_1";
-      default : _zz_94_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_95_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_95_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_95_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_95_string = "SRA_1    ";
-      default : _zz_95_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_96_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_96_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_96_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_96_string = "JALR";
-      default : _zz_96_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_97)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_97_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_97_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_97_string = "ECALL";
-      default : _zz_97_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2289,28 +2381,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2348,7 +2440,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_231) + $signed(_zz_239));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2356,44 +2448,44 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_241;
-  assign execute_REGFILE_WRITE_DATA = _zz_99;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_175[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_243[0];
-  assign decode_IS_RS1_SIGNED = _zz_244[0];
-  assign decode_IS_DIV = _zz_245[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[30];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_246[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_247[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_248[0];
-  assign decode_MEMORY_MANAGMENT = _zz_249[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_250[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_251[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_252[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -2413,22 +2505,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_121;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_253[0];
-  assign decode_RS1_USE = _zz_254[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_196)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2438,139 +2530,139 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_110)begin
-      if((_zz_111 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_112;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_197)begin
-      if(_zz_198)begin
-        if(_zz_114)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_199)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_200)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_110)begin
-      if((_zz_111 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_112;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_197)begin
-      if(_zz_198)begin
-        if(_zz_113)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_199)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_115)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_200)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_117)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_107;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_201)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_255[0];
-  assign decode_SRC_ADD_ZERO = _zz_256[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_105;
-  assign execute_SRC1 = _zz_100;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_257[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_326) == 32'h00001073),{(_zz_327 == _zz_328),{_zz_329,{_zz_330,_zz_331}}}}}}} != 21'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_230)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_299;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_300;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2582,201 +2674,201 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_258[0];
-  assign decode_FLUSH_ALL = _zz_259[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_202)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_203)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_204)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_205)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_108 || _zz_109)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_206)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_206)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_191 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_196)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_201)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_207)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_208)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2785,45 +2877,47 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_207)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_208)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_207)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_208)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_207)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_208)begin
-      case(_zz_209)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2836,59 +2930,65 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_54 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_55 = (_zz_54 & (~ _zz_260));
-  assign _zz_56 = _zz_55[3];
-  assign _zz_57 = (_zz_55[1] || _zz_56);
-  assign _zz_58 = (_zz_55[2] || _zz_56);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_195;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_262);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -2896,265 +2996,280 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_59);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_59);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
-  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_63 = _zz_64;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_65 = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_67;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_68 = _zz_263[11];
-  always @ (*) begin
-    _zz_69[18] = _zz_68;
-    _zz_69[17] = _zz_68;
-    _zz_69[16] = _zz_68;
-    _zz_69[15] = _zz_68;
-    _zz_69[14] = _zz_68;
-    _zz_69[13] = _zz_68;
-    _zz_69[12] = _zz_68;
-    _zz_69[11] = _zz_68;
-    _zz_69[10] = _zz_68;
-    _zz_69[9] = _zz_68;
-    _zz_69[8] = _zz_68;
-    _zz_69[7] = _zz_68;
-    _zz_69[6] = _zz_68;
-    _zz_69[5] = _zz_68;
-    _zz_69[4] = _zz_68;
-    _zz_69[3] = _zz_68;
-    _zz_69[2] = _zz_68;
-    _zz_69[1] = _zz_68;
-    _zz_69[0] = _zz_68;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_264[31]));
-    if(_zz_74)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_70 = _zz_265[19];
-  always @ (*) begin
-    _zz_71[10] = _zz_70;
-    _zz_71[9] = _zz_70;
-    _zz_71[8] = _zz_70;
-    _zz_71[7] = _zz_70;
-    _zz_71[6] = _zz_70;
-    _zz_71[5] = _zz_70;
-    _zz_71[4] = _zz_70;
-    _zz_71[3] = _zz_70;
-    _zz_71[2] = _zz_70;
-    _zz_71[1] = _zz_70;
-    _zz_71[0] = _zz_70;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_72 = _zz_266[11];
-  always @ (*) begin
-    _zz_73[18] = _zz_72;
-    _zz_73[17] = _zz_72;
-    _zz_73[16] = _zz_72;
-    _zz_73[15] = _zz_72;
-    _zz_73[14] = _zz_72;
-    _zz_73[13] = _zz_72;
-    _zz_73[12] = _zz_72;
-    _zz_73[11] = _zz_72;
-    _zz_73[10] = _zz_72;
-    _zz_73[9] = _zz_72;
-    _zz_73[8] = _zz_72;
-    _zz_73[7] = _zz_72;
-    _zz_73[6] = _zz_72;
-    _zz_73[5] = _zz_72;
-    _zz_73[4] = _zz_72;
-    _zz_73[3] = _zz_72;
-    _zz_73[2] = _zz_72;
-    _zz_73[1] = _zz_72;
-    _zz_73[0] = _zz_72;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_74 = _zz_267[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_74 = _zz_268[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_75 = _zz_269[19];
-  always @ (*) begin
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7] = _zz_75;
-    _zz_76[6] = _zz_75;
-    _zz_76[5] = _zz_75;
-    _zz_76[4] = _zz_75;
-    _zz_76[3] = _zz_75;
-    _zz_76[2] = _zz_75;
-    _zz_76[1] = _zz_75;
-    _zz_76[0] = _zz_75;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_77 = _zz_270[11];
-  always @ (*) begin
-    _zz_78[18] = _zz_77;
-    _zz_78[17] = _zz_77;
-    _zz_78[16] = _zz_77;
-    _zz_78[15] = _zz_77;
-    _zz_78[14] = _zz_77;
-    _zz_78[13] = _zz_77;
-    _zz_78[12] = _zz_77;
-    _zz_78[11] = _zz_77;
-    _zz_78[10] = _zz_77;
-    _zz_78[9] = _zz_77;
-    _zz_78[8] = _zz_77;
-    _zz_78[7] = _zz_77;
-    _zz_78[6] = _zz_77;
-    _zz_78[5] = _zz_77;
-    _zz_78[4] = _zz_77;
-    _zz_78[3] = _zz_77;
-    _zz_78[2] = _zz_77;
-    _zz_78[1] = _zz_77;
-    _zz_78[0] = _zz_77;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_76,{{{_zz_344,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_78,{{{_zz_345,_zz_346},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_166 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_167 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_168 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_167;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_170 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_171 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_172 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_205)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_203)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_203)begin
-      _zz_173 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_204)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_202)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_204)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_202)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_165 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_192 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3162,168 +3277,178 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_174 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_175 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_81 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_81 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_81 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_191 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_176 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_177 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_176;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_177;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_178 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_178 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_179 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_180 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_181 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_210)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_210)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_210)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_271};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_272};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_82 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_83[31] = _zz_82;
-    _zz_83[30] = _zz_82;
-    _zz_83[29] = _zz_82;
-    _zz_83[28] = _zz_82;
-    _zz_83[27] = _zz_82;
-    _zz_83[26] = _zz_82;
-    _zz_83[25] = _zz_82;
-    _zz_83[24] = _zz_82;
-    _zz_83[23] = _zz_82;
-    _zz_83[22] = _zz_82;
-    _zz_83[21] = _zz_82;
-    _zz_83[20] = _zz_82;
-    _zz_83[19] = _zz_82;
-    _zz_83[18] = _zz_82;
-    _zz_83[17] = _zz_82;
-    _zz_83[16] = _zz_82;
-    _zz_83[15] = _zz_82;
-    _zz_83[14] = _zz_82;
-    _zz_83[13] = _zz_82;
-    _zz_83[12] = _zz_82;
-    _zz_83[11] = _zz_82;
-    _zz_83[10] = _zz_82;
-    _zz_83[9] = _zz_82;
-    _zz_83[8] = _zz_82;
-    _zz_83[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_84 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_85[31] = _zz_84;
-    _zz_85[30] = _zz_84;
-    _zz_85[29] = _zz_84;
-    _zz_85[28] = _zz_84;
-    _zz_85[27] = _zz_84;
-    _zz_85[26] = _zz_84;
-    _zz_85[25] = _zz_84;
-    _zz_85[24] = _zz_84;
-    _zz_85[23] = _zz_84;
-    _zz_85[22] = _zz_84;
-    _zz_85[21] = _zz_84;
-    _zz_85[20] = _zz_84;
-    _zz_85[19] = _zz_84;
-    _zz_85[18] = _zz_84;
-    _zz_85[17] = _zz_84;
-    _zz_85[16] = _zz_84;
-    _zz_85[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_228)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_83;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_85;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3342,59 +3467,60 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_87 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_90 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_86 = {(_zz_90 != 1'b0),{(_zz_90 != 1'b0),{((_zz_347 == _zz_348) != 1'b0),{(_zz_349 != 1'b0),{(_zz_350 != _zz_351),{_zz_352,{_zz_353,_zz_354}}}}}}};
-  assign _zz_91 = _zz_86[2 : 1];
-  assign _zz_49 = _zz_91;
-  assign _zz_92 = _zz_86[7 : 6];
-  assign _zz_48 = _zz_92;
-  assign _zz_93 = _zz_86[9 : 8];
-  assign _zz_47 = _zz_93;
-  assign _zz_94 = _zz_86[19 : 18];
-  assign _zz_46 = _zz_94;
-  assign _zz_95 = _zz_86[22 : 21];
-  assign _zz_45 = _zz_95;
-  assign _zz_96 = _zz_86[24 : 23];
-  assign _zz_44 = _zz_96;
-  assign _zz_97 = _zz_86[27 : 26];
-  assign _zz_43 = _zz_97;
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_193;
-  assign decode_RegFilePlugin_rs2Data = _zz_194;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_98)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_98)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_98)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3403,353 +3529,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_99 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_99 = {31'd0, _zz_273};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_99 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_100 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_100 = {29'd0, _zz_274};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_100 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_100 = {27'd0, _zz_275};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_101 = _zz_276[11];
-  always @ (*) begin
-    _zz_102[19] = _zz_101;
-    _zz_102[18] = _zz_101;
-    _zz_102[17] = _zz_101;
-    _zz_102[16] = _zz_101;
-    _zz_102[15] = _zz_101;
-    _zz_102[14] = _zz_101;
-    _zz_102[13] = _zz_101;
-    _zz_102[12] = _zz_101;
-    _zz_102[11] = _zz_101;
-    _zz_102[10] = _zz_101;
-    _zz_102[9] = _zz_101;
-    _zz_102[8] = _zz_101;
-    _zz_102[7] = _zz_101;
-    _zz_102[6] = _zz_101;
-    _zz_102[5] = _zz_101;
-    _zz_102[4] = _zz_101;
-    _zz_102[3] = _zz_101;
-    _zz_102[2] = _zz_101;
-    _zz_102[1] = _zz_101;
-    _zz_102[0] = _zz_101;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_103 = _zz_277[11];
-  always @ (*) begin
-    _zz_104[19] = _zz_103;
-    _zz_104[18] = _zz_103;
-    _zz_104[17] = _zz_103;
-    _zz_104[16] = _zz_103;
-    _zz_104[15] = _zz_103;
-    _zz_104[14] = _zz_103;
-    _zz_104[13] = _zz_103;
-    _zz_104[12] = _zz_103;
-    _zz_104[11] = _zz_103;
-    _zz_104[10] = _zz_103;
-    _zz_104[9] = _zz_103;
-    _zz_104[8] = _zz_103;
-    _zz_104[7] = _zz_103;
-    _zz_104[6] = _zz_103;
-    _zz_104[5] = _zz_103;
-    _zz_104[4] = _zz_103;
-    _zz_104[3] = _zz_103;
-    _zz_104[2] = _zz_103;
-    _zz_104[1] = _zz_103;
-    _zz_104[0] = _zz_103;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_105 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_105 = {_zz_102,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_105 = {_zz_104,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_105 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_278;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_106[0] = execute_SRC1[31];
-    _zz_106[1] = execute_SRC1[30];
-    _zz_106[2] = execute_SRC1[29];
-    _zz_106[3] = execute_SRC1[28];
-    _zz_106[4] = execute_SRC1[27];
-    _zz_106[5] = execute_SRC1[26];
-    _zz_106[6] = execute_SRC1[25];
-    _zz_106[7] = execute_SRC1[24];
-    _zz_106[8] = execute_SRC1[23];
-    _zz_106[9] = execute_SRC1[22];
-    _zz_106[10] = execute_SRC1[21];
-    _zz_106[11] = execute_SRC1[20];
-    _zz_106[12] = execute_SRC1[19];
-    _zz_106[13] = execute_SRC1[18];
-    _zz_106[14] = execute_SRC1[17];
-    _zz_106[15] = execute_SRC1[16];
-    _zz_106[16] = execute_SRC1[15];
-    _zz_106[17] = execute_SRC1[14];
-    _zz_106[18] = execute_SRC1[13];
-    _zz_106[19] = execute_SRC1[12];
-    _zz_106[20] = execute_SRC1[11];
-    _zz_106[21] = execute_SRC1[10];
-    _zz_106[22] = execute_SRC1[9];
-    _zz_106[23] = execute_SRC1[8];
-    _zz_106[24] = execute_SRC1[7];
-    _zz_106[25] = execute_SRC1[6];
-    _zz_106[26] = execute_SRC1[5];
-    _zz_106[27] = execute_SRC1[4];
-    _zz_106[28] = execute_SRC1[3];
-    _zz_106[29] = execute_SRC1[2];
-    _zz_106[30] = execute_SRC1[1];
-    _zz_106[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_106 : execute_SRC1);
-  always @ (*) begin
-    _zz_107[0] = memory_SHIFT_RIGHT[31];
-    _zz_107[1] = memory_SHIFT_RIGHT[30];
-    _zz_107[2] = memory_SHIFT_RIGHT[29];
-    _zz_107[3] = memory_SHIFT_RIGHT[28];
-    _zz_107[4] = memory_SHIFT_RIGHT[27];
-    _zz_107[5] = memory_SHIFT_RIGHT[26];
-    _zz_107[6] = memory_SHIFT_RIGHT[25];
-    _zz_107[7] = memory_SHIFT_RIGHT[24];
-    _zz_107[8] = memory_SHIFT_RIGHT[23];
-    _zz_107[9] = memory_SHIFT_RIGHT[22];
-    _zz_107[10] = memory_SHIFT_RIGHT[21];
-    _zz_107[11] = memory_SHIFT_RIGHT[20];
-    _zz_107[12] = memory_SHIFT_RIGHT[19];
-    _zz_107[13] = memory_SHIFT_RIGHT[18];
-    _zz_107[14] = memory_SHIFT_RIGHT[17];
-    _zz_107[15] = memory_SHIFT_RIGHT[16];
-    _zz_107[16] = memory_SHIFT_RIGHT[15];
-    _zz_107[17] = memory_SHIFT_RIGHT[14];
-    _zz_107[18] = memory_SHIFT_RIGHT[13];
-    _zz_107[19] = memory_SHIFT_RIGHT[12];
-    _zz_107[20] = memory_SHIFT_RIGHT[11];
-    _zz_107[21] = memory_SHIFT_RIGHT[10];
-    _zz_107[22] = memory_SHIFT_RIGHT[9];
-    _zz_107[23] = memory_SHIFT_RIGHT[8];
-    _zz_107[24] = memory_SHIFT_RIGHT[7];
-    _zz_107[25] = memory_SHIFT_RIGHT[6];
-    _zz_107[26] = memory_SHIFT_RIGHT[5];
-    _zz_107[27] = memory_SHIFT_RIGHT[4];
-    _zz_107[28] = memory_SHIFT_RIGHT[3];
-    _zz_107[29] = memory_SHIFT_RIGHT[2];
-    _zz_107[30] = memory_SHIFT_RIGHT[1];
-    _zz_107[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_108 = 1'b0;
-    if(_zz_211)begin
-      if(_zz_212)begin
-        if(_zz_113)begin
-          _zz_108 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_213)begin
-      if(_zz_214)begin
-        if(_zz_115)begin
-          _zz_108 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_215)begin
-      if(_zz_216)begin
-        if(_zz_117)begin
-          _zz_108 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_108 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_109 = 1'b0;
-    if(_zz_211)begin
-      if(_zz_212)begin
-        if(_zz_114)begin
-          _zz_109 = 1'b1;
-        end
-      end
-    end
-    if(_zz_213)begin
-      if(_zz_214)begin
-        if(_zz_116)begin
-          _zz_109 = 1'b1;
-        end
-      end
-    end
-    if(_zz_215)begin
-      if(_zz_216)begin
-        if(_zz_118)begin
-          _zz_109 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_109 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_113 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_115 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_117 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_119 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_119 == 3'b000)) begin
-        _zz_120 = execute_BranchPlugin_eq;
-    end else if((_zz_119 == 3'b001)) begin
-        _zz_120 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_119 & 3'b101) == 3'b101))) begin
-        _zz_120 = (! execute_SRC_LESS);
-    end else begin
-        _zz_120 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_121 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_121 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_121 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_121 = _zz_120;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_122 = _zz_285[11];
-  always @ (*) begin
-    _zz_123[19] = _zz_122;
-    _zz_123[18] = _zz_122;
-    _zz_123[17] = _zz_122;
-    _zz_123[16] = _zz_122;
-    _zz_123[15] = _zz_122;
-    _zz_123[14] = _zz_122;
-    _zz_123[13] = _zz_122;
-    _zz_123[12] = _zz_122;
-    _zz_123[11] = _zz_122;
-    _zz_123[10] = _zz_122;
-    _zz_123[9] = _zz_122;
-    _zz_123[8] = _zz_122;
-    _zz_123[7] = _zz_122;
-    _zz_123[6] = _zz_122;
-    _zz_123[5] = _zz_122;
-    _zz_123[4] = _zz_122;
-    _zz_123[3] = _zz_122;
-    _zz_123[2] = _zz_122;
-    _zz_123[1] = _zz_122;
-    _zz_123[0] = _zz_122;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_124 = _zz_286[19];
-  always @ (*) begin
-    _zz_125[10] = _zz_124;
-    _zz_125[9] = _zz_124;
-    _zz_125[8] = _zz_124;
-    _zz_125[7] = _zz_124;
-    _zz_125[6] = _zz_124;
-    _zz_125[5] = _zz_124;
-    _zz_125[4] = _zz_124;
-    _zz_125[3] = _zz_124;
-    _zz_125[2] = _zz_124;
-    _zz_125[1] = _zz_124;
-    _zz_125[0] = _zz_124;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_126 = _zz_287[11];
-  always @ (*) begin
-    _zz_127[18] = _zz_126;
-    _zz_127[17] = _zz_126;
-    _zz_127[16] = _zz_126;
-    _zz_127[15] = _zz_126;
-    _zz_127[14] = _zz_126;
-    _zz_127[13] = _zz_126;
-    _zz_127[12] = _zz_126;
-    _zz_127[11] = _zz_126;
-    _zz_127[10] = _zz_126;
-    _zz_127[9] = _zz_126;
-    _zz_127[8] = _zz_126;
-    _zz_127[7] = _zz_126;
-    _zz_127[6] = _zz_126;
-    _zz_127[5] = _zz_126;
-    _zz_127[4] = _zz_126;
-    _zz_127[3] = _zz_126;
-    _zz_127[2] = _zz_126;
-    _zz_127[1] = _zz_126;
-    _zz_127[0] = _zz_126;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_128 = (_zz_288[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_128 = _zz_289[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_128 = _zz_290[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_128);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -3760,80 +3909,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_129 = _zz_291[11];
-  always @ (*) begin
-    _zz_130[19] = _zz_129;
-    _zz_130[18] = _zz_129;
-    _zz_130[17] = _zz_129;
-    _zz_130[16] = _zz_129;
-    _zz_130[15] = _zz_129;
-    _zz_130[14] = _zz_129;
-    _zz_130[13] = _zz_129;
-    _zz_130[12] = _zz_129;
-    _zz_130[11] = _zz_129;
-    _zz_130[10] = _zz_129;
-    _zz_130[9] = _zz_129;
-    _zz_130[8] = _zz_129;
-    _zz_130[7] = _zz_129;
-    _zz_130[6] = _zz_129;
-    _zz_130[5] = _zz_129;
-    _zz_130[4] = _zz_129;
-    _zz_130[3] = _zz_129;
-    _zz_130[2] = _zz_129;
-    _zz_130[1] = _zz_129;
-    _zz_130[0] = _zz_129;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_130,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_132,{{{_zz_505,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_134,{{{_zz_506,_zz_507},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_294};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_131 = _zz_292[19];
-  always @ (*) begin
-    _zz_132[10] = _zz_131;
-    _zz_132[9] = _zz_131;
-    _zz_132[8] = _zz_131;
-    _zz_132[7] = _zz_131;
-    _zz_132[6] = _zz_131;
-    _zz_132[5] = _zz_131;
-    _zz_132[4] = _zz_131;
-    _zz_132[3] = _zz_131;
-    _zz_132[2] = _zz_131;
-    _zz_132[1] = _zz_131;
-    _zz_132[0] = _zz_131;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_133 = _zz_293[11];
-  always @ (*) begin
-    _zz_134[18] = _zz_133;
-    _zz_134[17] = _zz_133;
-    _zz_134[16] = _zz_133;
-    _zz_134[15] = _zz_133;
-    _zz_134[14] = _zz_133;
-    _zz_134[13] = _zz_133;
-    _zz_134[12] = _zz_133;
-    _zz_134[11] = _zz_133;
-    _zz_134[10] = _zz_133;
-    _zz_134[9] = _zz_133;
-    _zz_134[8] = _zz_133;
-    _zz_134[7] = _zz_133;
-    _zz_134[6] = _zz_133;
-    _zz_134[5] = _zz_133;
-    _zz_134[4] = _zz_133;
-    _zz_134[3] = _zz_133;
-    _zz_134[2] = _zz_133;
-    _zz_134[1] = _zz_133;
-    _zz_134[0] = _zz_133;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -3843,95 +3992,109 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_135 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_136 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_137 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_138 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_139 = _zz_295[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_206)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -3942,8 +4105,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -3953,77 +4116,84 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_217)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_218)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_218)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4036,39 +4206,48 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_217)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_217)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_229)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_219)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4081,8 +4260,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_219)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4101,79 +4280,150 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_297) + $signed(_zz_298));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_201)begin
-      if(_zz_220)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_221)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_302);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_140 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_140[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_303);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_304 : _zz_305);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_306[31:0];
-  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_143 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_144[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_146 != 32'h0);
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4194,140 +4444,160 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_147 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_147[12 : 0] = 13'h1000;
-      _zz_147[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_148 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_148[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_148[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_148[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_149 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_149[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_149[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_149[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_150[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_150[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_150[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_151[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_152[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_152[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_153[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_154[31 : 0] = _zz_145;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_155[31 : 0] = _zz_146;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = ((((_zz_147 | _zz_148) | (_zz_149 | _zz_150)) | ((_zz_151 | _zz_152) | (_zz_153 | _zz_154))) | _zz_155);
-  assign iBusWishbone_ADR = {_zz_322,_zz_156};
-  assign iBusWishbone_CTI = ((_zz_156 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | _zz_CsrPlugin_csrMapping_readDataInit_10);
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_222)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_222)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_157;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_163 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_159 = dBus_cmd_valid;
-  assign _zz_161 = dBus_cmd_payload_wr;
-  assign _zz_162 = (_zz_158 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_160 && (_zz_161 || _zz_162));
-  assign dBusWishbone_ADR = ((_zz_163 ? {{dBus_cmd_payload_address[31 : 5],_zz_158},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_163 ? (_zz_162 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_161 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_161;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_160 = (_zz_159 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_159;
-  assign dBusWishbone_STB = _zz_159;
-  assign dBus_rsp_valid = _zz_164;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_64 <= 1'b0;
-      _zz_66 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_79;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_80;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_98 <= 1'b1;
-      _zz_110 <= 1'b0;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -4345,158 +4615,158 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_145 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_156 <= 3'b000;
-      _zz_157 <= 1'b0;
-      _zz_158 <= 3'b000;
-      _zz_164 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_62)begin
-        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_66 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_223)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_98 <= 1'b0;
-      _zz_110 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_224)begin
-        if(_zz_225)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_226)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_227)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_207)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4507,8 +4777,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_208)begin
-        case(_zz_209)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4518,135 +4788,135 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_137,{_zz_136,_zz_135}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_316[0];
-          CsrPlugin_mstatus_MIE <= _zz_317[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_319[0];
-          CsrPlugin_mie_MTIE <= _zz_320[0];
-          CsrPlugin_mie_MSIE <= _zz_321[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_222)begin
-        if(iBusWishbone_ACK)begin
-          _zz_156 <= (_zz_156 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_157 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_159 && _zz_160))begin
-        _zz_158 <= (_zz_158 + 3'b001);
-        if(_zz_162)begin
-          _zz_158 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_164 <= ((_zz_159 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_67 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_223)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_111 <= _zz_40[11 : 7];
-    _zz_112 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_206)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_224)begin
-      if(_zz_225)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_226)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_227)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_207)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -4654,258 +4924,258 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_201)begin
-      if(_zz_220)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_307[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_221)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_313);
-      memory_DivPlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_315);
-      memory_DivPlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_49) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_50) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_51) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_52) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_318[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -4918,9 +5188,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -4942,6 +5211,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -4957,9 +5227,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -4967,7 +5238,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -4976,24 +5247,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5018,40 +5280,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5061,23 +5331,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5085,10 +5365,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5100,59 +5388,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -5167,274 +5450,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -5442,89 +5744,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -5532,12 +5818,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -5548,20 +5834,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -5569,45 +5875,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -5618,46 +5926,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -5665,50 +5964,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -5758,13 +6058,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -5773,8 +6069,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -5788,22 +6089,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -5813,82 +6117,85 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -5904,30 +6211,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -5935,51 +6247,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -5990,10 +6302,10 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Debug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Debug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -81,37 +81,37 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_168;
-  wire                _zz_169;
-  wire                _zz_170;
-  wire                _zz_171;
-  wire                _zz_172;
-  wire                _zz_173;
-  wire                _zz_174;
-  wire                _zz_175;
-  reg                 _zz_176;
-  wire                _zz_177;
-  wire       [31:0]   _zz_178;
-  wire                _zz_179;
-  wire       [31:0]   _zz_180;
-  reg                 _zz_181;
-  wire                _zz_182;
-  wire                _zz_183;
-  wire       [31:0]   _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  wire                _zz_190;
-  wire                _zz_191;
-  wire                _zz_192;
-  wire       [3:0]    _zz_193;
-  wire                _zz_194;
-  wire                _zz_195;
-  reg        [31:0]   _zz_196;
-  reg        [31:0]   _zz_197;
-  reg        [31:0]   _zz_198;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -134,6 +134,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -142,325 +143,267 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  wire                _zz_207;
-  wire                _zz_208;
-  wire                _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire                _zz_212;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire       [1:0]    _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire                _zz_224;
-  wire       [1:0]    _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire       [5:0]    _zz_228;
-  wire                _zz_229;
-  wire                _zz_230;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire       [1:0]    _zz_235;
-  wire                _zz_236;
-  wire       [1:0]    _zz_237;
-  wire       [51:0]   _zz_238;
-  wire       [51:0]   _zz_239;
-  wire       [51:0]   _zz_240;
-  wire       [32:0]   _zz_241;
-  wire       [51:0]   _zz_242;
-  wire       [49:0]   _zz_243;
-  wire       [51:0]   _zz_244;
-  wire       [49:0]   _zz_245;
-  wire       [51:0]   _zz_246;
-  wire       [32:0]   _zz_247;
-  wire       [31:0]   _zz_248;
-  wire       [32:0]   _zz_249;
-  wire       [0:0]    _zz_250;
-  wire       [0:0]    _zz_251;
-  wire       [0:0]    _zz_252;
-  wire       [0:0]    _zz_253;
-  wire       [0:0]    _zz_254;
-  wire       [0:0]    _zz_255;
-  wire       [0:0]    _zz_256;
-  wire       [0:0]    _zz_257;
-  wire       [0:0]    _zz_258;
-  wire       [0:0]    _zz_259;
-  wire       [0:0]    _zz_260;
-  wire       [0:0]    _zz_261;
-  wire       [0:0]    _zz_262;
-  wire       [0:0]    _zz_263;
-  wire       [0:0]    _zz_264;
-  wire       [0:0]    _zz_265;
-  wire       [0:0]    _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [3:0]    _zz_268;
-  wire       [2:0]    _zz_269;
-  wire       [31:0]   _zz_270;
-  wire       [11:0]   _zz_271;
-  wire       [31:0]   _zz_272;
-  wire       [19:0]   _zz_273;
-  wire       [11:0]   _zz_274;
-  wire       [31:0]   _zz_275;
-  wire       [31:0]   _zz_276;
-  wire       [19:0]   _zz_277;
-  wire       [11:0]   _zz_278;
-  wire       [2:0]    _zz_279;
-  wire       [2:0]    _zz_280;
-  wire       [0:0]    _zz_281;
-  wire       [2:0]    _zz_282;
-  wire       [4:0]    _zz_283;
-  wire       [11:0]   _zz_284;
-  wire       [11:0]   _zz_285;
-  wire       [31:0]   _zz_286;
-  wire       [31:0]   _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [31:0]   _zz_289;
-  wire       [31:0]   _zz_290;
-  wire       [31:0]   _zz_291;
-  wire       [31:0]   _zz_292;
-  wire       [11:0]   _zz_293;
-  wire       [19:0]   _zz_294;
-  wire       [11:0]   _zz_295;
-  wire       [31:0]   _zz_296;
-  wire       [31:0]   _zz_297;
-  wire       [31:0]   _zz_298;
-  wire       [11:0]   _zz_299;
-  wire       [19:0]   _zz_300;
-  wire       [11:0]   _zz_301;
-  wire       [2:0]    _zz_302;
-  wire       [1:0]    _zz_303;
-  wire       [1:0]    _zz_304;
-  wire       [65:0]   _zz_305;
-  wire       [65:0]   _zz_306;
-  wire       [31:0]   _zz_307;
-  wire       [31:0]   _zz_308;
-  wire       [0:0]    _zz_309;
-  wire       [5:0]    _zz_310;
-  wire       [32:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  wire       [32:0]   _zz_314;
-  wire       [32:0]   _zz_315;
-  wire       [32:0]   _zz_316;
-  wire       [32:0]   _zz_317;
-  wire       [0:0]    _zz_318;
-  wire       [32:0]   _zz_319;
-  wire       [0:0]    _zz_320;
-  wire       [32:0]   _zz_321;
-  wire       [0:0]    _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [0:0]    _zz_324;
-  wire       [0:0]    _zz_325;
-  wire       [0:0]    _zz_326;
-  wire       [0:0]    _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [0:0]    _zz_329;
-  wire       [26:0]   _zz_330;
-  wire                _zz_331;
-  wire                _zz_332;
-  wire       [1:0]    _zz_333;
-  wire       [31:0]   _zz_334;
-  wire       [31:0]   _zz_335;
-  wire       [31:0]   _zz_336;
-  wire                _zz_337;
-  wire       [0:0]    _zz_338;
-  wire       [13:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire       [31:0]   _zz_341;
-  wire       [31:0]   _zz_342;
-  wire                _zz_343;
-  wire       [0:0]    _zz_344;
-  wire       [7:0]    _zz_345;
-  wire       [31:0]   _zz_346;
-  wire       [31:0]   _zz_347;
-  wire       [31:0]   _zz_348;
-  wire                _zz_349;
-  wire       [0:0]    _zz_350;
-  wire       [1:0]    _zz_351;
-  wire                _zz_352;
-  wire                _zz_353;
-  wire                _zz_354;
-  wire       [31:0]   _zz_355;
-  wire       [0:0]    _zz_356;
-  wire       [0:0]    _zz_357;
-  wire                _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [26:0]   _zz_360;
-  wire       [31:0]   _zz_361;
-  wire       [31:0]   _zz_362;
-  wire       [31:0]   _zz_363;
-  wire                _zz_364;
-  wire       [1:0]    _zz_365;
-  wire       [1:0]    _zz_366;
-  wire                _zz_367;
-  wire       [0:0]    _zz_368;
-  wire       [22:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire       [31:0]   _zz_371;
-  wire       [31:0]   _zz_372;
-  wire       [31:0]   _zz_373;
-  wire                _zz_374;
-  wire                _zz_375;
-  wire       [1:0]    _zz_376;
-  wire       [1:0]    _zz_377;
-  wire                _zz_378;
-  wire       [0:0]    _zz_379;
-  wire       [19:0]   _zz_380;
-  wire       [31:0]   _zz_381;
-  wire       [31:0]   _zz_382;
-  wire       [31:0]   _zz_383;
-  wire       [31:0]   _zz_384;
-  wire                _zz_385;
-  wire       [0:0]    _zz_386;
-  wire       [0:0]    _zz_387;
-  wire                _zz_388;
-  wire       [0:0]    _zz_389;
-  wire       [0:0]    _zz_390;
-  wire                _zz_391;
-  wire       [0:0]    _zz_392;
-  wire       [16:0]   _zz_393;
-  wire       [31:0]   _zz_394;
-  wire       [31:0]   _zz_395;
-  wire       [31:0]   _zz_396;
-  wire       [31:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [0:0]    _zz_399;
-  wire       [0:0]    _zz_400;
-  wire       [0:0]    _zz_401;
-  wire       [0:0]    _zz_402;
-  wire                _zz_403;
-  wire       [0:0]    _zz_404;
-  wire       [13:0]   _zz_405;
-  wire       [31:0]   _zz_406;
-  wire       [31:0]   _zz_407;
-  wire       [31:0]   _zz_408;
-  wire                _zz_409;
-  wire                _zz_410;
-  wire       [0:0]    _zz_411;
-  wire       [1:0]    _zz_412;
-  wire       [0:0]    _zz_413;
-  wire       [0:0]    _zz_414;
-  wire                _zz_415;
-  wire       [0:0]    _zz_416;
-  wire       [10:0]   _zz_417;
-  wire       [31:0]   _zz_418;
-  wire       [31:0]   _zz_419;
-  wire       [31:0]   _zz_420;
-  wire       [31:0]   _zz_421;
-  wire       [31:0]   _zz_422;
-  wire       [31:0]   _zz_423;
-  wire                _zz_424;
-  wire       [0:0]    _zz_425;
-  wire       [2:0]    _zz_426;
-  wire       [0:0]    _zz_427;
-  wire       [3:0]    _zz_428;
-  wire       [5:0]    _zz_429;
-  wire       [5:0]    _zz_430;
-  wire                _zz_431;
-  wire       [0:0]    _zz_432;
-  wire       [7:0]    _zz_433;
-  wire       [31:0]   _zz_434;
-  wire                _zz_435;
-  wire       [0:0]    _zz_436;
-  wire       [0:0]    _zz_437;
-  wire                _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [1:0]    _zz_440;
-  wire       [0:0]    _zz_441;
-  wire       [3:0]    _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [0:0]    _zz_444;
-  wire       [1:0]    _zz_445;
-  wire       [1:0]    _zz_446;
-  wire                _zz_447;
-  wire       [0:0]    _zz_448;
-  wire       [5:0]    _zz_449;
-  wire       [31:0]   _zz_450;
-  wire       [31:0]   _zz_451;
-  wire       [31:0]   _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire                _zz_458;
-  wire                _zz_459;
-  wire       [31:0]   _zz_460;
-  wire       [31:0]   _zz_461;
-  wire                _zz_462;
-  wire       [0:0]    _zz_463;
-  wire       [1:0]    _zz_464;
-  wire       [31:0]   _zz_465;
-  wire       [31:0]   _zz_466;
-  wire                _zz_467;
-  wire                _zz_468;
-  wire       [0:0]    _zz_469;
-  wire       [0:0]    _zz_470;
-  wire                _zz_471;
-  wire       [0:0]    _zz_472;
-  wire       [3:0]    _zz_473;
-  wire       [31:0]   _zz_474;
-  wire       [31:0]   _zz_475;
-  wire       [31:0]   _zz_476;
-  wire       [31:0]   _zz_477;
-  wire       [31:0]   _zz_478;
-  wire                _zz_479;
-  wire                _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire       [31:0]   _zz_483;
-  wire       [31:0]   _zz_484;
-  wire       [0:0]    _zz_485;
-  wire       [2:0]    _zz_486;
-  wire       [0:0]    _zz_487;
-  wire       [0:0]    _zz_488;
-  wire                _zz_489;
-  wire       [0:0]    _zz_490;
-  wire       [1:0]    _zz_491;
-  wire       [31:0]   _zz_492;
-  wire       [31:0]   _zz_493;
-  wire       [31:0]   _zz_494;
-  wire                _zz_495;
-  wire                _zz_496;
-  wire       [31:0]   _zz_497;
-  wire                _zz_498;
-  wire       [0:0]    _zz_499;
-  wire       [0:0]    _zz_500;
-  wire       [0:0]    _zz_501;
-  wire       [0:0]    _zz_502;
-  wire       [1:0]    _zz_503;
-  wire       [1:0]    _zz_504;
-  wire       [0:0]    _zz_505;
-  wire       [0:0]    _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [31:0]   _zz_508;
-  wire       [31:0]   _zz_509;
-  wire       [31:0]   _zz_510;
-  wire       [31:0]   _zz_511;
-  wire       [31:0]   _zz_512;
-  wire                _zz_513;
-  wire                _zz_514;
-  wire                _zz_515;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire       [26:0]   _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [16:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -471,8 +414,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
@@ -484,27 +427,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -513,17 +456,17 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -546,11 +489,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -558,10 +501,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -571,45 +514,45 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -628,10 +571,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -718,7 +661,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -744,7 +687,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_54;
+  reg                 _zz_when_DBusCachedPlugin_l386;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -753,6 +696,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -770,31 +718,37 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -817,16 +771,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63;
-  wire                _zz_64;
-  reg                 _zz_65;
-  wire                _zz_66;
-  reg                 _zz_67;
-  reg        [31:0]   _zz_68;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -834,22 +790,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69;
-  reg        [18:0]   _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
-  reg                 _zz_75;
-  wire                _zz_76;
-  reg        [10:0]   _zz_77;
-  wire                _zz_78;
-  reg        [18:0]   _zz_79;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -857,7 +820,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -865,6 +828,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -872,7 +840,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -880,8 +848,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -889,38 +858,52 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83;
-  reg        [31:0]   _zz_84;
-  wire                _zz_85;
-  reg        [31:0]   _zz_86;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
-  wire                _zz_90;
-  wire                _zz_91;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_92;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_94;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_96;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_97;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_98;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -928,52 +911,70 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100;
-  reg        [31:0]   _zz_101;
-  wire                _zz_102;
-  reg        [19:0]   _zz_103;
-  wire                _zz_104;
-  reg        [19:0]   _zz_105;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_107;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
-  reg                 _zz_111;
-  reg        [4:0]    _zz_112;
-  reg        [31:0]   _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire                _zz_118;
-  wire                _zz_119;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_120;
-  reg                 _zz_121;
-  reg                 _zz_122;
-  wire                _zz_123;
-  reg        [19:0]   _zz_124;
-  wire                _zz_125;
-  reg        [10:0]   _zz_126;
-  wire                _zz_127;
-  reg        [18:0]   _zz_128;
-  reg                 _zz_129;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_130;
-  reg        [19:0]   _zz_131;
-  wire                _zz_132;
-  reg        [10:0]   _zz_133;
-  wire                _zz_134;
-  reg        [18:0]   _zz_135;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -994,9 +995,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1009,40 +1010,64 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_139;
-  wire                _zz_140;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1050,6 +1075,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1062,19 +1089,26 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_141;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
-  reg        [32:0]   _zz_145;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_146;
-  wire       [31:0]   _zz_147;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1082,180 +1116,281 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_148;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_DO_EBREAK;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_50;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_51;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_54;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_55;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_62;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_149;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [31:0]   _zz_156;
-  reg        [31:0]   _zz_157;
-  reg        [31:0]   _zz_158;
-  reg        [2:0]    _zz_159;
-  reg                 _zz_160;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_161;
-  wire                _zz_162;
-  wire                _zz_163;
-  wire                _zz_164;
-  wire                _zz_165;
-  wire                _zz_166;
-  reg                 _zz_167;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_51_string;
-  reg [95:0] _zz_92_string;
-  reg [63:0] _zz_93_string;
-  reg [23:0] _zz_94_string;
-  reg [39:0] _zz_95_string;
-  reg [71:0] _zz_96_string;
-  reg [31:0] _zz_97_string;
-  reg [39:0] _zz_98_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1264,494 +1399,460 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_199 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_200 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_201 = 1'b1;
-  assign _zz_202 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_203 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_204 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_205 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_206 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_207 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_208 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_209 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_210 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_211 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_212 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_213 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_214 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_215 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_216 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_217 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_218 = (1'b0 || (! 1'b1));
-  assign _zz_219 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_220 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_221 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_222 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_223 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_224 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_225 = execute_INSTRUCTION[13 : 12];
-  assign _zz_226 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_227 = (! memory_arbitration_isStuck);
-  assign _zz_228 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_229 = (iBus_cmd_valid || (_zz_159 != 3'b000));
-  assign _zz_230 = (_zz_195 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_231 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_232 = ((_zz_136 && 1'b1) && (! 1'b0));
-  assign _zz_233 = ((_zz_137 && 1'b1) && (! 1'b0));
-  assign _zz_234 = ((_zz_138 && 1'b1) && (! 1'b0));
-  assign _zz_235 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_236 = execute_INSTRUCTION[13];
-  assign _zz_237 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_238 = ($signed(_zz_239) + $signed(_zz_244));
-  assign _zz_239 = ($signed(_zz_240) + $signed(_zz_242));
-  assign _zz_240 = 52'h0;
-  assign _zz_241 = {1'b0,memory_MUL_LL};
-  assign _zz_242 = {{19{_zz_241[32]}}, _zz_241};
-  assign _zz_243 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_244 = {{2{_zz_243[49]}}, _zz_243};
-  assign _zz_245 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_246 = {{2{_zz_245[49]}}, _zz_245};
-  assign _zz_247 = ($signed(_zz_249) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_248 = _zz_247[31 : 0];
-  assign _zz_249 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_250 = _zz_87[31 : 31];
-  assign _zz_251 = _zz_87[30 : 30];
-  assign _zz_252 = _zz_87[29 : 29];
-  assign _zz_253 = _zz_87[28 : 28];
-  assign _zz_254 = _zz_87[25 : 25];
-  assign _zz_255 = _zz_87[17 : 17];
-  assign _zz_256 = _zz_87[16 : 16];
-  assign _zz_257 = _zz_87[13 : 13];
-  assign _zz_258 = _zz_87[12 : 12];
-  assign _zz_259 = _zz_87[11 : 11];
-  assign _zz_260 = _zz_87[32 : 32];
-  assign _zz_261 = _zz_87[15 : 15];
-  assign _zz_262 = _zz_87[5 : 5];
-  assign _zz_263 = _zz_87[3 : 3];
-  assign _zz_264 = _zz_87[20 : 20];
-  assign _zz_265 = _zz_87[10 : 10];
-  assign _zz_266 = _zz_87[4 : 4];
-  assign _zz_267 = _zz_87[0 : 0];
-  assign _zz_268 = (_zz_55 - 4'b0001);
-  assign _zz_269 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_270 = {29'd0, _zz_269};
-  assign _zz_271 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_272 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_273 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_274 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_275 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_276 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_277 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_278 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_279 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_280 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_281 = execute_SRC_LESS;
-  assign _zz_282 = 3'b100;
-  assign _zz_283 = execute_INSTRUCTION[19 : 15];
-  assign _zz_284 = execute_INSTRUCTION[31 : 20];
-  assign _zz_285 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_286 = ($signed(_zz_287) + $signed(_zz_290));
-  assign _zz_287 = ($signed(_zz_288) + $signed(_zz_289));
-  assign _zz_288 = execute_SRC1;
-  assign _zz_289 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_290 = (execute_SRC_USE_SUB_LESS ? _zz_291 : _zz_292);
-  assign _zz_291 = 32'h00000001;
-  assign _zz_292 = 32'h0;
-  assign _zz_293 = execute_INSTRUCTION[31 : 20];
-  assign _zz_294 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_295 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_296 = {_zz_124,execute_INSTRUCTION[31 : 20]};
-  assign _zz_297 = {{_zz_126,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_298 = {{_zz_128,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_299 = execute_INSTRUCTION[31 : 20];
-  assign _zz_300 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_301 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_302 = 3'b100;
-  assign _zz_303 = (_zz_139 & (~ _zz_304));
-  assign _zz_304 = (_zz_139 - 2'b01);
-  assign _zz_305 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_306 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_307 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_308 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_309 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_310 = {5'd0, _zz_309};
-  assign _zz_311 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_312 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_313 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_314 = {_zz_141,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_315 = _zz_316;
-  assign _zz_316 = _zz_317;
-  assign _zz_317 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_142) : _zz_142)} + _zz_319);
-  assign _zz_318 = memory_DivPlugin_div_needRevert;
-  assign _zz_319 = {32'd0, _zz_318};
-  assign _zz_320 = _zz_144;
-  assign _zz_321 = {32'd0, _zz_320};
-  assign _zz_322 = _zz_143;
-  assign _zz_323 = {31'd0, _zz_322};
-  assign _zz_324 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_325 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_326 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_327 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_328 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_329 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_330 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_331 = 1'b1;
-  assign _zz_332 = 1'b1;
-  assign _zz_333 = {_zz_59,_zz_58};
-  assign _zz_334 = 32'h0000107f;
-  assign _zz_335 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_336 = 32'h00002073;
-  assign _zz_337 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_338 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_339 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_340) == 32'h00000003),{(_zz_341 == _zz_342),{_zz_343,{_zz_344,_zz_345}}}}}};
-  assign _zz_340 = 32'h0000505f;
-  assign _zz_341 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_342 = 32'h00000063;
-  assign _zz_343 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_344 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_345 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_346) == 32'h00001013),{(_zz_347 == _zz_348),{_zz_349,{_zz_350,_zz_351}}}}}};
-  assign _zz_346 = 32'hfc00307f;
-  assign _zz_347 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_348 = 32'h00005033;
-  assign _zz_349 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_350 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_351 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_352 = decode_INSTRUCTION[31];
-  assign _zz_353 = decode_INSTRUCTION[31];
-  assign _zz_354 = decode_INSTRUCTION[7];
-  assign _zz_355 = 32'h10103050;
-  assign _zz_356 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_357 = 1'b0;
-  assign _zz_358 = (((decode_INSTRUCTION & _zz_361) == 32'h02000030) != 1'b0);
-  assign _zz_359 = ((_zz_362 == _zz_363) != 1'b0);
-  assign _zz_360 = {(_zz_364 != 1'b0),{(_zz_365 != _zz_366),{_zz_367,{_zz_368,_zz_369}}}};
-  assign _zz_361 = 32'h02004074;
-  assign _zz_362 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_363 = 32'h00000050;
-  assign _zz_364 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_365 = {(_zz_370 == _zz_371),(_zz_372 == _zz_373)};
-  assign _zz_366 = 2'b00;
-  assign _zz_367 = ({_zz_90,_zz_374} != 2'b00);
-  assign _zz_368 = (_zz_375 != 1'b0);
-  assign _zz_369 = {(_zz_376 != _zz_377),{_zz_378,{_zz_379,_zz_380}}};
-  assign _zz_370 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_371 = 32'h00001050;
-  assign _zz_372 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_373 = 32'h00002050;
-  assign _zz_374 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_375 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_376 = {(_zz_381 == _zz_382),(_zz_383 == _zz_384)};
-  assign _zz_377 = 2'b00;
-  assign _zz_378 = ({_zz_385,{_zz_386,_zz_387}} != 3'b000);
-  assign _zz_379 = (_zz_388 != 1'b0);
-  assign _zz_380 = {(_zz_389 != _zz_390),{_zz_391,{_zz_392,_zz_393}}};
-  assign _zz_381 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_382 = 32'h00005010;
-  assign _zz_383 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_384 = 32'h00005020;
-  assign _zz_385 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_386 = ((decode_INSTRUCTION & _zz_394) == 32'h00001010);
-  assign _zz_387 = ((decode_INSTRUCTION & _zz_395) == 32'h00001010);
-  assign _zz_388 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_389 = ((decode_INSTRUCTION & _zz_396) == 32'h00001000);
-  assign _zz_390 = 1'b0;
-  assign _zz_391 = ((_zz_397 == _zz_398) != 1'b0);
-  assign _zz_392 = ({_zz_399,_zz_400} != 2'b00);
-  assign _zz_393 = {(_zz_401 != _zz_402),{_zz_403,{_zz_404,_zz_405}}};
-  assign _zz_394 = 32'h00007034;
-  assign _zz_395 = 32'h02007054;
-  assign _zz_396 = 32'h00001000;
-  assign _zz_397 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_398 = 32'h00002000;
-  assign _zz_399 = ((decode_INSTRUCTION & _zz_406) == 32'h00002000);
-  assign _zz_400 = ((decode_INSTRUCTION & _zz_407) == 32'h00001000);
-  assign _zz_401 = ((decode_INSTRUCTION & _zz_408) == 32'h00004008);
-  assign _zz_402 = 1'b0;
-  assign _zz_403 = ({_zz_409,_zz_410} != 2'b00);
-  assign _zz_404 = ({_zz_411,_zz_412} != 3'b000);
-  assign _zz_405 = {(_zz_413 != _zz_414),{_zz_415,{_zz_416,_zz_417}}};
-  assign _zz_406 = 32'h00002010;
-  assign _zz_407 = 32'h00005000;
-  assign _zz_408 = 32'h00004048;
-  assign _zz_409 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_410 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_411 = ((decode_INSTRUCTION & _zz_418) == 32'h00000040);
-  assign _zz_412 = {(_zz_419 == _zz_420),(_zz_421 == _zz_422)};
-  assign _zz_413 = ((decode_INSTRUCTION & _zz_423) == 32'h00000020);
-  assign _zz_414 = 1'b0;
-  assign _zz_415 = ({_zz_424,{_zz_425,_zz_426}} != 5'h0);
-  assign _zz_416 = ({_zz_427,_zz_428} != 5'h0);
-  assign _zz_417 = {(_zz_429 != _zz_430),{_zz_431,{_zz_432,_zz_433}}};
-  assign _zz_418 = 32'h00000050;
-  assign _zz_419 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_420 = 32'h0;
-  assign _zz_421 = (decode_INSTRUCTION & 32'h00103040);
-  assign _zz_422 = 32'h00000040;
-  assign _zz_423 = 32'h00000020;
-  assign _zz_424 = ((decode_INSTRUCTION & _zz_434) == 32'h00000040);
-  assign _zz_425 = _zz_89;
-  assign _zz_426 = {_zz_435,{_zz_436,_zz_437}};
-  assign _zz_427 = _zz_89;
-  assign _zz_428 = {_zz_438,{_zz_439,_zz_440}};
-  assign _zz_429 = {_zz_90,{_zz_441,_zz_442}};
-  assign _zz_430 = 6'h0;
-  assign _zz_431 = ({_zz_443,_zz_444} != 2'b00);
-  assign _zz_432 = (_zz_445 != _zz_446);
-  assign _zz_433 = {_zz_447,{_zz_448,_zz_449}};
-  assign _zz_434 = 32'h00000040;
-  assign _zz_435 = ((decode_INSTRUCTION & _zz_450) == 32'h00004020);
-  assign _zz_436 = (_zz_451 == _zz_452);
-  assign _zz_437 = (_zz_453 == _zz_454);
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_455) == 32'h00002010);
-  assign _zz_439 = (_zz_456 == _zz_457);
-  assign _zz_440 = {_zz_458,_zz_459};
-  assign _zz_441 = (_zz_460 == _zz_461);
-  assign _zz_442 = {_zz_462,{_zz_463,_zz_464}};
-  assign _zz_443 = _zz_89;
-  assign _zz_444 = (_zz_465 == _zz_466);
-  assign _zz_445 = {_zz_89,_zz_467};
-  assign _zz_446 = 2'b00;
-  assign _zz_447 = (_zz_468 != 1'b0);
-  assign _zz_448 = (_zz_469 != _zz_470);
-  assign _zz_449 = {_zz_471,{_zz_472,_zz_473}};
-  assign _zz_450 = 32'h00004020;
-  assign _zz_451 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_452 = 32'h00000010;
-  assign _zz_453 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_454 = 32'h00000020;
-  assign _zz_455 = 32'h00002030;
-  assign _zz_456 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_457 = 32'h00000010;
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_474) == 32'h00002020);
-  assign _zz_459 = ((decode_INSTRUCTION & _zz_475) == 32'h00000020);
-  assign _zz_460 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_461 = 32'h00001010;
-  assign _zz_462 = ((decode_INSTRUCTION & _zz_476) == 32'h00002010);
-  assign _zz_463 = (_zz_477 == _zz_478);
-  assign _zz_464 = {_zz_479,_zz_480};
-  assign _zz_465 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_466 = 32'h00000020;
-  assign _zz_467 = ((decode_INSTRUCTION & _zz_481) == 32'h0);
-  assign _zz_468 = ((decode_INSTRUCTION & _zz_482) == 32'h00004010);
-  assign _zz_469 = (_zz_483 == _zz_484);
-  assign _zz_470 = 1'b0;
-  assign _zz_471 = ({_zz_485,_zz_486} != 4'b0000);
-  assign _zz_472 = (_zz_487 != _zz_488);
-  assign _zz_473 = {_zz_489,{_zz_490,_zz_491}};
-  assign _zz_474 = 32'h02002060;
-  assign _zz_475 = 32'h02003020;
-  assign _zz_476 = 32'h00002010;
-  assign _zz_477 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_478 = 32'h00000010;
-  assign _zz_479 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_480 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_481 = 32'h00000020;
-  assign _zz_482 = 32'h00004014;
-  assign _zz_483 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_484 = 32'h00002010;
-  assign _zz_485 = ((decode_INSTRUCTION & _zz_492) == 32'h0);
-  assign _zz_486 = {(_zz_493 == _zz_494),{_zz_495,_zz_496}};
-  assign _zz_487 = ((decode_INSTRUCTION & _zz_497) == 32'h0);
-  assign _zz_488 = 1'b0;
-  assign _zz_489 = ({_zz_498,{_zz_499,_zz_500}} != 3'b000);
-  assign _zz_490 = ({_zz_501,_zz_502} != 2'b00);
-  assign _zz_491 = {(_zz_503 != _zz_504),(_zz_505 != _zz_506)};
-  assign _zz_492 = 32'h00000044;
-  assign _zz_493 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_494 = 32'h0;
-  assign _zz_495 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_496 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_497 = 32'h00000058;
-  assign _zz_498 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_499 = ((decode_INSTRUCTION & _zz_507) == 32'h00002010);
-  assign _zz_500 = ((decode_INSTRUCTION & _zz_508) == 32'h40000030);
-  assign _zz_501 = ((decode_INSTRUCTION & _zz_509) == 32'h00000004);
-  assign _zz_502 = _zz_88;
-  assign _zz_503 = {(_zz_510 == _zz_511),_zz_88};
-  assign _zz_504 = 2'b00;
-  assign _zz_505 = ((decode_INSTRUCTION & _zz_512) == 32'h00001008);
-  assign _zz_506 = 1'b0;
-  assign _zz_507 = 32'h00002014;
-  assign _zz_508 = 32'h40000034;
-  assign _zz_509 = 32'h00000014;
-  assign _zz_510 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_511 = 32'h00000004;
-  assign _zz_512 = 32'h00005048;
-  assign _zz_513 = execute_INSTRUCTION[31];
-  assign _zz_514 = execute_INSTRUCTION[31];
-  assign _zz_515 = execute_INSTRUCTION[7];
-  always @ (posedge clk) begin
-    if(_zz_331) begin
-      _zz_196 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_RS2_SIGNED = 32'h10103050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_4) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = ((_zz__zz_decode_IS_RS2_SIGNED_6 == _zz__zz_decode_IS_RS2_SIGNED_7) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = {(_zz__zz_decode_IS_RS2_SIGNED_9 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_10 != _zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_16,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_20}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h02004074;
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(_zz__zz_decode_IS_RS2_SIGNED_11 == _zz__zz_decode_IS_RS2_SIGNED_12),(_zz__zz_decode_IS_RS2_SIGNED_13 == _zz__zz_decode_IS_RS2_SIGNED_14)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ({_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_17} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (_zz__zz_decode_IS_RS2_SIGNED_19 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = {(_zz__zz_decode_IS_RS2_SIGNED_21 != _zz__zz_decode_IS_RS2_SIGNED_26),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ({_zz__zz_decode_IS_RS2_SIGNED_28,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_31}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (_zz__zz_decode_IS_RS2_SIGNED_34 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(_zz__zz_decode_IS_RS2_SIGNED_36 != _zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_39,{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_47}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00005020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_32) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((_zz__zz_decode_IS_RS2_SIGNED_40 == _zz__zz_decode_IS_RS2_SIGNED_41) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ({_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = {(_zz__zz_decode_IS_RS2_SIGNED_48 != _zz__zz_decode_IS_RS2_SIGNED_50),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_62}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00007034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_46) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ({_zz__zz_decode_IS_RS2_SIGNED_52,_zz__zz_decode_IS_RS2_SIGNED_53} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = ({_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_57} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {(_zz__zz_decode_IS_RS2_SIGNED_63 != _zz__zz_decode_IS_RS2_SIGNED_65),{_zz__zz_decode_IS_RS2_SIGNED_66,{_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_92}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {(_zz__zz_decode_IS_RS2_SIGNED_58 == _zz__zz_decode_IS_RS2_SIGNED_59),(_zz__zz_decode_IS_RS2_SIGNED_60 == _zz__zz_decode_IS_RS2_SIGNED_61)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_64) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = ({_zz__zz_decode_IS_RS2_SIGNED_67,{_zz__zz_decode_IS_RS2_SIGNED_69,_zz__zz_decode_IS_RS2_SIGNED_70}} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ({_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_81} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = {(_zz__zz_decode_IS_RS2_SIGNED_93 != _zz__zz_decode_IS_RS2_SIGNED_106),{_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_112,_zz__zz_decode_IS_RS2_SIGNED_117}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = (decode_INSTRUCTION & 32'h00103040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_68) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = {_zz__zz_decode_IS_RS2_SIGNED_71,{_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_76}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = {_zz__zz_decode_IS_RS2_SIGNED_82,{_zz__zz_decode_IS_RS2_SIGNED_84,_zz__zz_decode_IS_RS2_SIGNED_87}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_94,_zz__zz_decode_IS_RS2_SIGNED_97}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 6'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ({_zz__zz_decode_IS_RS2_SIGNED_108,_zz__zz_decode_IS_RS2_SIGNED_109} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 != _zz__zz_decode_IS_RS2_SIGNED_116);
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = {_zz__zz_decode_IS_RS2_SIGNED_118,{_zz__zz_decode_IS_RS2_SIGNED_121,_zz__zz_decode_IS_RS2_SIGNED_126}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_72) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = (_zz__zz_decode_IS_RS2_SIGNED_74 == _zz__zz_decode_IS_RS2_SIGNED_75);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (_zz__zz_decode_IS_RS2_SIGNED_77 == _zz__zz_decode_IS_RS2_SIGNED_78);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_83) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = (_zz__zz_decode_IS_RS2_SIGNED_85 == _zz__zz_decode_IS_RS2_SIGNED_86);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz__zz_decode_IS_RS2_SIGNED_88,_zz__zz_decode_IS_RS2_SIGNED_90};
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (_zz__zz_decode_IS_RS2_SIGNED_95 == _zz__zz_decode_IS_RS2_SIGNED_96);
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = {_zz__zz_decode_IS_RS2_SIGNED_98,{_zz__zz_decode_IS_RS2_SIGNED_100,_zz__zz_decode_IS_RS2_SIGNED_103}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_114};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (_zz__zz_decode_IS_RS2_SIGNED_119 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (_zz__zz_decode_IS_RS2_SIGNED_122 != _zz__zz_decode_IS_RS2_SIGNED_125);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {_zz__zz_decode_IS_RS2_SIGNED_127,{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_139}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_91) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_99) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (_zz__zz_decode_IS_RS2_SIGNED_101 == _zz__zz_decode_IS_RS2_SIGNED_102);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz__zz_decode_IS_RS2_SIGNED_104,_zz__zz_decode_IS_RS2_SIGNED_105};
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_115) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_120) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (_zz__zz_decode_IS_RS2_SIGNED_123 == _zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = ({_zz__zz_decode_IS_RS2_SIGNED_128,_zz__zz_decode_IS_RS2_SIGNED_130} != 4'b0000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (_zz__zz_decode_IS_RS2_SIGNED_136 != _zz__zz_decode_IS_RS2_SIGNED_138);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = {_zz__zz_decode_IS_RS2_SIGNED_140,{_zz__zz_decode_IS_RS2_SIGNED_146,_zz__zz_decode_IS_RS2_SIGNED_150}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h02002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_129) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = {(_zz__zz_decode_IS_RS2_SIGNED_131 == _zz__zz_decode_IS_RS2_SIGNED_132),{_zz__zz_decode_IS_RS2_SIGNED_133,_zz__zz_decode_IS_RS2_SIGNED_134}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_137) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ({_zz__zz_decode_IS_RS2_SIGNED_141,{_zz__zz_decode_IS_RS2_SIGNED_142,_zz__zz_decode_IS_RS2_SIGNED_144}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = ({_zz__zz_decode_IS_RS2_SIGNED_147,_zz__zz_decode_IS_RS2_SIGNED_149} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {(_zz__zz_decode_IS_RS2_SIGNED_151 != _zz__zz_decode_IS_RS2_SIGNED_154),(_zz__zz_decode_IS_RS2_SIGNED_155 != _zz__zz_decode_IS_RS2_SIGNED_157)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_145) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_148) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = {(_zz__zz_decode_IS_RS2_SIGNED_152 == _zz__zz_decode_IS_RS2_SIGNED_153),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_156) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00000014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = 32'h00005048;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_332) begin
-      _zz_197 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_168                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_169                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_170                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_171                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_172                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_173                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_174                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_175                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_176                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_149[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_177                                            ), //i
-    .io_cpu_execute_address                    (_zz_178[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_179                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_180[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_181                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_182                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_183                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_184[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_185                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_186                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_187                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_188                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_189                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_190                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_191                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_192                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_193[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_194                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_195                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_333)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_198 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_198 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_198 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_198 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1763,131 +1864,131 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1900,30 +2001,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1935,27 +2036,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1968,30 +2069,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2003,11 +2104,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2019,11 +2120,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2035,11 +2136,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2052,48 +2153,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2106,12 +2207,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2124,12 +2225,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2141,87 +2242,87 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2234,72 +2335,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_92_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_92_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_92_string = "URS1        ";
-      default : _zz_92_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_93_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_93_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_93_string = "BITWISE ";
-      default : _zz_93_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_94_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_94_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_94_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_94_string = "PC ";
-      default : _zz_94_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_95_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_95_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_95_string = "AND_1";
-      default : _zz_95_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_96_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_96_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_96_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_96_string = "SRA_1    ";
-      default : _zz_96_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_97)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_97_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_97_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97_string = "JALR";
-      default : _zz_97_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_98_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_98_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_98_string = "ECALL";
-      default : _zz_98_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2330,28 +2431,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2389,7 +2490,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_238) + $signed(_zz_246));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2397,45 +2498,45 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_248;
-  assign execute_REGFILE_WRITE_DATA = _zz_100;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_178[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_250[0];
-  assign decode_IS_RS1_SIGNED = _zz_251[0];
-  assign decode_IS_DIV = _zz_252[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[30];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_253[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_254[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_255[0];
-  assign decode_MEMORY_MANAGMENT = _zz_256[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_257[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_258[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_259[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -2443,7 +2544,7 @@ module VexRiscv (
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_260[0];
+  assign decode_IS_EBREAK = _zz_decode_IS_RS2_SIGNED[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2457,22 +2558,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_122;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_261[0];
-  assign decode_RS1_USE = _zz_262[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_199)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2482,139 +2583,139 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_113;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_200)begin
-      if(_zz_201)begin
-        if(_zz_115)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_202)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_203)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_113;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_200)begin
-      if(_zz_201)begin
-        if(_zz_114)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_202)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_203)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_108;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_204)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_263[0];
-  assign decode_SRC_ADD_ZERO = _zz_264[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_106;
-  assign execute_SRC1 = _zz_101;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_265[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_334) == 32'h00001073),{(_zz_335 == _zz_336),{_zz_337,{_zz_338,_zz_339}}}}}}} != 21'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_237)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_307;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_308;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2626,61 +2727,61 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_266[0];
-  assign decode_FLUSH_ALL = _zz_267[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_205)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_206)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_207)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_208)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_149)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2689,161 +2790,161 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_109 || _zz_110)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_209)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_209)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_194 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_199)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_210)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_210)begin
-      if(_zz_211)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_210)begin
-      if(_zz_211)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_204)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_212)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_213)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2852,69 +2953,71 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_212)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_213)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_210)begin
-      if(_zz_211)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_214)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_54 = 1'b1;
+  always @(*) begin
+    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    if(DebugPlugin_godmode) begin
+      _zz_when_DBusCachedPlugin_l386 = 1'b1;
     end
   end
 
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_212)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_213)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_212)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_213)begin
-      case(_zz_215)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2924,80 +3027,92 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_268));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_198;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_270);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3005,66 +3120,75 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
-  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64 = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_149)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3076,207 +3200,213 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_69 = _zz_271[11];
-  always @ (*) begin
-    _zz_70[18] = _zz_69;
-    _zz_70[17] = _zz_69;
-    _zz_70[16] = _zz_69;
-    _zz_70[15] = _zz_69;
-    _zz_70[14] = _zz_69;
-    _zz_70[13] = _zz_69;
-    _zz_70[12] = _zz_69;
-    _zz_70[11] = _zz_69;
-    _zz_70[10] = _zz_69;
-    _zz_70[9] = _zz_69;
-    _zz_70[8] = _zz_69;
-    _zz_70[7] = _zz_69;
-    _zz_70[6] = _zz_69;
-    _zz_70[5] = _zz_69;
-    _zz_70[4] = _zz_69;
-    _zz_70[3] = _zz_69;
-    _zz_70[2] = _zz_69;
-    _zz_70[1] = _zz_69;
-    _zz_70[0] = _zz_69;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_272[31]));
-    if(_zz_75)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_71 = _zz_273[19];
-  always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_73 = _zz_274[11];
-  always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75 = _zz_275[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_75 = _zz_276[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76 = _zz_277[19];
-  always @ (*) begin
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_78 = _zz_278[11];
-  always @ (*) begin
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15] = _zz_78;
-    _zz_79[14] = _zz_78;
-    _zz_79[13] = _zz_78;
-    _zz_79[12] = _zz_78;
-    _zz_79[11] = _zz_78;
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_352,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_353,_zz_354},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_169 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_170 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_171 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_170;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_173 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_174 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_175 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_208)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_206)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_206)begin
-      _zz_176 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_207)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_205)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_207)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_205)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_168 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_195 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3284,168 +3414,178 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_177 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_178 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_194 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_179 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_180 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_179;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_180;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_181 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_181 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_182 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_183 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_184 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_216)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_216)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_216)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_279};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_280};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_84[31] = _zz_83;
-    _zz_84[30] = _zz_83;
-    _zz_84[29] = _zz_83;
-    _zz_84[28] = _zz_83;
-    _zz_84[27] = _zz_83;
-    _zz_84[26] = _zz_83;
-    _zz_84[25] = _zz_83;
-    _zz_84[24] = _zz_83;
-    _zz_84[23] = _zz_83;
-    _zz_84[22] = _zz_83;
-    _zz_84[21] = _zz_83;
-    _zz_84[20] = _zz_83;
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_86[31] = _zz_85;
-    _zz_86[30] = _zz_85;
-    _zz_86[29] = _zz_85;
-    _zz_86[28] = _zz_85;
-    _zz_86[27] = _zz_85;
-    _zz_86[26] = _zz_85;
-    _zz_86[25] = _zz_85;
-    _zz_86[24] = _zz_85;
-    _zz_86[23] = _zz_85;
-    _zz_86[22] = _zz_85;
-    _zz_86[21] = _zz_85;
-    _zz_86[20] = _zz_85;
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_235)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3464,59 +3604,60 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_90 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_91 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_87 = {(((decode_INSTRUCTION & _zz_355) == 32'h00100050) != 1'b0),{(_zz_91 != 1'b0),{(_zz_91 != 1'b0),{(_zz_356 != _zz_357),{_zz_358,{_zz_359,_zz_360}}}}}};
-  assign _zz_92 = _zz_87[2 : 1];
-  assign _zz_49 = _zz_92;
-  assign _zz_93 = _zz_87[7 : 6];
-  assign _zz_48 = _zz_93;
-  assign _zz_94 = _zz_87[9 : 8];
-  assign _zz_47 = _zz_94;
-  assign _zz_95 = _zz_87[19 : 18];
-  assign _zz_46 = _zz_95;
-  assign _zz_96 = _zz_87[22 : 21];
-  assign _zz_45 = _zz_96;
-  assign _zz_97 = _zz_87[24 : 23];
-  assign _zz_44 = _zz_97;
-  assign _zz_98 = _zz_87[27 : 26];
-  assign _zz_43 = _zz_98;
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED) == 32'h00100050) != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_1 != _zz__zz_decode_IS_RS2_SIGNED_2),{_zz__zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_8}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_196;
-  assign decode_RegFilePlugin_rs2Data = _zz_197;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_99)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_99)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_99)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3525,353 +3666,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100 = {31'd0, _zz_281};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_100 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101 = {29'd0, _zz_282};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101 = {27'd0, _zz_283};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_102 = _zz_284[11];
-  always @ (*) begin
-    _zz_103[19] = _zz_102;
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_104 = _zz_285[11];
-  always @ (*) begin
-    _zz_105[19] = _zz_104;
-    _zz_105[18] = _zz_104;
-    _zz_105[17] = _zz_104;
-    _zz_105[16] = _zz_104;
-    _zz_105[15] = _zz_104;
-    _zz_105[14] = _zz_104;
-    _zz_105[13] = _zz_104;
-    _zz_105[12] = _zz_104;
-    _zz_105[11] = _zz_104;
-    _zz_105[10] = _zz_104;
-    _zz_105[9] = _zz_104;
-    _zz_105[8] = _zz_104;
-    _zz_105[7] = _zz_104;
-    _zz_105[6] = _zz_104;
-    _zz_105[5] = _zz_104;
-    _zz_105[4] = _zz_104;
-    _zz_105[3] = _zz_104;
-    _zz_105[2] = _zz_104;
-    _zz_105[1] = _zz_104;
-    _zz_105[0] = _zz_104;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106 = {_zz_103,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106 = {_zz_105,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_286;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_107[0] = execute_SRC1[31];
-    _zz_107[1] = execute_SRC1[30];
-    _zz_107[2] = execute_SRC1[29];
-    _zz_107[3] = execute_SRC1[28];
-    _zz_107[4] = execute_SRC1[27];
-    _zz_107[5] = execute_SRC1[26];
-    _zz_107[6] = execute_SRC1[25];
-    _zz_107[7] = execute_SRC1[24];
-    _zz_107[8] = execute_SRC1[23];
-    _zz_107[9] = execute_SRC1[22];
-    _zz_107[10] = execute_SRC1[21];
-    _zz_107[11] = execute_SRC1[20];
-    _zz_107[12] = execute_SRC1[19];
-    _zz_107[13] = execute_SRC1[18];
-    _zz_107[14] = execute_SRC1[17];
-    _zz_107[15] = execute_SRC1[16];
-    _zz_107[16] = execute_SRC1[15];
-    _zz_107[17] = execute_SRC1[14];
-    _zz_107[18] = execute_SRC1[13];
-    _zz_107[19] = execute_SRC1[12];
-    _zz_107[20] = execute_SRC1[11];
-    _zz_107[21] = execute_SRC1[10];
-    _zz_107[22] = execute_SRC1[9];
-    _zz_107[23] = execute_SRC1[8];
-    _zz_107[24] = execute_SRC1[7];
-    _zz_107[25] = execute_SRC1[6];
-    _zz_107[26] = execute_SRC1[5];
-    _zz_107[27] = execute_SRC1[4];
-    _zz_107[28] = execute_SRC1[3];
-    _zz_107[29] = execute_SRC1[2];
-    _zz_107[30] = execute_SRC1[1];
-    _zz_107[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107 : execute_SRC1);
-  always @ (*) begin
-    _zz_108[0] = memory_SHIFT_RIGHT[31];
-    _zz_108[1] = memory_SHIFT_RIGHT[30];
-    _zz_108[2] = memory_SHIFT_RIGHT[29];
-    _zz_108[3] = memory_SHIFT_RIGHT[28];
-    _zz_108[4] = memory_SHIFT_RIGHT[27];
-    _zz_108[5] = memory_SHIFT_RIGHT[26];
-    _zz_108[6] = memory_SHIFT_RIGHT[25];
-    _zz_108[7] = memory_SHIFT_RIGHT[24];
-    _zz_108[8] = memory_SHIFT_RIGHT[23];
-    _zz_108[9] = memory_SHIFT_RIGHT[22];
-    _zz_108[10] = memory_SHIFT_RIGHT[21];
-    _zz_108[11] = memory_SHIFT_RIGHT[20];
-    _zz_108[12] = memory_SHIFT_RIGHT[19];
-    _zz_108[13] = memory_SHIFT_RIGHT[18];
-    _zz_108[14] = memory_SHIFT_RIGHT[17];
-    _zz_108[15] = memory_SHIFT_RIGHT[16];
-    _zz_108[16] = memory_SHIFT_RIGHT[15];
-    _zz_108[17] = memory_SHIFT_RIGHT[14];
-    _zz_108[18] = memory_SHIFT_RIGHT[13];
-    _zz_108[19] = memory_SHIFT_RIGHT[12];
-    _zz_108[20] = memory_SHIFT_RIGHT[11];
-    _zz_108[21] = memory_SHIFT_RIGHT[10];
-    _zz_108[22] = memory_SHIFT_RIGHT[9];
-    _zz_108[23] = memory_SHIFT_RIGHT[8];
-    _zz_108[24] = memory_SHIFT_RIGHT[7];
-    _zz_108[25] = memory_SHIFT_RIGHT[6];
-    _zz_108[26] = memory_SHIFT_RIGHT[5];
-    _zz_108[27] = memory_SHIFT_RIGHT[4];
-    _zz_108[28] = memory_SHIFT_RIGHT[3];
-    _zz_108[29] = memory_SHIFT_RIGHT[2];
-    _zz_108[30] = memory_SHIFT_RIGHT[1];
-    _zz_108[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_109 = 1'b0;
-    if(_zz_217)begin
-      if(_zz_218)begin
-        if(_zz_114)begin
-          _zz_109 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_219)begin
-      if(_zz_220)begin
-        if(_zz_116)begin
-          _zz_109 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_221)begin
-      if(_zz_222)begin
-        if(_zz_118)begin
-          _zz_109 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_109 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_110 = 1'b0;
-    if(_zz_217)begin
-      if(_zz_218)begin
-        if(_zz_115)begin
-          _zz_110 = 1'b1;
-        end
-      end
-    end
-    if(_zz_219)begin
-      if(_zz_220)begin
-        if(_zz_117)begin
-          _zz_110 = 1'b1;
-        end
-      end
-    end
-    if(_zz_221)begin
-      if(_zz_222)begin
-        if(_zz_119)begin
-          _zz_110 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_110 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_115 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_117 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_119 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_120 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_120 == 3'b000)) begin
-        _zz_121 = execute_BranchPlugin_eq;
-    end else if((_zz_120 == 3'b001)) begin
-        _zz_121 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_120 & 3'b101) == 3'b101))) begin
-        _zz_121 = (! execute_SRC_LESS);
-    end else begin
-        _zz_121 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_122 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_122 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_122 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_122 = _zz_121;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_123 = _zz_293[11];
-  always @ (*) begin
-    _zz_124[19] = _zz_123;
-    _zz_124[18] = _zz_123;
-    _zz_124[17] = _zz_123;
-    _zz_124[16] = _zz_123;
-    _zz_124[15] = _zz_123;
-    _zz_124[14] = _zz_123;
-    _zz_124[13] = _zz_123;
-    _zz_124[12] = _zz_123;
-    _zz_124[11] = _zz_123;
-    _zz_124[10] = _zz_123;
-    _zz_124[9] = _zz_123;
-    _zz_124[8] = _zz_123;
-    _zz_124[7] = _zz_123;
-    _zz_124[6] = _zz_123;
-    _zz_124[5] = _zz_123;
-    _zz_124[4] = _zz_123;
-    _zz_124[3] = _zz_123;
-    _zz_124[2] = _zz_123;
-    _zz_124[1] = _zz_123;
-    _zz_124[0] = _zz_123;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_125 = _zz_294[19];
-  always @ (*) begin
-    _zz_126[10] = _zz_125;
-    _zz_126[9] = _zz_125;
-    _zz_126[8] = _zz_125;
-    _zz_126[7] = _zz_125;
-    _zz_126[6] = _zz_125;
-    _zz_126[5] = _zz_125;
-    _zz_126[4] = _zz_125;
-    _zz_126[3] = _zz_125;
-    _zz_126[2] = _zz_125;
-    _zz_126[1] = _zz_125;
-    _zz_126[0] = _zz_125;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_127 = _zz_295[11];
-  always @ (*) begin
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_129 = (_zz_296[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_129 = _zz_297[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_129 = _zz_298[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -3882,80 +4046,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_130 = _zz_299[11];
-  always @ (*) begin
-    _zz_131[19] = _zz_130;
-    _zz_131[18] = _zz_130;
-    _zz_131[17] = _zz_130;
-    _zz_131[16] = _zz_130;
-    _zz_131[15] = _zz_130;
-    _zz_131[14] = _zz_130;
-    _zz_131[13] = _zz_130;
-    _zz_131[12] = _zz_130;
-    _zz_131[11] = _zz_130;
-    _zz_131[10] = _zz_130;
-    _zz_131[9] = _zz_130;
-    _zz_131[8] = _zz_130;
-    _zz_131[7] = _zz_130;
-    _zz_131[6] = _zz_130;
-    _zz_131[5] = _zz_130;
-    _zz_131[4] = _zz_130;
-    _zz_131[3] = _zz_130;
-    _zz_131[2] = _zz_130;
-    _zz_131[1] = _zz_130;
-    _zz_131[0] = _zz_130;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_131,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133,{{{_zz_513,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135,{{{_zz_514,_zz_515},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_302};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_132 = _zz_300[19];
-  always @ (*) begin
-    _zz_133[10] = _zz_132;
-    _zz_133[9] = _zz_132;
-    _zz_133[8] = _zz_132;
-    _zz_133[7] = _zz_132;
-    _zz_133[6] = _zz_132;
-    _zz_133[5] = _zz_132;
-    _zz_133[4] = _zz_132;
-    _zz_133[3] = _zz_132;
-    _zz_133[2] = _zz_132;
-    _zz_133[1] = _zz_132;
-    _zz_133[0] = _zz_132;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_134 = _zz_301[11];
-  always @ (*) begin
-    _zz_135[18] = _zz_134;
-    _zz_135[17] = _zz_134;
-    _zz_135[16] = _zz_134;
-    _zz_135[15] = _zz_134;
-    _zz_135[14] = _zz_134;
-    _zz_135[13] = _zz_134;
-    _zz_135[12] = _zz_134;
-    _zz_135[11] = _zz_134;
-    _zz_135[10] = _zz_134;
-    _zz_135[9] = _zz_134;
-    _zz_135[8] = _zz_134;
-    _zz_135[7] = _zz_134;
-    _zz_135[6] = _zz_134;
-    _zz_135[5] = _zz_134;
-    _zz_135[4] = _zz_134;
-    _zz_135[3] = _zz_134;
-    _zz_135[2] = _zz_134;
-    _zz_135[1] = _zz_134;
-    _zz_135[0] = _zz_134;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -3965,95 +4129,109 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_136 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_137 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_138 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_139 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_140 = _zz_303[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_209)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4064,8 +4242,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4075,77 +4253,84 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_223)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_224)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_224)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4158,39 +4343,48 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_223)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_223)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_236)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_225)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4203,8 +4397,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_225)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4223,58 +4417,69 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_305) + $signed(_zz_306));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_204)begin
-      if(_zz_226)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_227)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_310);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_141 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_311);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_312 : _zz_313);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_314[31:0];
-  assign _zz_142 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_143 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_144 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_145[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_145[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_147 = (_zz_146 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_147 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_228)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -4284,9 +4489,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_148))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4295,12 +4500,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_228)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -4311,35 +4517,110 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4360,9 +4641,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_149)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -4371,140 +4658,155 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_150[12 : 0] = 13'h1000;
-      _zz_150[25 : 20] = 6'h20;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_151[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_151[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_151[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_152[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_152[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_152[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_153[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_153[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_153[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_154[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_155[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_155[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_156 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_156[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_157 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_157[31 : 0] = _zz_146;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_158 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_158[31 : 0] = _zz_147;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = ((((_zz_150 | _zz_151) | (_zz_152 | _zz_153)) | ((_zz_154 | _zz_155) | (_zz_156 | _zz_157))) | _zz_158);
-  assign iBusWishbone_ADR = {_zz_330,_zz_159};
-  assign iBusWishbone_CTI = ((_zz_159 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | _zz_CsrPlugin_csrMapping_readDataInit_10);
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_229)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_229)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_160;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_166 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_162 = dBus_cmd_valid;
-  assign _zz_164 = dBus_cmd_payload_wr;
-  assign _zz_165 = (_zz_161 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_163 && (_zz_164 || _zz_165));
-  assign dBusWishbone_ADR = ((_zz_166 ? {{dBus_cmd_payload_address[31 : 5],_zz_161},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_166 ? (_zz_165 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_164 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_164;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_163 = (_zz_162 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_162;
-  assign dBusWishbone_STB = _zz_162;
-  assign dBus_rsp_valid = _zz_167;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65 <= 1'b0;
-      _zz_67 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99 <= 1'b1;
-      _zz_111 <= 1'b0;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -4522,159 +4824,159 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_146 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_149 <= 3'b000;
-      _zz_159 <= 3'b000;
-      _zz_160 <= 1'b0;
-      _zz_161 <= 3'b000;
-      _zz_167 <= 1'b0;
+      switch_Fetcher_l362 <= 3'b000;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_63)begin
-        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_230)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99 <= 1'b0;
-      _zz_111 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_231)begin
-        if(_zz_232)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_233)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_234)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_212)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4685,8 +4987,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_213)begin
-        case(_zz_215)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4696,158 +4998,158 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_138,{_zz_137,_zz_136}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_149)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_149 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_149 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_149 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_149 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_149 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_324[0];
-          CsrPlugin_mstatus_MIE <= _zz_325[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_327[0];
-          CsrPlugin_mie_MTIE <= _zz_328[0];
-          CsrPlugin_mie_MSIE <= _zz_329[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_146 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_229)begin
-        if(iBusWishbone_ACK)begin
-          _zz_159 <= (_zz_159 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_160 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_162 && _zz_163))begin
-        _zz_161 <= (_zz_161 + 3'b001);
-        if(_zz_165)begin
-          _zz_161 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_167 <= ((_zz_162 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_230)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_112 <= _zz_40[11 : 7];
-    _zz_113 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_209)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_231)begin
-      if(_zz_232)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_233)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_234)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_212)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -4855,317 +5157,328 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_204)begin
-      if(_zz_226)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_315[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_227)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_144 ? (~ _zz_145) : _zz_145) + _zz_321);
-      memory_DivPlugin_rs2 <= ((_zz_143 ? (~ execute_RS2) : execute_RS2) + _zz_323);
-      memory_DivPlugin_div_needRevert <= ((_zz_144 ^ (_zz_143 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_50) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_51) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_52) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_53) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_326[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_148 <= debug_bus_cmd_payload_address[2];
-    if(_zz_210)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_228)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -5173,14 +5486,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_210)begin
-        if(_zz_211)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_214)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -5193,9 +5506,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -5217,6 +5529,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5232,9 +5545,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5242,7 +5556,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5251,24 +5565,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5293,40 +5598,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5336,23 +5649,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5360,10 +5683,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5375,59 +5706,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -5442,274 +5768,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -5717,89 +6062,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -5807,12 +6136,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -5823,20 +6152,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -5844,45 +6193,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -5893,46 +6244,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -5940,50 +6282,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6030,18 +6373,14 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
+  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [21:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [21:0]   _zz_17;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6050,8 +6389,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6065,22 +6409,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -6090,82 +6437,86 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
+  wire                when_Fetcher_l398;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_13 = (! lineLoader_flushCounter[7]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6181,30 +6532,36 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6212,51 +6569,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_14)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -6267,14 +6624,14 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
+    if(when_Fetcher_l398) begin
+      io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Full.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Full.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -74,37 +74,37 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_179;
-  wire                _zz_180;
-  wire                _zz_181;
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  reg                 _zz_187;
-  wire                _zz_188;
-  wire       [31:0]   _zz_189;
-  wire                _zz_190;
-  wire       [31:0]   _zz_191;
-  reg                 _zz_192;
-  wire                _zz_193;
-  wire                _zz_194;
-  wire       [31:0]   _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire       [3:0]    _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  reg        [31:0]   _zz_207;
-  reg        [31:0]   _zz_208;
-  reg        [31:0]   _zz_209;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -127,6 +127,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -135,330 +136,274 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire                _zz_212;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire       [1:0]    _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire                _zz_228;
-  wire                _zz_229;
-  wire                _zz_230;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire       [1:0]    _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  wire                _zz_240;
-  wire                _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire       [1:0]    _zz_244;
-  wire                _zz_245;
-  wire       [1:0]    _zz_246;
-  wire       [51:0]   _zz_247;
-  wire       [51:0]   _zz_248;
-  wire       [51:0]   _zz_249;
-  wire       [32:0]   _zz_250;
-  wire       [51:0]   _zz_251;
-  wire       [49:0]   _zz_252;
-  wire       [51:0]   _zz_253;
-  wire       [49:0]   _zz_254;
-  wire       [51:0]   _zz_255;
-  wire       [32:0]   _zz_256;
-  wire       [31:0]   _zz_257;
-  wire       [32:0]   _zz_258;
-  wire       [0:0]    _zz_259;
-  wire       [0:0]    _zz_260;
-  wire       [0:0]    _zz_261;
-  wire       [0:0]    _zz_262;
-  wire       [0:0]    _zz_263;
-  wire       [0:0]    _zz_264;
-  wire       [0:0]    _zz_265;
-  wire       [0:0]    _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [0:0]    _zz_268;
-  wire       [0:0]    _zz_269;
-  wire       [0:0]    _zz_270;
-  wire       [0:0]    _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [0:0]    _zz_273;
-  wire       [0:0]    _zz_274;
-  wire       [0:0]    _zz_275;
-  wire       [3:0]    _zz_276;
-  wire       [2:0]    _zz_277;
-  wire       [31:0]   _zz_278;
-  wire       [11:0]   _zz_279;
-  wire       [31:0]   _zz_280;
-  wire       [19:0]   _zz_281;
-  wire       [11:0]   _zz_282;
-  wire       [31:0]   _zz_283;
-  wire       [31:0]   _zz_284;
-  wire       [19:0]   _zz_285;
-  wire       [11:0]   _zz_286;
-  wire       [2:0]    _zz_287;
-  wire       [2:0]    _zz_288;
-  wire       [0:0]    _zz_289;
-  wire       [2:0]    _zz_290;
-  wire       [4:0]    _zz_291;
-  wire       [11:0]   _zz_292;
-  wire       [11:0]   _zz_293;
-  wire       [31:0]   _zz_294;
-  wire       [31:0]   _zz_295;
-  wire       [31:0]   _zz_296;
-  wire       [31:0]   _zz_297;
-  wire       [31:0]   _zz_298;
-  wire       [31:0]   _zz_299;
-  wire       [31:0]   _zz_300;
-  wire       [11:0]   _zz_301;
-  wire       [19:0]   _zz_302;
-  wire       [11:0]   _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [31:0]   _zz_306;
-  wire       [11:0]   _zz_307;
-  wire       [19:0]   _zz_308;
-  wire       [11:0]   _zz_309;
-  wire       [2:0]    _zz_310;
-  wire       [1:0]    _zz_311;
-  wire       [1:0]    _zz_312;
-  wire       [65:0]   _zz_313;
-  wire       [65:0]   _zz_314;
-  wire       [31:0]   _zz_315;
-  wire       [31:0]   _zz_316;
-  wire       [0:0]    _zz_317;
-  wire       [5:0]    _zz_318;
-  wire       [32:0]   _zz_319;
-  wire       [31:0]   _zz_320;
-  wire       [31:0]   _zz_321;
-  wire       [32:0]   _zz_322;
-  wire       [32:0]   _zz_323;
-  wire       [32:0]   _zz_324;
-  wire       [32:0]   _zz_325;
-  wire       [0:0]    _zz_326;
-  wire       [32:0]   _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [32:0]   _zz_329;
-  wire       [0:0]    _zz_330;
-  wire       [31:0]   _zz_331;
-  wire       [0:0]    _zz_332;
-  wire       [0:0]    _zz_333;
-  wire       [0:0]    _zz_334;
-  wire       [0:0]    _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [0:0]    _zz_337;
-  wire       [0:0]    _zz_338;
-  wire       [26:0]   _zz_339;
-  wire                _zz_340;
-  wire                _zz_341;
-  wire       [1:0]    _zz_342;
-  wire       [31:0]   _zz_343;
-  wire       [31:0]   _zz_344;
-  wire       [31:0]   _zz_345;
-  wire                _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [13:0]   _zz_348;
-  wire       [31:0]   _zz_349;
-  wire       [31:0]   _zz_350;
-  wire       [31:0]   _zz_351;
-  wire                _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [7:0]    _zz_354;
-  wire       [31:0]   _zz_355;
-  wire       [31:0]   _zz_356;
-  wire       [31:0]   _zz_357;
-  wire                _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [1:0]    _zz_360;
-  wire                _zz_361;
-  wire                _zz_362;
-  wire                _zz_363;
-  wire       [31:0]   _zz_364;
-  wire       [31:0]   _zz_365;
-  wire                _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [0:0]    _zz_368;
-  wire                _zz_369;
-  wire       [0:0]    _zz_370;
-  wire       [24:0]   _zz_371;
-  wire       [31:0]   _zz_372;
-  wire                _zz_373;
-  wire                _zz_374;
-  wire       [0:0]    _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [0:0]    _zz_377;
-  wire       [0:0]    _zz_378;
-  wire                _zz_379;
-  wire       [0:0]    _zz_380;
-  wire       [20:0]   _zz_381;
-  wire       [31:0]   _zz_382;
-  wire       [31:0]   _zz_383;
-  wire                _zz_384;
-  wire                _zz_385;
-  wire       [0:0]    _zz_386;
-  wire       [1:0]    _zz_387;
-  wire       [0:0]    _zz_388;
-  wire       [0:0]    _zz_389;
-  wire                _zz_390;
-  wire       [0:0]    _zz_391;
-  wire       [17:0]   _zz_392;
-  wire       [31:0]   _zz_393;
-  wire       [31:0]   _zz_394;
-  wire       [31:0]   _zz_395;
-  wire       [31:0]   _zz_396;
-  wire       [31:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [31:0]   _zz_399;
-  wire       [31:0]   _zz_400;
-  wire                _zz_401;
-  wire       [1:0]    _zz_402;
-  wire       [1:0]    _zz_403;
-  wire                _zz_404;
-  wire       [0:0]    _zz_405;
-  wire       [14:0]   _zz_406;
-  wire       [31:0]   _zz_407;
-  wire       [31:0]   _zz_408;
-  wire       [31:0]   _zz_409;
-  wire       [31:0]   _zz_410;
-  wire       [31:0]   _zz_411;
-  wire       [31:0]   _zz_412;
-  wire       [0:0]    _zz_413;
-  wire       [0:0]    _zz_414;
-  wire       [4:0]    _zz_415;
-  wire       [4:0]    _zz_416;
-  wire                _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [11:0]   _zz_419;
-  wire       [31:0]   _zz_420;
-  wire       [31:0]   _zz_421;
-  wire       [31:0]   _zz_422;
-  wire       [31:0]   _zz_423;
-  wire                _zz_424;
-  wire       [0:0]    _zz_425;
-  wire       [1:0]    _zz_426;
-  wire       [31:0]   _zz_427;
-  wire       [31:0]   _zz_428;
-  wire       [0:0]    _zz_429;
-  wire       [3:0]    _zz_430;
-  wire       [4:0]    _zz_431;
-  wire       [4:0]    _zz_432;
-  wire                _zz_433;
-  wire       [0:0]    _zz_434;
-  wire       [8:0]    _zz_435;
-  wire       [31:0]   _zz_436;
-  wire       [31:0]   _zz_437;
-  wire       [31:0]   _zz_438;
-  wire                _zz_439;
-  wire                _zz_440;
-  wire       [31:0]   _zz_441;
-  wire       [31:0]   _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [1:0]    _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [2:0]    _zz_446;
-  wire       [0:0]    _zz_447;
-  wire       [4:0]    _zz_448;
-  wire       [1:0]    _zz_449;
-  wire       [1:0]    _zz_450;
-  wire                _zz_451;
-  wire       [0:0]    _zz_452;
-  wire       [6:0]    _zz_453;
-  wire       [31:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire                _zz_458;
-  wire                _zz_459;
-  wire       [31:0]   _zz_460;
-  wire       [31:0]   _zz_461;
-  wire                _zz_462;
-  wire       [0:0]    _zz_463;
-  wire       [0:0]    _zz_464;
-  wire                _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [2:0]    _zz_467;
-  wire                _zz_468;
-  wire       [0:0]    _zz_469;
-  wire       [0:0]    _zz_470;
-  wire       [0:0]    _zz_471;
-  wire       [0:0]    _zz_472;
-  wire                _zz_473;
-  wire       [0:0]    _zz_474;
-  wire       [4:0]    _zz_475;
-  wire       [31:0]   _zz_476;
-  wire       [31:0]   _zz_477;
-  wire       [31:0]   _zz_478;
-  wire       [31:0]   _zz_479;
-  wire       [31:0]   _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire       [31:0]   _zz_483;
-  wire       [31:0]   _zz_484;
-  wire       [31:0]   _zz_485;
-  wire                _zz_486;
-  wire       [0:0]    _zz_487;
-  wire       [0:0]    _zz_488;
-  wire       [31:0]   _zz_489;
-  wire       [31:0]   _zz_490;
-  wire       [31:0]   _zz_491;
-  wire       [31:0]   _zz_492;
-  wire       [31:0]   _zz_493;
-  wire                _zz_494;
-  wire       [3:0]    _zz_495;
-  wire       [3:0]    _zz_496;
-  wire                _zz_497;
-  wire       [0:0]    _zz_498;
-  wire       [2:0]    _zz_499;
-  wire       [31:0]   _zz_500;
-  wire       [31:0]   _zz_501;
-  wire       [31:0]   _zz_502;
-  wire       [31:0]   _zz_503;
-  wire       [31:0]   _zz_504;
-  wire       [31:0]   _zz_505;
-  wire                _zz_506;
-  wire       [0:0]    _zz_507;
-  wire       [1:0]    _zz_508;
-  wire                _zz_509;
-  wire       [2:0]    _zz_510;
-  wire       [2:0]    _zz_511;
-  wire                _zz_512;
-  wire       [0:0]    _zz_513;
-  wire       [0:0]    _zz_514;
-  wire       [31:0]   _zz_515;
-  wire       [31:0]   _zz_516;
-  wire       [31:0]   _zz_517;
-  wire       [31:0]   _zz_518;
-  wire       [31:0]   _zz_519;
-  wire       [31:0]   _zz_520;
-  wire       [31:0]   _zz_521;
-  wire                _zz_522;
-  wire                _zz_523;
-  wire                _zz_524;
-  wire       [0:0]    _zz_525;
-  wire       [0:0]    _zz_526;
-  wire                _zz_527;
-  wire                _zz_528;
-  wire                _zz_529;
-  wire                _zz_530;
-  wire       [31:0]   _zz_531;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -469,8 +414,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
@@ -481,27 +426,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -510,17 +455,17 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -541,11 +486,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -553,10 +498,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -566,45 +511,45 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -623,10 +568,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -713,7 +658,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -747,6 +692,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -764,28 +714,34 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_54;
-  wire       [3:0]    _zz_55;
-  wire                _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -808,16 +764,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_62;
-  wire                _zz_63;
-  reg                 _zz_64;
-  wire                _zz_65;
-  reg                 _zz_66;
-  reg        [31:0]   _zz_67;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -825,22 +783,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_68;
-  reg        [18:0]   _zz_69;
-  wire                _zz_70;
-  reg        [10:0]   _zz_71;
-  wire                _zz_72;
-  reg        [18:0]   _zz_73;
-  reg                 _zz_74;
-  wire                _zz_75;
-  reg        [10:0]   _zz_76;
-  wire                _zz_77;
-  reg        [18:0]   _zz_78;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -848,7 +813,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_79;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -856,6 +821,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -863,7 +833,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -871,8 +841,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -880,38 +851,52 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_80;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_81;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_82;
-  reg        [31:0]   _zz_83;
-  wire                _zz_84;
-  reg        [31:0]   _zz_85;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [31:0]   _zz_86;
-  wire                _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
-  wire                _zz_90;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_91;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_92;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_93;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_94;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_96;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_97;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -919,52 +904,70 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_98;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_99;
-  reg        [31:0]   _zz_100;
-  wire                _zz_101;
-  reg        [19:0]   _zz_102;
-  wire                _zz_103;
-  reg        [19:0]   _zz_104;
-  reg        [31:0]   _zz_105;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_107;
-  reg                 _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
-  reg        [4:0]    _zz_111;
-  reg        [31:0]   _zz_112;
-  wire                _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire                _zz_118;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_119;
-  reg                 _zz_120;
-  reg                 _zz_121;
-  wire                _zz_122;
-  reg        [19:0]   _zz_123;
-  wire                _zz_124;
-  reg        [10:0]   _zz_125;
-  wire                _zz_126;
-  reg        [18:0]   _zz_127;
-  reg                 _zz_128;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_129;
-  reg        [19:0]   _zz_130;
-  wire                _zz_131;
-  reg        [10:0]   _zz_132;
-  wire                _zz_133;
-  reg        [18:0]   _zz_134;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -986,9 +989,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1001,40 +1004,67 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_138;
-  wire                _zz_139;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1042,6 +1072,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1054,214 +1086,317 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_140;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  reg        [32:0]   _zz_144;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_145;
-  wire       [31:0]   _zz_146;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_49;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_50;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_51;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_54;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_55;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_57;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_147;
-  reg        [31:0]   _zz_148;
-  reg        [31:0]   _zz_149;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [31:0]   _zz_156;
-  reg        [31:0]   _zz_157;
-  reg        [31:0]   _zz_158;
-  reg        [31:0]   _zz_159;
-  reg        [31:0]   _zz_160;
-  reg        [31:0]   _zz_161;
-  reg        [31:0]   _zz_162;
-  reg        [31:0]   _zz_163;
-  reg        [31:0]   _zz_164;
-  reg        [31:0]   _zz_165;
-  reg        [31:0]   _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [2:0]    _zz_170;
-  reg                 _zz_171;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_172;
-  wire                _zz_173;
-  wire                _zz_174;
-  wire                _zz_175;
-  wire                _zz_176;
-  wire                _zz_177;
-  reg                 _zz_178;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_51_string;
-  reg [95:0] _zz_91_string;
-  reg [63:0] _zz_92_string;
-  reg [23:0] _zz_93_string;
-  reg [39:0] _zz_94_string;
-  reg [71:0] _zz_95_string;
-  reg [31:0] _zz_96_string;
-  reg [39:0] _zz_97_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1270,501 +1405,469 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_210 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_211 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_212 = 1'b1;
-  assign _zz_213 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_214 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_215 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_216 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_217 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_218 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_219 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_220 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_221 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_222 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_223 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_224 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_225 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_226 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_227 = (1'b0 || (! 1'b1));
-  assign _zz_228 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_229 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_230 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_231 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_232 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_233 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_234 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_235 = execute_INSTRUCTION[13 : 12];
-  assign _zz_236 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_237 = (! memory_arbitration_isStuck);
-  assign _zz_238 = (iBus_cmd_valid || (_zz_170 != 3'b000));
-  assign _zz_239 = (_zz_206 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_240 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_241 = ((_zz_135 && 1'b1) && (! 1'b0));
-  assign _zz_242 = ((_zz_136 && 1'b1) && (! 1'b0));
-  assign _zz_243 = ((_zz_137 && 1'b1) && (! 1'b0));
-  assign _zz_244 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_245 = execute_INSTRUCTION[13];
-  assign _zz_246 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_247 = ($signed(_zz_248) + $signed(_zz_253));
-  assign _zz_248 = ($signed(_zz_249) + $signed(_zz_251));
-  assign _zz_249 = 52'h0;
-  assign _zz_250 = {1'b0,memory_MUL_LL};
-  assign _zz_251 = {{19{_zz_250[32]}}, _zz_250};
-  assign _zz_252 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_253 = {{2{_zz_252[49]}}, _zz_252};
-  assign _zz_254 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_255 = {{2{_zz_254[49]}}, _zz_254};
-  assign _zz_256 = ($signed(_zz_258) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_257 = _zz_256[31 : 0];
-  assign _zz_258 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_259 = _zz_86[31 : 31];
-  assign _zz_260 = _zz_86[30 : 30];
-  assign _zz_261 = _zz_86[29 : 29];
-  assign _zz_262 = _zz_86[28 : 28];
-  assign _zz_263 = _zz_86[25 : 25];
-  assign _zz_264 = _zz_86[17 : 17];
-  assign _zz_265 = _zz_86[16 : 16];
-  assign _zz_266 = _zz_86[13 : 13];
-  assign _zz_267 = _zz_86[12 : 12];
-  assign _zz_268 = _zz_86[11 : 11];
-  assign _zz_269 = _zz_86[15 : 15];
-  assign _zz_270 = _zz_86[5 : 5];
-  assign _zz_271 = _zz_86[3 : 3];
-  assign _zz_272 = _zz_86[20 : 20];
-  assign _zz_273 = _zz_86[10 : 10];
-  assign _zz_274 = _zz_86[4 : 4];
-  assign _zz_275 = _zz_86[0 : 0];
-  assign _zz_276 = (_zz_54 - 4'b0001);
-  assign _zz_277 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_278 = {29'd0, _zz_277};
-  assign _zz_279 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_280 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_281 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_282 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_283 = {{_zz_71,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_284 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_285 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_286 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_287 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_288 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_289 = execute_SRC_LESS;
-  assign _zz_290 = 3'b100;
-  assign _zz_291 = execute_INSTRUCTION[19 : 15];
-  assign _zz_292 = execute_INSTRUCTION[31 : 20];
-  assign _zz_293 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_294 = ($signed(_zz_295) + $signed(_zz_298));
-  assign _zz_295 = ($signed(_zz_296) + $signed(_zz_297));
-  assign _zz_296 = execute_SRC1;
-  assign _zz_297 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_298 = (execute_SRC_USE_SUB_LESS ? _zz_299 : _zz_300);
-  assign _zz_299 = 32'h00000001;
-  assign _zz_300 = 32'h0;
-  assign _zz_301 = execute_INSTRUCTION[31 : 20];
-  assign _zz_302 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_303 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_304 = {_zz_123,execute_INSTRUCTION[31 : 20]};
-  assign _zz_305 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_306 = {{_zz_127,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_307 = execute_INSTRUCTION[31 : 20];
-  assign _zz_308 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_309 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_310 = 3'b100;
-  assign _zz_311 = (_zz_138 & (~ _zz_312));
-  assign _zz_312 = (_zz_138 - 2'b01);
-  assign _zz_313 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_314 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_315 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_316 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_317 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_318 = {5'd0, _zz_317};
-  assign _zz_319 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_320 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_321 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_322 = {_zz_140,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_323 = _zz_324;
-  assign _zz_324 = _zz_325;
-  assign _zz_325 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_327);
-  assign _zz_326 = memory_DivPlugin_div_needRevert;
-  assign _zz_327 = {32'd0, _zz_326};
-  assign _zz_328 = _zz_143;
-  assign _zz_329 = {32'd0, _zz_328};
-  assign _zz_330 = _zz_142;
-  assign _zz_331 = {31'd0, _zz_330};
-  assign _zz_332 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_333 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_334 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_335 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_336 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_337 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_338 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_339 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_340 = 1'b1;
-  assign _zz_341 = 1'b1;
-  assign _zz_342 = {_zz_58,_zz_57};
-  assign _zz_343 = 32'h0000107f;
-  assign _zz_344 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_345 = 32'h00002073;
-  assign _zz_346 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_347 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_348 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_349) == 32'h00000003),{(_zz_350 == _zz_351),{_zz_352,{_zz_353,_zz_354}}}}}};
-  assign _zz_349 = 32'h0000505f;
-  assign _zz_350 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_351 = 32'h00000063;
-  assign _zz_352 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_353 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_354 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_355) == 32'h00001013),{(_zz_356 == _zz_357),{_zz_358,{_zz_359,_zz_360}}}}}};
-  assign _zz_355 = 32'hfc00307f;
-  assign _zz_356 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_357 = 32'h00005033;
-  assign _zz_358 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_359 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_360 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_361 = decode_INSTRUCTION[31];
-  assign _zz_362 = decode_INSTRUCTION[31];
-  assign _zz_363 = decode_INSTRUCTION[7];
-  assign _zz_364 = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_365 = 32'h02004020;
-  assign _zz_366 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_367 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
-  assign _zz_368 = 1'b0;
-  assign _zz_369 = (((decode_INSTRUCTION & _zz_372) == 32'h00000050) != 1'b0);
-  assign _zz_370 = ({_zz_373,_zz_374} != 2'b00);
-  assign _zz_371 = {({_zz_375,_zz_376} != 2'b00),{(_zz_377 != _zz_378),{_zz_379,{_zz_380,_zz_381}}}};
-  assign _zz_372 = 32'h00403050;
-  assign _zz_373 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_374 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_375 = _zz_89;
-  assign _zz_376 = ((decode_INSTRUCTION & _zz_382) == 32'h00000004);
-  assign _zz_377 = ((decode_INSTRUCTION & _zz_383) == 32'h00000040);
-  assign _zz_378 = 1'b0;
-  assign _zz_379 = ({_zz_384,_zz_385} != 2'b00);
-  assign _zz_380 = ({_zz_386,_zz_387} != 3'b000);
-  assign _zz_381 = {(_zz_388 != _zz_389),{_zz_390,{_zz_391,_zz_392}}};
-  assign _zz_382 = 32'h0000001c;
-  assign _zz_383 = 32'h00000058;
-  assign _zz_384 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz_385 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz_386 = ((decode_INSTRUCTION & _zz_393) == 32'h40001010);
-  assign _zz_387 = {(_zz_394 == _zz_395),(_zz_396 == _zz_397)};
-  assign _zz_388 = ((decode_INSTRUCTION & _zz_398) == 32'h00000024);
-  assign _zz_389 = 1'b0;
-  assign _zz_390 = ((_zz_399 == _zz_400) != 1'b0);
-  assign _zz_391 = (_zz_401 != 1'b0);
-  assign _zz_392 = {(_zz_402 != _zz_403),{_zz_404,{_zz_405,_zz_406}}};
-  assign _zz_393 = 32'h40003054;
-  assign _zz_394 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_395 = 32'h00001010;
-  assign _zz_396 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_397 = 32'h00001010;
-  assign _zz_398 = 32'h00000064;
-  assign _zz_399 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_400 = 32'h00001000;
-  assign _zz_401 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_402 = {(_zz_407 == _zz_408),(_zz_409 == _zz_410)};
-  assign _zz_403 = 2'b00;
-  assign _zz_404 = ((_zz_411 == _zz_412) != 1'b0);
-  assign _zz_405 = ({_zz_413,_zz_414} != 2'b00);
-  assign _zz_406 = {(_zz_415 != _zz_416),{_zz_417,{_zz_418,_zz_419}}};
-  assign _zz_407 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_408 = 32'h00002000;
-  assign _zz_409 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_410 = 32'h00001000;
-  assign _zz_411 = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_412 = 32'h00004008;
-  assign _zz_413 = ((decode_INSTRUCTION & _zz_420) == 32'h00000020);
-  assign _zz_414 = ((decode_INSTRUCTION & _zz_421) == 32'h00000020);
-  assign _zz_415 = {(_zz_422 == _zz_423),{_zz_424,{_zz_425,_zz_426}}};
-  assign _zz_416 = 5'h0;
-  assign _zz_417 = ((_zz_427 == _zz_428) != 1'b0);
-  assign _zz_418 = ({_zz_429,_zz_430} != 5'h0);
-  assign _zz_419 = {(_zz_431 != _zz_432),{_zz_433,{_zz_434,_zz_435}}};
-  assign _zz_420 = 32'h00000034;
-  assign _zz_421 = 32'h00000064;
-  assign _zz_422 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_423 = 32'h00002040;
-  assign _zz_424 = ((decode_INSTRUCTION & _zz_436) == 32'h00001040);
-  assign _zz_425 = (_zz_437 == _zz_438);
-  assign _zz_426 = {_zz_439,_zz_440};
-  assign _zz_427 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_428 = 32'h00000020;
-  assign _zz_429 = (_zz_441 == _zz_442);
-  assign _zz_430 = {_zz_88,{_zz_443,_zz_444}};
-  assign _zz_431 = {_zz_88,{_zz_445,_zz_446}};
-  assign _zz_432 = 5'h0;
-  assign _zz_433 = ({_zz_447,_zz_448} != 6'h0);
-  assign _zz_434 = (_zz_449 != _zz_450);
-  assign _zz_435 = {_zz_451,{_zz_452,_zz_453}};
-  assign _zz_436 = 32'h00001040;
-  assign _zz_437 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_438 = 32'h00000040;
-  assign _zz_439 = ((decode_INSTRUCTION & _zz_454) == 32'h00000040);
-  assign _zz_440 = ((decode_INSTRUCTION & _zz_455) == 32'h0);
-  assign _zz_441 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_442 = 32'h00000040;
-  assign _zz_443 = (_zz_456 == _zz_457);
-  assign _zz_444 = {_zz_458,_zz_459};
-  assign _zz_445 = (_zz_460 == _zz_461);
-  assign _zz_446 = {_zz_462,{_zz_463,_zz_464}};
-  assign _zz_447 = _zz_89;
-  assign _zz_448 = {_zz_465,{_zz_466,_zz_467}};
-  assign _zz_449 = {_zz_88,_zz_468};
-  assign _zz_450 = 2'b00;
-  assign _zz_451 = ({_zz_469,_zz_470} != 2'b00);
-  assign _zz_452 = (_zz_471 != _zz_472);
-  assign _zz_453 = {_zz_473,{_zz_474,_zz_475}};
-  assign _zz_454 = 32'h00400040;
-  assign _zz_455 = 32'h00000038;
-  assign _zz_456 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_457 = 32'h00004020;
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_476) == 32'h00000010);
-  assign _zz_459 = ((decode_INSTRUCTION & _zz_477) == 32'h00000020);
-  assign _zz_460 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_461 = 32'h00002010;
-  assign _zz_462 = ((decode_INSTRUCTION & _zz_478) == 32'h00000010);
-  assign _zz_463 = (_zz_479 == _zz_480);
-  assign _zz_464 = (_zz_481 == _zz_482);
-  assign _zz_465 = ((decode_INSTRUCTION & _zz_483) == 32'h00001010);
-  assign _zz_466 = (_zz_484 == _zz_485);
-  assign _zz_467 = {_zz_486,{_zz_487,_zz_488}};
-  assign _zz_468 = ((decode_INSTRUCTION & _zz_489) == 32'h00000020);
-  assign _zz_469 = _zz_88;
-  assign _zz_470 = (_zz_490 == _zz_491);
-  assign _zz_471 = (_zz_492 == _zz_493);
-  assign _zz_472 = 1'b0;
-  assign _zz_473 = (_zz_494 != 1'b0);
-  assign _zz_474 = (_zz_495 != _zz_496);
-  assign _zz_475 = {_zz_497,{_zz_498,_zz_499}};
-  assign _zz_476 = 32'h00000030;
-  assign _zz_477 = 32'h02000020;
-  assign _zz_478 = 32'h00001030;
-  assign _zz_479 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_480 = 32'h00002020;
-  assign _zz_481 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_482 = 32'h00000020;
-  assign _zz_483 = 32'h00001010;
-  assign _zz_484 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_485 = 32'h00002010;
-  assign _zz_486 = ((decode_INSTRUCTION & _zz_500) == 32'h00000010);
-  assign _zz_487 = (_zz_501 == _zz_502);
-  assign _zz_488 = (_zz_503 == _zz_504);
-  assign _zz_489 = 32'h00000070;
-  assign _zz_490 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_491 = 32'h0;
-  assign _zz_492 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_493 = 32'h00004010;
-  assign _zz_494 = ((decode_INSTRUCTION & _zz_505) == 32'h00002010);
-  assign _zz_495 = {_zz_506,{_zz_507,_zz_508}};
-  assign _zz_496 = 4'b0000;
-  assign _zz_497 = (_zz_509 != 1'b0);
-  assign _zz_498 = (_zz_510 != _zz_511);
-  assign _zz_499 = {_zz_512,{_zz_513,_zz_514}};
-  assign _zz_500 = 32'h00000050;
-  assign _zz_501 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_502 = 32'h00000004;
-  assign _zz_503 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_504 = 32'h0;
-  assign _zz_505 = 32'h00006014;
-  assign _zz_506 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz_507 = ((decode_INSTRUCTION & _zz_515) == 32'h0);
-  assign _zz_508 = {(_zz_516 == _zz_517),(_zz_518 == _zz_519)};
-  assign _zz_509 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_510 = {(_zz_520 == _zz_521),{_zz_522,_zz_523}};
-  assign _zz_511 = 3'b000;
-  assign _zz_512 = ({_zz_524,_zz_87} != 2'b00);
-  assign _zz_513 = ({_zz_525,_zz_526} != 2'b00);
-  assign _zz_514 = (_zz_527 != 1'b0);
-  assign _zz_515 = 32'h00000018;
-  assign _zz_516 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_517 = 32'h00002000;
-  assign _zz_518 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_519 = 32'h00001000;
-  assign _zz_520 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_521 = 32'h00000040;
-  assign _zz_522 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_523 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz_524 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_525 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_526 = _zz_87;
-  assign _zz_527 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_528 = execute_INSTRUCTION[31];
-  assign _zz_529 = execute_INSTRUCTION[31];
-  assign _zz_530 = execute_INSTRUCTION[7];
-  assign _zz_531 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_340) begin
-      _zz_207 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_6) == 32'h00000050) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ({_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {({_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_12} != 2'b00),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_16),{_zz__zz_decode_IS_RS2_SIGNED_17,{_zz__zz_decode_IS_RS2_SIGNED_20,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h00403050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_15) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ({_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25),(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (_zz__zz_decode_IS_RS2_SIGNED_36 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(_zz__zz_decode_IS_RS2_SIGNED_38 != _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_52}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40),(_zz__zz_decode_IS_RS2_SIGNED_41 == _zz__zz_decode_IS_RS2_SIGNED_42)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ({_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_50} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = {(_zz__zz_decode_IS_RS2_SIGNED_53 != _zz__zz_decode_IS_RS2_SIGNED_66),{_zz__zz_decode_IS_RS2_SIGNED_67,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_83}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00004008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = {(_zz__zz_decode_IS_RS2_SIGNED_54 == _zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_58,_zz__zz_decode_IS_RS2_SIGNED_61}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = ((_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ({_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_74} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(_zz__zz_decode_IS_RS2_SIGNED_84 != _zz__zz_decode_IS_RS2_SIGNED_97),{_zz__zz_decode_IS_RS2_SIGNED_98,{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_120}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_57) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (_zz__zz_decode_IS_RS2_SIGNED_59 == _zz__zz_decode_IS_RS2_SIGNED_60);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_64};
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (_zz__zz_decode_IS_RS2_SIGNED_72 == _zz__zz_decode_IS_RS2_SIGNED_73);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ({_zz__zz_decode_IS_RS2_SIGNED_99,_zz__zz_decode_IS_RS2_SIGNED_100} != 6'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (_zz__zz_decode_IS_RS2_SIGNED_116 != _zz__zz_decode_IS_RS2_SIGNED_119);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = {_zz__zz_decode_IS_RS2_SIGNED_121,{_zz__zz_decode_IS_RS2_SIGNED_126,_zz__zz_decode_IS_RS2_SIGNED_131}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_81};
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_94}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {_zz__zz_decode_IS_RS2_SIGNED_101,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_117};
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ({_zz__zz_decode_IS_RS2_SIGNED_122,_zz__zz_decode_IS_RS2_SIGNED_123} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (_zz__zz_decode_IS_RS2_SIGNED_127 != _zz__zz_decode_IS_RS2_SIGNED_130);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = {_zz__zz_decode_IS_RS2_SIGNED_132,{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_146}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00400040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000038;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (_zz__zz_decode_IS_RS2_SIGNED_92 == _zz__zz_decode_IS_RS2_SIGNED_93);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (_zz__zz_decode_IS_RS2_SIGNED_95 == _zz__zz_decode_IS_RS2_SIGNED_96);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_112}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (_zz__zz_decode_IS_RS2_SIGNED_124 == _zz__zz_decode_IS_RS2_SIGNED_125);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (_zz__zz_decode_IS_RS2_SIGNED_128 == _zz__zz_decode_IS_RS2_SIGNED_129);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (_zz__zz_decode_IS_RS2_SIGNED_133 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (_zz__zz_decode_IS_RS2_SIGNED_136 != _zz__zz_decode_IS_RS2_SIGNED_145);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz__zz_decode_IS_RS2_SIGNED_147,{_zz__zz_decode_IS_RS2_SIGNED_149,_zz__zz_decode_IS_RS2_SIGNED_156}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_134) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {_zz__zz_decode_IS_RS2_SIGNED_137,{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_140}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = 4'b0000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (_zz__zz_decode_IS_RS2_SIGNED_148 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = (_zz__zz_decode_IS_RS2_SIGNED_150 != _zz__zz_decode_IS_RS2_SIGNED_155);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = {_zz__zz_decode_IS_RS2_SIGNED_157,{_zz__zz_decode_IS_RS2_SIGNED_159,_zz__zz_decode_IS_RS2_SIGNED_162}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {(_zz__zz_decode_IS_RS2_SIGNED_141 == _zz__zz_decode_IS_RS2_SIGNED_142),(_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {(_zz__zz_decode_IS_RS2_SIGNED_151 == _zz__zz_decode_IS_RS2_SIGNED_152),{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_154}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = ({_zz__zz_decode_IS_RS2_SIGNED_158,_zz_decode_IS_RS2_SIGNED_1} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = ({_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_161} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = (_zz__zz_decode_IS_RS2_SIGNED_163 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000018;
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_341) begin
-      _zz_208 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_179                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_180                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_181                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_182                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_183                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_184                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_185                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_186                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_187                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_188                                            ), //i
-    .io_cpu_execute_address                    (_zz_189[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_81[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_190                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_191[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_192                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_193                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_194                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_195[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_196                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_197                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_198                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_199                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_200                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_201                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_202                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_203                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_204[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_205                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_206                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_342)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_209 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_209 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_209 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_209 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1777,134 +1880,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1917,30 +2020,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1952,27 +2055,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1985,30 +2088,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2021,12 +2124,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2039,12 +2142,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2057,12 +2160,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2075,48 +2178,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2129,12 +2232,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2147,12 +2250,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2164,88 +2267,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2258,73 +2361,73 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_91)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_91_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_91_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_91_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_91_string = "URS1        ";
-      default : _zz_91_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_92_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_92_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_92_string = "BITWISE ";
-      default : _zz_92_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_93_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_93_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_93_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_93_string = "PC ";
-      default : _zz_93_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_94_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_94_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_94_string = "AND_1";
-      default : _zz_94_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_95_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_95_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_95_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_95_string = "SRA_1    ";
-      default : _zz_95_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_96_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_96_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_96_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_96_string = "JALR";
-      default : _zz_96_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_97)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_97_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_97_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_97_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_97_string = "ECALL";
-      default : _zz_97_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2355,28 +2458,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2417,7 +2520,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_247) + $signed(_zz_255));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2425,44 +2528,44 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_257;
-  assign execute_REGFILE_WRITE_DATA = _zz_99;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_189[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_259[0];
-  assign decode_IS_RS1_SIGNED = _zz_260[0];
-  assign decode_IS_DIV = _zz_261[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[30];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_262[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_263[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_264[0];
-  assign decode_MEMORY_MANAGMENT = _zz_265[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_266[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_267[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_268[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -2482,22 +2585,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_121;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_269[0];
-  assign decode_RS1_USE = _zz_270[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_210)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2507,139 +2610,139 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_110)begin
-      if((_zz_111 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_112;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_211)begin
-      if(_zz_212)begin
-        if(_zz_114)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_213)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_214)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_110)begin
-      if((_zz_111 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_112;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_211)begin
-      if(_zz_212)begin
-        if(_zz_113)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_213)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_115)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_214)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_117)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_107;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_215)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_271[0];
-  assign decode_SRC_ADD_ZERO = _zz_272[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_105;
-  assign execute_SRC1 = _zz_100;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_273[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_343) == 32'h00001073),{(_zz_344 == _zz_345),{_zz_346,{_zz_347,_zz_348}}}}}}} != 21'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_246)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_315;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_316;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2651,206 +2754,206 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_274[0];
-  assign decode_FLUSH_ALL = _zz_275[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_216)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_217)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_218)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_219)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_108 || _zz_109)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_220)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_220)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_205 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_221)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_210)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_215)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_222)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_223)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2859,51 +2962,53 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_222)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_223)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_221)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_222)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_223)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_222)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_223)begin
-      case(_zz_224)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2916,59 +3021,65 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_54 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_55 = (_zz_54 & (~ _zz_276));
-  assign _zz_56 = _zz_55[3];
-  assign _zz_57 = (_zz_55[1] || _zz_56);
-  assign _zz_58 = (_zz_55[2] || _zz_56);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_209;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_278);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -2976,265 +3087,280 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_59);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_59);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
-  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_63 = _zz_64;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_65 = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_67;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_68 = _zz_279[11];
-  always @ (*) begin
-    _zz_69[18] = _zz_68;
-    _zz_69[17] = _zz_68;
-    _zz_69[16] = _zz_68;
-    _zz_69[15] = _zz_68;
-    _zz_69[14] = _zz_68;
-    _zz_69[13] = _zz_68;
-    _zz_69[12] = _zz_68;
-    _zz_69[11] = _zz_68;
-    _zz_69[10] = _zz_68;
-    _zz_69[9] = _zz_68;
-    _zz_69[8] = _zz_68;
-    _zz_69[7] = _zz_68;
-    _zz_69[6] = _zz_68;
-    _zz_69[5] = _zz_68;
-    _zz_69[4] = _zz_68;
-    _zz_69[3] = _zz_68;
-    _zz_69[2] = _zz_68;
-    _zz_69[1] = _zz_68;
-    _zz_69[0] = _zz_68;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_280[31]));
-    if(_zz_74)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_70 = _zz_281[19];
-  always @ (*) begin
-    _zz_71[10] = _zz_70;
-    _zz_71[9] = _zz_70;
-    _zz_71[8] = _zz_70;
-    _zz_71[7] = _zz_70;
-    _zz_71[6] = _zz_70;
-    _zz_71[5] = _zz_70;
-    _zz_71[4] = _zz_70;
-    _zz_71[3] = _zz_70;
-    _zz_71[2] = _zz_70;
-    _zz_71[1] = _zz_70;
-    _zz_71[0] = _zz_70;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_72 = _zz_282[11];
-  always @ (*) begin
-    _zz_73[18] = _zz_72;
-    _zz_73[17] = _zz_72;
-    _zz_73[16] = _zz_72;
-    _zz_73[15] = _zz_72;
-    _zz_73[14] = _zz_72;
-    _zz_73[13] = _zz_72;
-    _zz_73[12] = _zz_72;
-    _zz_73[11] = _zz_72;
-    _zz_73[10] = _zz_72;
-    _zz_73[9] = _zz_72;
-    _zz_73[8] = _zz_72;
-    _zz_73[7] = _zz_72;
-    _zz_73[6] = _zz_72;
-    _zz_73[5] = _zz_72;
-    _zz_73[4] = _zz_72;
-    _zz_73[3] = _zz_72;
-    _zz_73[2] = _zz_72;
-    _zz_73[1] = _zz_72;
-    _zz_73[0] = _zz_72;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_74 = _zz_283[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_74 = _zz_284[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_75 = _zz_285[19];
-  always @ (*) begin
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7] = _zz_75;
-    _zz_76[6] = _zz_75;
-    _zz_76[5] = _zz_75;
-    _zz_76[4] = _zz_75;
-    _zz_76[3] = _zz_75;
-    _zz_76[2] = _zz_75;
-    _zz_76[1] = _zz_75;
-    _zz_76[0] = _zz_75;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_77 = _zz_286[11];
-  always @ (*) begin
-    _zz_78[18] = _zz_77;
-    _zz_78[17] = _zz_77;
-    _zz_78[16] = _zz_77;
-    _zz_78[15] = _zz_77;
-    _zz_78[14] = _zz_77;
-    _zz_78[13] = _zz_77;
-    _zz_78[12] = _zz_77;
-    _zz_78[11] = _zz_77;
-    _zz_78[10] = _zz_77;
-    _zz_78[9] = _zz_77;
-    _zz_78[8] = _zz_77;
-    _zz_78[7] = _zz_77;
-    _zz_78[6] = _zz_77;
-    _zz_78[5] = _zz_77;
-    _zz_78[4] = _zz_77;
-    _zz_78[3] = _zz_77;
-    _zz_78[2] = _zz_77;
-    _zz_78[1] = _zz_77;
-    _zz_78[0] = _zz_77;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_76,{{{_zz_361,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_78,{{{_zz_362,_zz_363},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_180 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_181 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_182 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_181;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_184 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_185 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_186 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_219)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_217)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_187 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_217)begin
-      _zz_187 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_218)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_216)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_218)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_216)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_179 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_206 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3242,168 +3368,178 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_188 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_189 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_81 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_81 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_81 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_205 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_190 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_191 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_190;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_191;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_192 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_192 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_193 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_194 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_195 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_225)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_225)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_225)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_287};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_288};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_82 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_83[31] = _zz_82;
-    _zz_83[30] = _zz_82;
-    _zz_83[29] = _zz_82;
-    _zz_83[28] = _zz_82;
-    _zz_83[27] = _zz_82;
-    _zz_83[26] = _zz_82;
-    _zz_83[25] = _zz_82;
-    _zz_83[24] = _zz_82;
-    _zz_83[23] = _zz_82;
-    _zz_83[22] = _zz_82;
-    _zz_83[21] = _zz_82;
-    _zz_83[20] = _zz_82;
-    _zz_83[19] = _zz_82;
-    _zz_83[18] = _zz_82;
-    _zz_83[17] = _zz_82;
-    _zz_83[16] = _zz_82;
-    _zz_83[15] = _zz_82;
-    _zz_83[14] = _zz_82;
-    _zz_83[13] = _zz_82;
-    _zz_83[12] = _zz_82;
-    _zz_83[11] = _zz_82;
-    _zz_83[10] = _zz_82;
-    _zz_83[9] = _zz_82;
-    _zz_83[8] = _zz_82;
-    _zz_83[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_84 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_85[31] = _zz_84;
-    _zz_85[30] = _zz_84;
-    _zz_85[29] = _zz_84;
-    _zz_85[28] = _zz_84;
-    _zz_85[27] = _zz_84;
-    _zz_85[26] = _zz_84;
-    _zz_85[25] = _zz_84;
-    _zz_85[24] = _zz_84;
-    _zz_85[23] = _zz_84;
-    _zz_85[22] = _zz_84;
-    _zz_85[21] = _zz_84;
-    _zz_85[20] = _zz_84;
-    _zz_85[19] = _zz_84;
-    _zz_85[18] = _zz_84;
-    _zz_85[17] = _zz_84;
-    _zz_85[16] = _zz_84;
-    _zz_85[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_244)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_83;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_85;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3422,59 +3558,60 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_87 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_90 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_86 = {(_zz_90 != 1'b0),{(_zz_90 != 1'b0),{((_zz_364 == _zz_365) != 1'b0),{(_zz_366 != 1'b0),{(_zz_367 != _zz_368),{_zz_369,{_zz_370,_zz_371}}}}}}};
-  assign _zz_91 = _zz_86[2 : 1];
-  assign _zz_49 = _zz_91;
-  assign _zz_92 = _zz_86[7 : 6];
-  assign _zz_48 = _zz_92;
-  assign _zz_93 = _zz_86[9 : 8];
-  assign _zz_47 = _zz_93;
-  assign _zz_94 = _zz_86[19 : 18];
-  assign _zz_46 = _zz_94;
-  assign _zz_95 = _zz_86[22 : 21];
-  assign _zz_45 = _zz_95;
-  assign _zz_96 = _zz_86[24 : 23];
-  assign _zz_44 = _zz_96;
-  assign _zz_97 = _zz_86[27 : 26];
-  assign _zz_43 = _zz_97;
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_207;
-  assign decode_RegFilePlugin_rs2Data = _zz_208;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_98)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_98)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_98)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3483,353 +3620,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_99 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_99 = {31'd0, _zz_289};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_99 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_100 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_100 = {29'd0, _zz_290};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_100 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_100 = {27'd0, _zz_291};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_101 = _zz_292[11];
-  always @ (*) begin
-    _zz_102[19] = _zz_101;
-    _zz_102[18] = _zz_101;
-    _zz_102[17] = _zz_101;
-    _zz_102[16] = _zz_101;
-    _zz_102[15] = _zz_101;
-    _zz_102[14] = _zz_101;
-    _zz_102[13] = _zz_101;
-    _zz_102[12] = _zz_101;
-    _zz_102[11] = _zz_101;
-    _zz_102[10] = _zz_101;
-    _zz_102[9] = _zz_101;
-    _zz_102[8] = _zz_101;
-    _zz_102[7] = _zz_101;
-    _zz_102[6] = _zz_101;
-    _zz_102[5] = _zz_101;
-    _zz_102[4] = _zz_101;
-    _zz_102[3] = _zz_101;
-    _zz_102[2] = _zz_101;
-    _zz_102[1] = _zz_101;
-    _zz_102[0] = _zz_101;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_103 = _zz_293[11];
-  always @ (*) begin
-    _zz_104[19] = _zz_103;
-    _zz_104[18] = _zz_103;
-    _zz_104[17] = _zz_103;
-    _zz_104[16] = _zz_103;
-    _zz_104[15] = _zz_103;
-    _zz_104[14] = _zz_103;
-    _zz_104[13] = _zz_103;
-    _zz_104[12] = _zz_103;
-    _zz_104[11] = _zz_103;
-    _zz_104[10] = _zz_103;
-    _zz_104[9] = _zz_103;
-    _zz_104[8] = _zz_103;
-    _zz_104[7] = _zz_103;
-    _zz_104[6] = _zz_103;
-    _zz_104[5] = _zz_103;
-    _zz_104[4] = _zz_103;
-    _zz_104[3] = _zz_103;
-    _zz_104[2] = _zz_103;
-    _zz_104[1] = _zz_103;
-    _zz_104[0] = _zz_103;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_105 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_105 = {_zz_102,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_105 = {_zz_104,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_105 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_294;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_106[0] = execute_SRC1[31];
-    _zz_106[1] = execute_SRC1[30];
-    _zz_106[2] = execute_SRC1[29];
-    _zz_106[3] = execute_SRC1[28];
-    _zz_106[4] = execute_SRC1[27];
-    _zz_106[5] = execute_SRC1[26];
-    _zz_106[6] = execute_SRC1[25];
-    _zz_106[7] = execute_SRC1[24];
-    _zz_106[8] = execute_SRC1[23];
-    _zz_106[9] = execute_SRC1[22];
-    _zz_106[10] = execute_SRC1[21];
-    _zz_106[11] = execute_SRC1[20];
-    _zz_106[12] = execute_SRC1[19];
-    _zz_106[13] = execute_SRC1[18];
-    _zz_106[14] = execute_SRC1[17];
-    _zz_106[15] = execute_SRC1[16];
-    _zz_106[16] = execute_SRC1[15];
-    _zz_106[17] = execute_SRC1[14];
-    _zz_106[18] = execute_SRC1[13];
-    _zz_106[19] = execute_SRC1[12];
-    _zz_106[20] = execute_SRC1[11];
-    _zz_106[21] = execute_SRC1[10];
-    _zz_106[22] = execute_SRC1[9];
-    _zz_106[23] = execute_SRC1[8];
-    _zz_106[24] = execute_SRC1[7];
-    _zz_106[25] = execute_SRC1[6];
-    _zz_106[26] = execute_SRC1[5];
-    _zz_106[27] = execute_SRC1[4];
-    _zz_106[28] = execute_SRC1[3];
-    _zz_106[29] = execute_SRC1[2];
-    _zz_106[30] = execute_SRC1[1];
-    _zz_106[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_106 : execute_SRC1);
-  always @ (*) begin
-    _zz_107[0] = memory_SHIFT_RIGHT[31];
-    _zz_107[1] = memory_SHIFT_RIGHT[30];
-    _zz_107[2] = memory_SHIFT_RIGHT[29];
-    _zz_107[3] = memory_SHIFT_RIGHT[28];
-    _zz_107[4] = memory_SHIFT_RIGHT[27];
-    _zz_107[5] = memory_SHIFT_RIGHT[26];
-    _zz_107[6] = memory_SHIFT_RIGHT[25];
-    _zz_107[7] = memory_SHIFT_RIGHT[24];
-    _zz_107[8] = memory_SHIFT_RIGHT[23];
-    _zz_107[9] = memory_SHIFT_RIGHT[22];
-    _zz_107[10] = memory_SHIFT_RIGHT[21];
-    _zz_107[11] = memory_SHIFT_RIGHT[20];
-    _zz_107[12] = memory_SHIFT_RIGHT[19];
-    _zz_107[13] = memory_SHIFT_RIGHT[18];
-    _zz_107[14] = memory_SHIFT_RIGHT[17];
-    _zz_107[15] = memory_SHIFT_RIGHT[16];
-    _zz_107[16] = memory_SHIFT_RIGHT[15];
-    _zz_107[17] = memory_SHIFT_RIGHT[14];
-    _zz_107[18] = memory_SHIFT_RIGHT[13];
-    _zz_107[19] = memory_SHIFT_RIGHT[12];
-    _zz_107[20] = memory_SHIFT_RIGHT[11];
-    _zz_107[21] = memory_SHIFT_RIGHT[10];
-    _zz_107[22] = memory_SHIFT_RIGHT[9];
-    _zz_107[23] = memory_SHIFT_RIGHT[8];
-    _zz_107[24] = memory_SHIFT_RIGHT[7];
-    _zz_107[25] = memory_SHIFT_RIGHT[6];
-    _zz_107[26] = memory_SHIFT_RIGHT[5];
-    _zz_107[27] = memory_SHIFT_RIGHT[4];
-    _zz_107[28] = memory_SHIFT_RIGHT[3];
-    _zz_107[29] = memory_SHIFT_RIGHT[2];
-    _zz_107[30] = memory_SHIFT_RIGHT[1];
-    _zz_107[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_108 = 1'b0;
-    if(_zz_226)begin
-      if(_zz_227)begin
-        if(_zz_113)begin
-          _zz_108 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_228)begin
-      if(_zz_229)begin
-        if(_zz_115)begin
-          _zz_108 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_230)begin
-      if(_zz_231)begin
-        if(_zz_117)begin
-          _zz_108 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_108 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_109 = 1'b0;
-    if(_zz_226)begin
-      if(_zz_227)begin
-        if(_zz_114)begin
-          _zz_109 = 1'b1;
-        end
-      end
-    end
-    if(_zz_228)begin
-      if(_zz_229)begin
-        if(_zz_116)begin
-          _zz_109 = 1'b1;
-        end
-      end
-    end
-    if(_zz_230)begin
-      if(_zz_231)begin
-        if(_zz_118)begin
-          _zz_109 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_109 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_113 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_115 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_117 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_119 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_119 == 3'b000)) begin
-        _zz_120 = execute_BranchPlugin_eq;
-    end else if((_zz_119 == 3'b001)) begin
-        _zz_120 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_119 & 3'b101) == 3'b101))) begin
-        _zz_120 = (! execute_SRC_LESS);
-    end else begin
-        _zz_120 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_121 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_121 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_121 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_121 = _zz_120;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_122 = _zz_301[11];
-  always @ (*) begin
-    _zz_123[19] = _zz_122;
-    _zz_123[18] = _zz_122;
-    _zz_123[17] = _zz_122;
-    _zz_123[16] = _zz_122;
-    _zz_123[15] = _zz_122;
-    _zz_123[14] = _zz_122;
-    _zz_123[13] = _zz_122;
-    _zz_123[12] = _zz_122;
-    _zz_123[11] = _zz_122;
-    _zz_123[10] = _zz_122;
-    _zz_123[9] = _zz_122;
-    _zz_123[8] = _zz_122;
-    _zz_123[7] = _zz_122;
-    _zz_123[6] = _zz_122;
-    _zz_123[5] = _zz_122;
-    _zz_123[4] = _zz_122;
-    _zz_123[3] = _zz_122;
-    _zz_123[2] = _zz_122;
-    _zz_123[1] = _zz_122;
-    _zz_123[0] = _zz_122;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_124 = _zz_302[19];
-  always @ (*) begin
-    _zz_125[10] = _zz_124;
-    _zz_125[9] = _zz_124;
-    _zz_125[8] = _zz_124;
-    _zz_125[7] = _zz_124;
-    _zz_125[6] = _zz_124;
-    _zz_125[5] = _zz_124;
-    _zz_125[4] = _zz_124;
-    _zz_125[3] = _zz_124;
-    _zz_125[2] = _zz_124;
-    _zz_125[1] = _zz_124;
-    _zz_125[0] = _zz_124;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_126 = _zz_303[11];
-  always @ (*) begin
-    _zz_127[18] = _zz_126;
-    _zz_127[17] = _zz_126;
-    _zz_127[16] = _zz_126;
-    _zz_127[15] = _zz_126;
-    _zz_127[14] = _zz_126;
-    _zz_127[13] = _zz_126;
-    _zz_127[12] = _zz_126;
-    _zz_127[11] = _zz_126;
-    _zz_127[10] = _zz_126;
-    _zz_127[9] = _zz_126;
-    _zz_127[8] = _zz_126;
-    _zz_127[7] = _zz_126;
-    _zz_127[6] = _zz_126;
-    _zz_127[5] = _zz_126;
-    _zz_127[4] = _zz_126;
-    _zz_127[3] = _zz_126;
-    _zz_127[2] = _zz_126;
-    _zz_127[1] = _zz_126;
-    _zz_127[0] = _zz_126;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_128 = (_zz_304[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_128 = _zz_305[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_128 = _zz_306[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_128);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -3840,80 +4000,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_129 = _zz_307[11];
-  always @ (*) begin
-    _zz_130[19] = _zz_129;
-    _zz_130[18] = _zz_129;
-    _zz_130[17] = _zz_129;
-    _zz_130[16] = _zz_129;
-    _zz_130[15] = _zz_129;
-    _zz_130[14] = _zz_129;
-    _zz_130[13] = _zz_129;
-    _zz_130[12] = _zz_129;
-    _zz_130[11] = _zz_129;
-    _zz_130[10] = _zz_129;
-    _zz_130[9] = _zz_129;
-    _zz_130[8] = _zz_129;
-    _zz_130[7] = _zz_129;
-    _zz_130[6] = _zz_129;
-    _zz_130[5] = _zz_129;
-    _zz_130[4] = _zz_129;
-    _zz_130[3] = _zz_129;
-    _zz_130[2] = _zz_129;
-    _zz_130[1] = _zz_129;
-    _zz_130[0] = _zz_129;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_130,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_132,{{{_zz_528,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_134,{{{_zz_529,_zz_530},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_310};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_131 = _zz_308[19];
-  always @ (*) begin
-    _zz_132[10] = _zz_131;
-    _zz_132[9] = _zz_131;
-    _zz_132[8] = _zz_131;
-    _zz_132[7] = _zz_131;
-    _zz_132[6] = _zz_131;
-    _zz_132[5] = _zz_131;
-    _zz_132[4] = _zz_131;
-    _zz_132[3] = _zz_131;
-    _zz_132[2] = _zz_131;
-    _zz_132[1] = _zz_131;
-    _zz_132[0] = _zz_131;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_133 = _zz_309[11];
-  always @ (*) begin
-    _zz_134[18] = _zz_133;
-    _zz_134[17] = _zz_133;
-    _zz_134[16] = _zz_133;
-    _zz_134[15] = _zz_133;
-    _zz_134[14] = _zz_133;
-    _zz_134[13] = _zz_133;
-    _zz_134[12] = _zz_133;
-    _zz_134[11] = _zz_133;
-    _zz_134[10] = _zz_133;
-    _zz_134[9] = _zz_133;
-    _zz_134[8] = _zz_133;
-    _zz_134[7] = _zz_133;
-    _zz_134[6] = _zz_133;
-    _zz_134[5] = _zz_133;
-    _zz_134[4] = _zz_133;
-    _zz_134[3] = _zz_133;
-    _zz_134[2] = _zz_133;
-    _zz_134[1] = _zz_133;
-    _zz_134[0] = _zz_133;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -3923,92 +4083,106 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_135 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_136 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_137 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_138 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_139 = _zz_311[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_220)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4019,8 +4193,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4030,135 +4204,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_232)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_233)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_234)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_233)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_234)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4171,39 +4354,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_232)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_232)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_245)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_235)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4216,8 +4409,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_235)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4236,79 +4429,150 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_313) + $signed(_zz_314));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_215)begin
-      if(_zz_236)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_237)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_318);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_140 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_140[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_319);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_320 : _zz_321);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_322[31:0];
-  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_143 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_144[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_146 != 32'h0);
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4329,240 +4593,274 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_147 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_147[12 : 0] = 13'h1000;
-      _zz_147[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_148 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_148[3 : 0] = 4'b1011;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
     end
   end
 
-  always @ (*) begin
-    _zz_149 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_149[4 : 0] = 5'h16;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
     end
   end
 
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_150[5 : 0] = 6'h21;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
     end
   end
 
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_151[31 : 30] = CsrPlugin_misa_base;
-      _zz_151[25 : 0] = CsrPlugin_misa_extensions;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_152[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_152[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_152[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_153[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_153[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_153[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_154[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_154[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_154[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_155[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_155[1 : 0] = CsrPlugin_mtvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_156 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_156[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_157 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_157[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_158 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_158[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_158[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_159 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_159[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_160 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_160[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_161 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_161[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_162 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_162[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_163 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_163[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_164[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_165[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_166[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_167[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_168[31 : 0] = _zz_145;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_169[31 : 0] = _zz_146;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_147 | _zz_148) | (_zz_149 | _zz_150)) | ((_zz_531 | _zz_151) | (_zz_152 | _zz_153))) | (((_zz_154 | _zz_155) | (_zz_156 | _zz_157)) | ((_zz_158 | _zz_159) | (_zz_160 | _zz_161)))) | (((_zz_162 | _zz_163) | (_zz_164 | _zz_165)) | ((_zz_166 | _zz_167) | (_zz_168 | _zz_169))));
-  assign iBusWishbone_ADR = {_zz_339,_zz_170};
-  assign iBusWishbone_CTI = ((_zz_170 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_238)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_238)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_171;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_177 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_173 = dBus_cmd_valid;
-  assign _zz_175 = dBus_cmd_payload_wr;
-  assign _zz_176 = (_zz_172 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_174 && (_zz_175 || _zz_176));
-  assign dBusWishbone_ADR = ((_zz_177 ? {{dBus_cmd_payload_address[31 : 5],_zz_172},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_177 ? (_zz_176 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_175 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_175;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_174 = (_zz_173 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_173;
-  assign dBusWishbone_STB = _zz_173;
-  assign dBus_rsp_valid = _zz_178;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_64 <= 1'b0;
-      _zz_66 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_79;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_80;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_98 <= 1'b1;
-      _zz_110 <= 1'b0;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4583,159 +4881,159 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_145 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_170 <= 3'b000;
-      _zz_171 <= 1'b0;
-      _zz_172 <= 3'b000;
-      _zz_178 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_62)begin
-        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_66 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_239)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_98 <= 1'b0;
-      _zz_110 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_240)begin
-        if(_zz_241)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_242)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_243)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_222)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4746,8 +5044,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_223)begin
-        case(_zz_224)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4757,141 +5055,141 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_137,{_zz_136,_zz_135}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_332[0];
-          CsrPlugin_mstatus_MIE <= _zz_333[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_335[0];
-          CsrPlugin_mie_MTIE <= _zz_336[0];
-          CsrPlugin_mie_MSIE <= _zz_337[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_238)begin
-        if(iBusWishbone_ACK)begin
-          _zz_170 <= (_zz_170 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_171 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_173 && _zz_174))begin
-        _zz_172 <= (_zz_172 + 3'b001);
-        if(_zz_176)begin
-          _zz_172 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_178 <= ((_zz_173 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_67 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_239)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_111 <= _zz_40[11 : 7];
-    _zz_112 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_220)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_240)begin
-      if(_zz_241)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_242)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_243)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_222)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -4899,336 +5197,336 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_215)begin
-      if(_zz_236)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_323[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_237)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_329);
-      memory_DivPlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_331);
-      memory_DivPlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_49) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_50) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_51) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_52) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_334[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_338[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -5241,9 +5539,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -5265,6 +5562,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5280,9 +5578,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5290,7 +5589,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5299,24 +5598,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5341,40 +5631,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5384,23 +5682,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5408,10 +5716,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5423,59 +5739,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -5490,274 +5801,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -5765,89 +6095,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -5855,12 +6169,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -5871,20 +6185,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -5892,45 +6226,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -5941,46 +6277,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -5988,50 +6315,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6081,13 +6409,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6096,8 +6420,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6111,22 +6440,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -6136,82 +6468,85 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6227,30 +6562,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6258,51 +6598,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -6313,10 +6653,10 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define Input2Kind_defaultEncoding_type [0:0]
@@ -20,15 +20,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -60,7 +60,6 @@ module VexRiscv (
   output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
   input               CfuPlugin_bus_rsp_valid,
   output              CfuPlugin_bus_rsp_ready,
-  input               CfuPlugin_bus_rsp_payload_response_ok,
   input      [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
   output reg          iBusWishbone_CYC,
   output reg          iBusWishbone_STB,
@@ -87,37 +86,37 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_193;
-  wire                _zz_194;
-  wire                _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  reg                 _zz_201;
-  wire                _zz_202;
-  wire       [31:0]   _zz_203;
-  wire                _zz_204;
-  wire       [31:0]   _zz_205;
-  reg                 _zz_206;
-  wire                _zz_207;
-  wire                _zz_208;
-  wire       [31:0]   _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire                _zz_212;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire       [3:0]    _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  reg        [31:0]   _zz_221;
-  reg        [31:0]   _zz_222;
-  reg        [31:0]   _zz_223;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -140,6 +139,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -148,340 +148,281 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire                _zz_228;
-  wire                _zz_229;
-  wire                _zz_230;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire       [1:0]    _zz_239;
-  wire                _zz_240;
-  wire                _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire                _zz_244;
-  wire                _zz_245;
-  wire                _zz_246;
-  wire                _zz_247;
-  wire                _zz_248;
-  wire                _zz_249;
-  wire       [1:0]    _zz_250;
-  wire                _zz_251;
-  wire                _zz_252;
-  wire                _zz_253;
-  wire                _zz_254;
-  wire                _zz_255;
-  wire                _zz_256;
-  wire                _zz_257;
-  wire                _zz_258;
-  wire                _zz_259;
-  wire       [1:0]    _zz_260;
-  wire                _zz_261;
-  wire       [1:0]    _zz_262;
-  wire       [51:0]   _zz_263;
-  wire       [51:0]   _zz_264;
-  wire       [51:0]   _zz_265;
-  wire       [32:0]   _zz_266;
-  wire       [51:0]   _zz_267;
-  wire       [49:0]   _zz_268;
-  wire       [51:0]   _zz_269;
-  wire       [49:0]   _zz_270;
-  wire       [51:0]   _zz_271;
-  wire       [32:0]   _zz_272;
-  wire       [31:0]   _zz_273;
-  wire       [32:0]   _zz_274;
-  wire       [0:0]    _zz_275;
-  wire       [0:0]    _zz_276;
-  wire       [0:0]    _zz_277;
-  wire       [0:0]    _zz_278;
-  wire       [0:0]    _zz_279;
-  wire       [0:0]    _zz_280;
-  wire       [0:0]    _zz_281;
-  wire       [0:0]    _zz_282;
-  wire       [0:0]    _zz_283;
-  wire       [0:0]    _zz_284;
-  wire       [0:0]    _zz_285;
-  wire       [0:0]    _zz_286;
-  wire       [0:0]    _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [0:0]    _zz_289;
-  wire       [0:0]    _zz_290;
-  wire       [0:0]    _zz_291;
-  wire       [0:0]    _zz_292;
-  wire       [3:0]    _zz_293;
-  wire       [2:0]    _zz_294;
-  wire       [31:0]   _zz_295;
-  wire       [11:0]   _zz_296;
-  wire       [31:0]   _zz_297;
-  wire       [19:0]   _zz_298;
-  wire       [11:0]   _zz_299;
-  wire       [31:0]   _zz_300;
-  wire       [31:0]   _zz_301;
-  wire       [19:0]   _zz_302;
-  wire       [11:0]   _zz_303;
-  wire       [2:0]    _zz_304;
-  wire       [2:0]    _zz_305;
-  wire       [0:0]    _zz_306;
-  wire       [2:0]    _zz_307;
-  wire       [4:0]    _zz_308;
-  wire       [11:0]   _zz_309;
-  wire       [11:0]   _zz_310;
-  wire       [31:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  wire       [31:0]   _zz_314;
-  wire       [31:0]   _zz_315;
-  wire       [31:0]   _zz_316;
-  wire       [31:0]   _zz_317;
-  wire       [11:0]   _zz_318;
-  wire       [19:0]   _zz_319;
-  wire       [11:0]   _zz_320;
-  wire       [31:0]   _zz_321;
-  wire       [31:0]   _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [11:0]   _zz_324;
-  wire       [19:0]   _zz_325;
-  wire       [11:0]   _zz_326;
-  wire       [2:0]    _zz_327;
-  wire       [1:0]    _zz_328;
-  wire       [1:0]    _zz_329;
-  wire       [1:0]    _zz_330;
-  wire       [1:0]    _zz_331;
-  wire       [65:0]   _zz_332;
-  wire       [65:0]   _zz_333;
-  wire       [31:0]   _zz_334;
-  wire       [31:0]   _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [5:0]    _zz_337;
-  wire       [32:0]   _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire       [32:0]   _zz_341;
-  wire       [32:0]   _zz_342;
-  wire       [32:0]   _zz_343;
-  wire       [32:0]   _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [32:0]   _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [32:0]   _zz_348;
-  wire       [0:0]    _zz_349;
-  wire       [31:0]   _zz_350;
-  wire       [9:0]    _zz_351;
-  wire       [7:0]    _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [0:0]    _zz_354;
-  wire       [0:0]    _zz_355;
-  wire       [0:0]    _zz_356;
-  wire       [0:0]    _zz_357;
-  wire       [0:0]    _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [26:0]   _zz_360;
-  wire                _zz_361;
-  wire                _zz_362;
-  wire       [1:0]    _zz_363;
-  wire       [31:0]   _zz_364;
-  wire       [31:0]   _zz_365;
-  wire       [31:0]   _zz_366;
-  wire                _zz_367;
-  wire       [0:0]    _zz_368;
-  wire       [14:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire       [31:0]   _zz_371;
-  wire       [31:0]   _zz_372;
-  wire                _zz_373;
-  wire       [0:0]    _zz_374;
-  wire       [8:0]    _zz_375;
-  wire       [31:0]   _zz_376;
-  wire       [31:0]   _zz_377;
-  wire       [31:0]   _zz_378;
-  wire                _zz_379;
-  wire       [0:0]    _zz_380;
-  wire       [2:0]    _zz_381;
-  wire                _zz_382;
-  wire                _zz_383;
-  wire                _zz_384;
-  wire       [0:0]    _zz_385;
-  wire       [0:0]    _zz_386;
-  wire                _zz_387;
-  wire       [0:0]    _zz_388;
-  wire       [26:0]   _zz_389;
-  wire       [31:0]   _zz_390;
-  wire       [31:0]   _zz_391;
-  wire       [31:0]   _zz_392;
-  wire                _zz_393;
-  wire       [1:0]    _zz_394;
-  wire       [1:0]    _zz_395;
-  wire                _zz_396;
-  wire       [0:0]    _zz_397;
-  wire       [22:0]   _zz_398;
-  wire       [31:0]   _zz_399;
-  wire       [31:0]   _zz_400;
-  wire       [31:0]   _zz_401;
-  wire       [31:0]   _zz_402;
-  wire                _zz_403;
-  wire                _zz_404;
-  wire       [1:0]    _zz_405;
-  wire       [1:0]    _zz_406;
-  wire                _zz_407;
-  wire       [0:0]    _zz_408;
-  wire       [19:0]   _zz_409;
-  wire       [31:0]   _zz_410;
-  wire       [31:0]   _zz_411;
-  wire       [31:0]   _zz_412;
-  wire       [31:0]   _zz_413;
-  wire                _zz_414;
-  wire       [0:0]    _zz_415;
-  wire       [0:0]    _zz_416;
-  wire                _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [0:0]    _zz_419;
-  wire                _zz_420;
-  wire       [0:0]    _zz_421;
-  wire       [16:0]   _zz_422;
-  wire       [31:0]   _zz_423;
-  wire       [31:0]   _zz_424;
-  wire       [31:0]   _zz_425;
-  wire       [31:0]   _zz_426;
-  wire       [31:0]   _zz_427;
-  wire       [0:0]    _zz_428;
-  wire       [0:0]    _zz_429;
-  wire       [0:0]    _zz_430;
-  wire       [0:0]    _zz_431;
-  wire                _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [13:0]   _zz_434;
-  wire       [31:0]   _zz_435;
-  wire       [31:0]   _zz_436;
-  wire       [31:0]   _zz_437;
-  wire       [0:0]    _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [3:0]    _zz_441;
-  wire       [0:0]    _zz_442;
-  wire       [0:0]    _zz_443;
-  wire                _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [10:0]   _zz_446;
-  wire       [31:0]   _zz_447;
-  wire       [31:0]   _zz_448;
-  wire       [31:0]   _zz_449;
-  wire       [31:0]   _zz_450;
-  wire       [31:0]   _zz_451;
-  wire                _zz_452;
-  wire       [0:0]    _zz_453;
-  wire       [0:0]    _zz_454;
-  wire       [31:0]   _zz_455;
-  wire                _zz_456;
-  wire       [0:0]    _zz_457;
-  wire       [3:0]    _zz_458;
-  wire       [0:0]    _zz_459;
-  wire       [3:0]    _zz_460;
-  wire       [5:0]    _zz_461;
-  wire       [5:0]    _zz_462;
-  wire                _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [7:0]    _zz_465;
-  wire       [31:0]   _zz_466;
-  wire       [31:0]   _zz_467;
-  wire       [31:0]   _zz_468;
-  wire       [31:0]   _zz_469;
-  wire       [31:0]   _zz_470;
-  wire       [31:0]   _zz_471;
-  wire       [31:0]   _zz_472;
-  wire       [31:0]   _zz_473;
-  wire       [0:0]    _zz_474;
-  wire       [1:0]    _zz_475;
-  wire                _zz_476;
-  wire       [0:0]    _zz_477;
-  wire       [1:0]    _zz_478;
-  wire       [0:0]    _zz_479;
-  wire       [3:0]    _zz_480;
-  wire       [0:0]    _zz_481;
-  wire       [0:0]    _zz_482;
-  wire       [1:0]    _zz_483;
-  wire       [1:0]    _zz_484;
-  wire                _zz_485;
-  wire       [0:0]    _zz_486;
-  wire       [5:0]    _zz_487;
-  wire       [31:0]   _zz_488;
-  wire       [31:0]   _zz_489;
-  wire                _zz_490;
-  wire                _zz_491;
-  wire       [31:0]   _zz_492;
-  wire       [31:0]   _zz_493;
-  wire       [31:0]   _zz_494;
-  wire                _zz_495;
-  wire                _zz_496;
-  wire       [31:0]   _zz_497;
-  wire       [31:0]   _zz_498;
-  wire                _zz_499;
-  wire       [0:0]    _zz_500;
-  wire       [1:0]    _zz_501;
-  wire       [31:0]   _zz_502;
-  wire       [31:0]   _zz_503;
-  wire                _zz_504;
-  wire                _zz_505;
-  wire       [0:0]    _zz_506;
-  wire       [0:0]    _zz_507;
-  wire                _zz_508;
-  wire       [0:0]    _zz_509;
-  wire       [3:0]    _zz_510;
-  wire       [31:0]   _zz_511;
-  wire       [31:0]   _zz_512;
-  wire       [31:0]   _zz_513;
-  wire       [31:0]   _zz_514;
-  wire       [31:0]   _zz_515;
-  wire       [31:0]   _zz_516;
-  wire       [31:0]   _zz_517;
-  wire                _zz_518;
-  wire                _zz_519;
-  wire       [31:0]   _zz_520;
-  wire       [31:0]   _zz_521;
-  wire       [31:0]   _zz_522;
-  wire       [31:0]   _zz_523;
-  wire       [0:0]    _zz_524;
-  wire       [2:0]    _zz_525;
-  wire       [0:0]    _zz_526;
-  wire       [0:0]    _zz_527;
-  wire                _zz_528;
-  wire       [0:0]    _zz_529;
-  wire       [1:0]    _zz_530;
-  wire       [31:0]   _zz_531;
-  wire       [31:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire                _zz_534;
-  wire                _zz_535;
-  wire       [31:0]   _zz_536;
-  wire                _zz_537;
-  wire       [0:0]    _zz_538;
-  wire       [0:0]    _zz_539;
-  wire       [0:0]    _zz_540;
-  wire       [0:0]    _zz_541;
-  wire       [1:0]    _zz_542;
-  wire       [1:0]    _zz_543;
-  wire       [0:0]    _zz_544;
-  wire       [0:0]    _zz_545;
-  wire       [31:0]   _zz_546;
-  wire       [31:0]   _zz_547;
-  wire       [31:0]   _zz_548;
-  wire       [31:0]   _zz_549;
-  wire       [31:0]   _zz_550;
-  wire       [31:0]   _zz_551;
-  wire                _zz_552;
-  wire                _zz_553;
-  wire                _zz_554;
-  wire       [31:0]   _zz_555;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [14:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [8:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [2:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
+  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
+  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
+  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1;
+  wire                _zz_when;
+  wire                _zz_when_1;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [9:0]    _zz_execute_CfuPlugin_functionsIds_0;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
   wire                execute_CfuPlugin_CFU_IN_FLIGHT;
@@ -492,16 +433,16 @@ module VexRiscv (
   wire       [31:0]   execute_MUL_LL;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
   wire       `Input2Kind_defaultEncoding_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_defaultEncoding_type _zz_1;
-  wire       `Input2Kind_defaultEncoding_type _zz_2;
-  wire       `Input2Kind_defaultEncoding_type _zz_3;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -509,27 +450,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -538,28 +479,28 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_25;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_26;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_28;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_29;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire       [31:0]   memory_PC;
-  reg                 _zz_30;
-  reg                 _zz_31;
+  reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
   wire       `Input2Kind_defaultEncoding_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_defaultEncoding_type _zz_32;
+  wire       `Input2Kind_defaultEncoding_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
@@ -575,11 +516,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -587,10 +528,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_36;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_37;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -600,46 +541,46 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_38;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_39;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_40;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_41;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_42;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_43;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_45;
-  wire       [31:0]   _zz_46;
-  wire                _zz_47;
-  reg                 _zz_48;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_defaultEncoding_type _zz_49;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_50;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_52;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_53;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_54;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_55;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_56;
-  reg        [31:0]   _zz_57;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -658,10 +599,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_58;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_59;
-  reg        [31:0]   _zz_60;
+  reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -691,7 +632,7 @@ module VexRiscv (
   wire                memory_arbitration_haltByOther;
   reg                 memory_arbitration_removeIt;
   wire                memory_arbitration_flushIt;
-  reg                 memory_arbitration_flushNext;
+  wire                memory_arbitration_flushNext;
   reg                 memory_arbitration_isValid;
   wire                memory_arbitration_isStuck;
   wire                memory_arbitration_isStuckByOthers;
@@ -748,7 +689,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -782,6 +723,11 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -799,31 +745,34 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
-  reg                 CfuPlugin_joinException_valid;
-  wire       [3:0]    CfuPlugin_joinException_payload_code;
-  wire       [31:0]   CfuPlugin_joinException_payload_badAddr;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_61;
-  wire       [3:0]    _zz_62;
-  wire                _zz_63;
-  wire                _zz_64;
-  wire                _zz_65;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -846,16 +795,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_66;
-  wire                _zz_67;
-  wire                _zz_68;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_69;
-  wire                _zz_70;
-  reg                 _zz_71;
-  wire                _zz_72;
-  reg                 _zz_73;
-  reg        [31:0]   _zz_74;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -863,22 +814,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_75;
-  reg        [18:0]   _zz_76;
-  wire                _zz_77;
-  reg        [10:0]   _zz_78;
-  wire                _zz_79;
-  reg        [18:0]   _zz_80;
-  reg                 _zz_81;
-  wire                _zz_82;
-  reg        [10:0]   _zz_83;
-  wire                _zz_84;
-  reg        [18:0]   _zz_85;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -886,7 +844,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_86;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -894,6 +852,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -901,7 +864,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -909,8 +872,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -918,40 +882,54 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_87;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_88;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_89;
-  reg        [31:0]   _zz_90;
-  wire                _zz_91;
-  reg        [31:0]   _zz_92;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [33:0]   _zz_93;
-  wire                _zz_94;
-  wire                _zz_95;
-  wire                _zz_96;
-  wire                _zz_97;
-  wire                _zz_98;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_99;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_100;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_101;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_102;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_103;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_104;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_105;
-  wire       `Input2Kind_defaultEncoding_type _zz_106;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -959,53 +937,72 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_107;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_108;
-  reg        [31:0]   _zz_109;
-  wire                _zz_110;
-  reg        [19:0]   _zz_111;
-  wire                _zz_112;
-  reg        [19:0]   _zz_113;
-  reg        [31:0]   _zz_114;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_115;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_116;
-  reg                 _zz_117;
-  reg                 _zz_118;
-  reg                 _zz_119;
-  reg        [4:0]    _zz_120;
-  reg        [31:0]   _zz_121;
-  wire                _zz_122;
-  wire                _zz_123;
-  wire                _zz_124;
-  wire                _zz_125;
-  wire                _zz_126;
-  wire                _zz_127;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_128;
-  reg                 _zz_129;
-  reg                 _zz_130;
-  wire                _zz_131;
-  reg        [19:0]   _zz_132;
-  wire                _zz_133;
-  reg        [10:0]   _zz_134;
-  wire                _zz_135;
-  reg        [18:0]   _zz_136;
-  reg                 _zz_137;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_138;
-  reg        [19:0]   _zz_139;
-  wire                _zz_140;
-  reg        [10:0]   _zz_141;
-  wire                _zz_142;
-  reg        [18:0]   _zz_143;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
+  wire                when_BranchPlugin_l296;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1026,9 +1023,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_144;
-  wire                _zz_145;
-  wire                _zz_146;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1041,42 +1038,69 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_147;
-  wire                _zz_148;
-  wire       [1:0]    _zz_149;
-  wire                _zz_150;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1084,6 +1108,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1096,238 +1122,346 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_151;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_152;
-  wire                _zz_153;
-  wire                _zz_154;
-  reg        [32:0]   _zz_155;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_156;
-  wire       [31:0]   _zz_157;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   wire                execute_CfuPlugin_schedule;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
+  wire                when_CfuPlugin_l171;
+  wire                when_CfuPlugin_l171_1;
+  wire                when_CfuPlugin_l175;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
-  wire                _zz_158;
-  reg        [23:0]   _zz_159;
-  reg        [31:0]   _zz_160;
+  wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+  reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
+  reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   wire                memory_CfuPlugin_rsp_valid;
   reg                 memory_CfuPlugin_rsp_ready;
-  wire                memory_CfuPlugin_rsp_payload_response_ok;
   wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_s2mPipe_rValid;
-  reg                 CfuPlugin_bus_rsp_s2mPipe_rData_response_ok;
   reg        [31:0]   CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0;
+  wire                when_Stream_l365_1;
+  wire                when_CfuPlugin_l208;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  wire                when_Pipeline_l124_44;
   reg        `Input2Kind_defaultEncoding_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire                when_Pipeline_l124_45;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_46;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_50;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_51;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_52;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_54;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_55;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_57;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_62;
   reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_63;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_161;
-  reg        [31:0]   _zz_162;
-  reg        [31:0]   _zz_163;
-  reg        [31:0]   _zz_164;
-  reg        [31:0]   _zz_165;
-  reg        [31:0]   _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  reg        [31:0]   _zz_172;
-  reg        [31:0]   _zz_173;
-  reg        [31:0]   _zz_174;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [31:0]   _zz_183;
-  reg        [2:0]    _zz_184;
-  reg                 _zz_185;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  wire                _zz_190;
-  wire                _zz_191;
-  reg                 _zz_192;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
   reg [39:0] decode_CfuPlugin_CFU_INPUT_2_KIND_string;
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_8_string;
-  reg [39:0] _zz_9_string;
-  reg [39:0] _zz_10_string;
-  reg [31:0] _zz_11_string;
-  reg [31:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_15_string;
-  reg [71:0] _zz_16_string;
-  reg [71:0] _zz_17_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_18_string;
-  reg [39:0] _zz_19_string;
-  reg [39:0] _zz_20_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_21_string;
-  reg [23:0] _zz_22_string;
-  reg [23:0] _zz_23_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_24_string;
-  reg [63:0] _zz_25_string;
-  reg [63:0] _zz_26_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_27_string;
-  reg [95:0] _zz_28_string;
-  reg [95:0] _zz_29_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
-  reg [39:0] _zz_32_string;
+  reg [39:0] _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_33_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_34_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_35_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_36_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_39_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_40_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_42_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_43_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_44_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_45_string;
-  reg [39:0] _zz_49_string;
-  reg [39:0] _zz_50_string;
-  reg [31:0] _zz_51_string;
-  reg [71:0] _zz_52_string;
-  reg [39:0] _zz_53_string;
-  reg [23:0] _zz_54_string;
-  reg [63:0] _zz_55_string;
-  reg [95:0] _zz_56_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_58_string;
-  reg [95:0] _zz_99_string;
-  reg [63:0] _zz_100_string;
-  reg [23:0] _zz_101_string;
-  reg [39:0] _zz_102_string;
-  reg [71:0] _zz_103_string;
-  reg [31:0] _zz_104_string;
-  reg [39:0] _zz_105_string;
-  reg [39:0] _zz_106_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1337,472 +1471,437 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_224 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_225 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_226 = 1'b1;
-  assign _zz_227 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_228 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_229 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_230 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_231 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_232 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_233 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_234 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_235 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_236 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
-  assign _zz_237 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_238 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_239 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_240 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_241 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_242 = (1'b0 || (! 1'b1));
-  assign _zz_243 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_244 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_245 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_246 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_247 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_248 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_249 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_250 = execute_INSTRUCTION[13 : 12];
-  assign _zz_251 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_252 = (! memory_arbitration_isStuck);
-  assign _zz_253 = (iBus_cmd_valid || (_zz_184 != 3'b000));
-  assign _zz_254 = (_zz_220 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_255 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_256 = ((_zz_144 && 1'b1) && (! 1'b0));
-  assign _zz_257 = ((_zz_145 && 1'b1) && (! 1'b0));
-  assign _zz_258 = ((_zz_146 && 1'b1) && (! 1'b0));
-  assign _zz_259 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
-  assign _zz_260 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_261 = execute_INSTRUCTION[13];
-  assign _zz_262 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_263 = ($signed(_zz_264) + $signed(_zz_269));
-  assign _zz_264 = ($signed(_zz_265) + $signed(_zz_267));
-  assign _zz_265 = 52'h0;
-  assign _zz_266 = {1'b0,memory_MUL_LL};
-  assign _zz_267 = {{19{_zz_266[32]}}, _zz_266};
-  assign _zz_268 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_269 = {{2{_zz_268[49]}}, _zz_268};
-  assign _zz_270 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_271 = {{2{_zz_270[49]}}, _zz_270};
-  assign _zz_272 = ($signed(_zz_274) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_273 = _zz_272[31 : 0];
-  assign _zz_274 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_275 = _zz_93[32 : 32];
-  assign _zz_276 = _zz_93[31 : 31];
-  assign _zz_277 = _zz_93[30 : 30];
-  assign _zz_278 = _zz_93[29 : 29];
-  assign _zz_279 = _zz_93[28 : 28];
-  assign _zz_280 = _zz_93[25 : 25];
-  assign _zz_281 = _zz_93[17 : 17];
-  assign _zz_282 = _zz_93[16 : 16];
-  assign _zz_283 = _zz_93[13 : 13];
-  assign _zz_284 = _zz_93[12 : 12];
-  assign _zz_285 = _zz_93[11 : 11];
-  assign _zz_286 = _zz_93[15 : 15];
-  assign _zz_287 = _zz_93[5 : 5];
-  assign _zz_288 = _zz_93[3 : 3];
-  assign _zz_289 = _zz_93[20 : 20];
-  assign _zz_290 = _zz_93[10 : 10];
-  assign _zz_291 = _zz_93[4 : 4];
-  assign _zz_292 = _zz_93[0 : 0];
-  assign _zz_293 = (_zz_61 - 4'b0001);
-  assign _zz_294 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_295 = {29'd0, _zz_294};
-  assign _zz_296 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_297 = {{_zz_76,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_298 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_299 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_300 = {{_zz_78,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_301 = {{_zz_80,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_302 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_303 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_304 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_305 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_306 = execute_SRC_LESS;
-  assign _zz_307 = 3'b100;
-  assign _zz_308 = execute_INSTRUCTION[19 : 15];
-  assign _zz_309 = execute_INSTRUCTION[31 : 20];
-  assign _zz_310 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_311 = ($signed(_zz_312) + $signed(_zz_315));
-  assign _zz_312 = ($signed(_zz_313) + $signed(_zz_314));
-  assign _zz_313 = execute_SRC1;
-  assign _zz_314 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_315 = (execute_SRC_USE_SUB_LESS ? _zz_316 : _zz_317);
-  assign _zz_316 = 32'h00000001;
-  assign _zz_317 = 32'h0;
-  assign _zz_318 = execute_INSTRUCTION[31 : 20];
-  assign _zz_319 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_320 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_321 = {_zz_132,execute_INSTRUCTION[31 : 20]};
-  assign _zz_322 = {{_zz_134,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_323 = {{_zz_136,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_324 = execute_INSTRUCTION[31 : 20];
-  assign _zz_325 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_326 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_327 = 3'b100;
-  assign _zz_328 = (_zz_147 & (~ _zz_329));
-  assign _zz_329 = (_zz_147 - 2'b01);
-  assign _zz_330 = (_zz_149 & (~ _zz_331));
-  assign _zz_331 = (_zz_149 - 2'b01);
-  assign _zz_332 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_333 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_334 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_335 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_336 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_337 = {5'd0, _zz_336};
-  assign _zz_338 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_339 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_340 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_341 = {_zz_151,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_342 = _zz_343;
-  assign _zz_343 = _zz_344;
-  assign _zz_344 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_152) : _zz_152)} + _zz_346);
-  assign _zz_345 = memory_DivPlugin_div_needRevert;
-  assign _zz_346 = {32'd0, _zz_345};
-  assign _zz_347 = _zz_154;
-  assign _zz_348 = {32'd0, _zz_347};
-  assign _zz_349 = _zz_153;
-  assign _zz_350 = {31'd0, _zz_349};
-  assign _zz_351 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
-  assign _zz_352 = execute_INSTRUCTION[31 : 24];
-  assign _zz_353 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_354 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_355 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_356 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_357 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_358 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_359 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_360 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_361 = 1'b1;
-  assign _zz_362 = 1'b1;
-  assign _zz_363 = {_zz_65,_zz_64};
-  assign _zz_364 = 32'h0000106f;
-  assign _zz_365 = (decode_INSTRUCTION & 32'h0000107f);
-  assign _zz_366 = 32'h00001073;
-  assign _zz_367 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
-  assign _zz_368 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_369 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_370) == 32'h00000003),{(_zz_371 == _zz_372),{_zz_373,{_zz_374,_zz_375}}}}}};
-  assign _zz_370 = 32'h0000207f;
-  assign _zz_371 = (decode_INSTRUCTION & 32'h0000505f);
-  assign _zz_372 = 32'h00000003;
-  assign _zz_373 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
-  assign _zz_374 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_375 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_376) == 32'h00005013),{(_zz_377 == _zz_378),{_zz_379,{_zz_380,_zz_381}}}}}};
-  assign _zz_376 = 32'hbc00707f;
-  assign _zz_377 = (decode_INSTRUCTION & 32'hfc00307f);
-  assign _zz_378 = 32'h00001013;
-  assign _zz_379 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_380 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_381 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
-  assign _zz_382 = decode_INSTRUCTION[31];
-  assign _zz_383 = decode_INSTRUCTION[31];
-  assign _zz_384 = decode_INSTRUCTION[7];
-  assign _zz_385 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_386 = 1'b0;
-  assign _zz_387 = (((decode_INSTRUCTION & _zz_390) == 32'h02000030) != 1'b0);
-  assign _zz_388 = ((_zz_391 == _zz_392) != 1'b0);
-  assign _zz_389 = {(_zz_393 != 1'b0),{(_zz_394 != _zz_395),{_zz_396,{_zz_397,_zz_398}}}};
-  assign _zz_390 = 32'h02004074;
-  assign _zz_391 = (decode_INSTRUCTION & 32'h00203050);
-  assign _zz_392 = 32'h00000050;
-  assign _zz_393 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz_394 = {(_zz_399 == _zz_400),(_zz_401 == _zz_402)};
-  assign _zz_395 = 2'b00;
-  assign _zz_396 = ({_zz_96,_zz_403} != 2'b00);
-  assign _zz_397 = (_zz_404 != 1'b0);
-  assign _zz_398 = {(_zz_405 != _zz_406),{_zz_407,{_zz_408,_zz_409}}};
-  assign _zz_399 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_400 = 32'h00001050;
-  assign _zz_401 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_402 = 32'h00002050;
-  assign _zz_403 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_404 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_405 = {(_zz_410 == _zz_411),(_zz_412 == _zz_413)};
-  assign _zz_406 = 2'b00;
-  assign _zz_407 = ({_zz_414,{_zz_415,_zz_416}} != 3'b000);
-  assign _zz_408 = (_zz_417 != 1'b0);
-  assign _zz_409 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
-  assign _zz_410 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_411 = 32'h00005010;
-  assign _zz_412 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_413 = 32'h00005020;
-  assign _zz_414 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_415 = ((decode_INSTRUCTION & _zz_423) == 32'h00001010);
-  assign _zz_416 = ((decode_INSTRUCTION & _zz_424) == 32'h00001010);
-  assign _zz_417 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h00001000);
-  assign _zz_419 = 1'b0;
-  assign _zz_420 = ((_zz_426 == _zz_427) != 1'b0);
-  assign _zz_421 = ({_zz_428,_zz_429} != 2'b00);
-  assign _zz_422 = {(_zz_430 != _zz_431),{_zz_432,{_zz_433,_zz_434}}};
-  assign _zz_423 = 32'h00007034;
-  assign _zz_424 = 32'h02007054;
-  assign _zz_425 = 32'h00001000;
-  assign _zz_426 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_427 = 32'h00002000;
-  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00002000);
-  assign _zz_429 = ((decode_INSTRUCTION & _zz_436) == 32'h00001000);
-  assign _zz_430 = ((decode_INSTRUCTION & _zz_437) == 32'h00004004);
-  assign _zz_431 = 1'b0;
-  assign _zz_432 = ({_zz_97,{_zz_438,_zz_439}} != 3'b000);
-  assign _zz_433 = ({_zz_440,_zz_441} != 5'h0);
-  assign _zz_434 = {(_zz_442 != _zz_443),{_zz_444,{_zz_445,_zz_446}}};
-  assign _zz_435 = 32'h00002010;
-  assign _zz_436 = 32'h00005000;
-  assign _zz_437 = 32'h00004054;
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_447) == 32'h00000020);
-  assign _zz_439 = ((decode_INSTRUCTION & _zz_448) == 32'h00000020);
-  assign _zz_440 = ((decode_INSTRUCTION & _zz_449) == 32'h00002040);
-  assign _zz_441 = {(_zz_450 == _zz_451),{_zz_452,{_zz_453,_zz_454}}};
-  assign _zz_442 = ((decode_INSTRUCTION & _zz_455) == 32'h00000020);
-  assign _zz_443 = 1'b0;
-  assign _zz_444 = ({_zz_456,{_zz_457,_zz_458}} != 6'h0);
-  assign _zz_445 = ({_zz_459,_zz_460} != 5'h0);
-  assign _zz_446 = {(_zz_461 != _zz_462),{_zz_463,{_zz_464,_zz_465}}};
-  assign _zz_447 = 32'h00000034;
-  assign _zz_448 = 32'h00000064;
-  assign _zz_449 = 32'h00002040;
-  assign _zz_450 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_451 = 32'h00001040;
-  assign _zz_452 = ((decode_INSTRUCTION & _zz_466) == 32'h00000040);
-  assign _zz_453 = (_zz_467 == _zz_468);
-  assign _zz_454 = (_zz_469 == _zz_470);
-  assign _zz_455 = 32'h00000020;
-  assign _zz_456 = ((decode_INSTRUCTION & _zz_471) == 32'h00000008);
-  assign _zz_457 = (_zz_472 == _zz_473);
-  assign _zz_458 = {_zz_95,{_zz_474,_zz_475}};
-  assign _zz_459 = _zz_95;
-  assign _zz_460 = {_zz_476,{_zz_477,_zz_478}};
-  assign _zz_461 = {_zz_96,{_zz_479,_zz_480}};
-  assign _zz_462 = 6'h0;
-  assign _zz_463 = ({_zz_481,_zz_482} != 2'b00);
-  assign _zz_464 = (_zz_483 != _zz_484);
-  assign _zz_465 = {_zz_485,{_zz_486,_zz_487}};
-  assign _zz_466 = 32'h00000050;
-  assign _zz_467 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz_468 = 32'h00000040;
-  assign _zz_469 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_470 = 32'h0;
-  assign _zz_471 = 32'h00000008;
-  assign _zz_472 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_473 = 32'h00000040;
-  assign _zz_474 = (_zz_488 == _zz_489);
-  assign _zz_475 = {_zz_490,_zz_491};
-  assign _zz_476 = ((decode_INSTRUCTION & _zz_492) == 32'h00002010);
-  assign _zz_477 = (_zz_493 == _zz_494);
-  assign _zz_478 = {_zz_495,_zz_496};
-  assign _zz_479 = (_zz_497 == _zz_498);
-  assign _zz_480 = {_zz_499,{_zz_500,_zz_501}};
-  assign _zz_481 = _zz_95;
-  assign _zz_482 = (_zz_502 == _zz_503);
-  assign _zz_483 = {_zz_95,_zz_504};
-  assign _zz_484 = 2'b00;
-  assign _zz_485 = (_zz_505 != 1'b0);
-  assign _zz_486 = (_zz_506 != _zz_507);
-  assign _zz_487 = {_zz_508,{_zz_509,_zz_510}};
-  assign _zz_488 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_489 = 32'h00004020;
-  assign _zz_490 = ((decode_INSTRUCTION & _zz_511) == 32'h00000010);
-  assign _zz_491 = ((decode_INSTRUCTION & _zz_512) == 32'h00000020);
-  assign _zz_492 = 32'h00002030;
-  assign _zz_493 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_494 = 32'h00000010;
-  assign _zz_495 = ((decode_INSTRUCTION & _zz_513) == 32'h00002020);
-  assign _zz_496 = ((decode_INSTRUCTION & _zz_514) == 32'h00000020);
-  assign _zz_497 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_498 = 32'h00001010;
-  assign _zz_499 = ((decode_INSTRUCTION & _zz_515) == 32'h00002010);
-  assign _zz_500 = (_zz_516 == _zz_517);
-  assign _zz_501 = {_zz_518,_zz_519};
-  assign _zz_502 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_503 = 32'h00000020;
-  assign _zz_504 = ((decode_INSTRUCTION & _zz_520) == 32'h0);
-  assign _zz_505 = ((decode_INSTRUCTION & _zz_521) == 32'h00004010);
-  assign _zz_506 = (_zz_522 == _zz_523);
-  assign _zz_507 = 1'b0;
-  assign _zz_508 = ({_zz_524,_zz_525} != 4'b0000);
-  assign _zz_509 = (_zz_526 != _zz_527);
-  assign _zz_510 = {_zz_528,{_zz_529,_zz_530}};
-  assign _zz_511 = 32'h00000030;
-  assign _zz_512 = 32'h02000020;
-  assign _zz_513 = 32'h02002060;
-  assign _zz_514 = 32'h02003020;
-  assign _zz_515 = 32'h00002010;
-  assign _zz_516 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_517 = 32'h00000010;
-  assign _zz_518 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_519 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz_520 = 32'h00000020;
-  assign _zz_521 = 32'h00004014;
-  assign _zz_522 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_523 = 32'h00002010;
-  assign _zz_524 = ((decode_INSTRUCTION & _zz_531) == 32'h0);
-  assign _zz_525 = {(_zz_532 == _zz_533),{_zz_534,_zz_535}};
-  assign _zz_526 = ((decode_INSTRUCTION & _zz_536) == 32'h0);
-  assign _zz_527 = 1'b0;
-  assign _zz_528 = ({_zz_537,{_zz_538,_zz_539}} != 3'b000);
-  assign _zz_529 = ({_zz_540,_zz_541} != 2'b00);
-  assign _zz_530 = {(_zz_542 != _zz_543),(_zz_544 != _zz_545)};
-  assign _zz_531 = 32'h00000044;
-  assign _zz_532 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_533 = 32'h0;
-  assign _zz_534 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_535 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_536 = 32'h00000058;
-  assign _zz_537 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_538 = ((decode_INSTRUCTION & _zz_546) == 32'h00002010);
-  assign _zz_539 = ((decode_INSTRUCTION & _zz_547) == 32'h40000030);
-  assign _zz_540 = ((decode_INSTRUCTION & _zz_548) == 32'h00000004);
-  assign _zz_541 = _zz_94;
-  assign _zz_542 = {(_zz_549 == _zz_550),_zz_94};
-  assign _zz_543 = 2'b00;
-  assign _zz_544 = ((decode_INSTRUCTION & _zz_551) == 32'h00001004);
-  assign _zz_545 = 1'b0;
-  assign _zz_546 = 32'h00002014;
-  assign _zz_547 = 32'h40000034;
-  assign _zz_548 = 32'h00000014;
-  assign _zz_549 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_550 = 32'h00000004;
-  assign _zz_551 = 32'h00005054;
-  assign _zz_552 = execute_INSTRUCTION[31];
-  assign _zz_553 = execute_INSTRUCTION[31];
-  assign _zz_554 = execute_INSTRUCTION[7];
-  assign _zz_555 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_361) begin
-      _zz_221 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_execute_CfuPlugin_functionsIds_0 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000106f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000107f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00001073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000505f);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000003;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbc00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00001013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_362) begin
-      _zz_222 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_48) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_193                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_194                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_195                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_196                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_197                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_198                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_199                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_200                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_201                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_202                                            ), //i
-    .io_cpu_execute_address                    (_zz_203[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_88[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_204                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_205[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_206                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_207                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_208                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_209[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_210                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_211                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_212                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_213                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_214                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_215                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_216                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_217                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_218[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_219                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_220                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_363)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_223 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_223 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_223 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_223 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
@@ -1816,60 +1915,60 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_1)
-      `Input2Kind_defaultEncoding_RS : _zz_1_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_1_string = "IMM_I";
-      default : _zz_1_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `Input2Kind_defaultEncoding_RS : _zz_2_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_2_string = "IMM_I";
-      default : _zz_2_string = "?????";
+    case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `Input2Kind_defaultEncoding_RS : _zz_3_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_3_string = "IMM_I";
-      default : _zz_3_string = "?????";
+    case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1882,134 +1981,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_8_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8_string = "ECALL";
-      default : _zz_8_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9_string = "ECALL";
-      default : _zz_9_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_10_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10_string = "ECALL";
-      default : _zz_10_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_11_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_11_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_11_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_11_string = "JALR";
-      default : _zz_11_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_12_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_12_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12_string = "JALR";
-      default : _zz_12_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
-      default : _zz_15_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16_string = "SRA_1    ";
-      default : _zz_16_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17_string = "SRA_1    ";
-      default : _zz_17_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
-      default : _zz_18_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19_string = "AND_1";
-      default : _zz_19_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20_string = "AND_1";
-      default : _zz_20_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2022,30 +2121,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
-      default : _zz_21_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_22_string = "PC ";
-      default : _zz_22_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
-      default : _zz_23_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2057,27 +2156,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
-      default : _zz_24_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25_string = "BITWISE ";
-      default : _zz_25_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26_string = "BITWISE ";
-      default : _zz_26_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2090,30 +2189,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
-      default : _zz_27_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_28_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_28_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_28_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_28_string = "URS1        ";
-      default : _zz_28_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_29_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_29_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_29_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_29_string = "URS1        ";
-      default : _zz_29_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2124,10 +2223,10 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_32)
-      `Input2Kind_defaultEncoding_RS : _zz_32_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_32_string = "IMM_I";
-      default : _zz_32_string = "?????";
+    case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2140,12 +2239,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_33_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_33_string = "ECALL";
-      default : _zz_33_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2158,12 +2257,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_34_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_34_string = "ECALL";
-      default : _zz_34_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2176,12 +2275,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_35_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
-      default : _zz_35_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2194,48 +2293,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_36_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_36_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_36_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_36_string = "JALR";
-      default : _zz_36_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_39_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_39_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_39_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_39_string = "SRA_1    ";
-      default : _zz_39_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_40_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_40_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_40_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_40_string = "SRA_1    ";
-      default : _zz_40_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2248,12 +2347,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_42_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_42_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_42_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_42_string = "PC ";
-      default : _zz_42_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2266,12 +2365,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_43_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_43_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_43_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_43_string = "URS1        ";
-      default : _zz_43_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2283,95 +2382,95 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_44_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_44_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_44_string = "BITWISE ";
-      default : _zz_44_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_45_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_45_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_45_string = "AND_1";
-      default : _zz_45_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Input2Kind_defaultEncoding_RS : _zz_49_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_49_string = "IMM_I";
-      default : _zz_49_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_50)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_50_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_50_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_50_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_50_string = "ECALL";
-      default : _zz_50_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_52)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_52_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_52_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_52_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_52_string = "SRA_1    ";
-      default : _zz_52_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_53)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_53_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_53_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_53_string = "AND_1";
-      default : _zz_53_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_54)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_54_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_54_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_54_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_54_string = "PC ";
-      default : _zz_54_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_55)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_55_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_55_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_55_string = "BITWISE ";
-      default : _zz_55_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_56)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_56_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_56_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_56_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_56_string = "URS1        ";
-      default : _zz_56_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2384,80 +2483,80 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_58)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_58_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_58_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_58_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_58_string = "JALR";
-      default : _zz_58_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_99)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_99_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_99_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_99_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_99_string = "URS1        ";
-      default : _zz_99_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_100)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_100_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_100_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_100_string = "BITWISE ";
-      default : _zz_100_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_101)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_101_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_101_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_101_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_101_string = "PC ";
-      default : _zz_101_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_102)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_102_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_102_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_102_string = "AND_1";
-      default : _zz_102_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_103)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_103_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_103_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_103_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_103_string = "SRA_1    ";
-      default : _zz_103_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_104)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_104_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_104_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_104_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_104_string = "JALR";
-      default : _zz_104_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_105)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_105_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_105_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_105_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_105_string = "ECALL";
-      default : _zz_105_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_106)
-      `Input2Kind_defaultEncoding_RS : _zz_106_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_106_string = "IMM_I";
-      default : _zz_106_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2488,28 +2587,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2557,7 +2656,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_263) + $signed(_zz_271));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
@@ -2565,69 +2664,69 @@ module VexRiscv (
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign execute_SHIFT_RIGHT = _zz_273;
-  assign execute_REGFILE_WRITE_DATA = _zz_108;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_203[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_1;
-  assign _zz_2 = _zz_3;
-  assign decode_CfuPlugin_CFU_ENABLE = _zz_275[0];
-  assign decode_IS_RS2_SIGNED = _zz_276[0];
-  assign decode_IS_RS1_SIGNED = _zz_277[0];
-  assign decode_IS_DIV = _zz_278[0];
+  assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
+  assign decode_IS_RS2_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[30];
+  assign decode_IS_DIV = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_279[0];
-  assign _zz_4 = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_ENV_CTRL = _zz_8;
-  assign _zz_9 = _zz_10;
-  assign decode_IS_CSR = _zz_280[0];
-  assign _zz_11 = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_SHIFT_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_ALU_BITWISE_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_SRC_LESS_UNSIGNED = _zz_281[0];
-  assign decode_MEMORY_MANAGMENT = _zz_282[0];
+  assign decode_IS_MUL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_283[0];
+  assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_284[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_285[0];
-  assign decode_SRC2_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_ALU_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
-  assign decode_SRC1_CTRL = _zz_27;
-  assign _zz_28 = _zz_29;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
-  always @ (*) begin
-    _zz_30 = memory_CfuPlugin_CFU_IN_FLIGHT;
-    if(memory_arbitration_isStuck)begin
-      _zz_30 = 1'b0;
+  always @(*) begin
+    _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_CfuPlugin_CFU_IN_FLIGHT;
+    if(memory_arbitration_isStuck) begin
+      _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_31 = execute_CfuPlugin_CFU_IN_FLIGHT;
-    if(execute_arbitration_isStuck)begin
-      _zz_31 = 1'b0;
+  always @(*) begin
+    _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT = execute_CfuPlugin_CFU_IN_FLIGHT;
+    if(execute_arbitration_isStuck) begin
+      _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT = 1'b0;
     end
   end
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
-  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_32;
+  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
@@ -2642,22 +2741,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_33;
-  assign execute_ENV_CTRL = _zz_34;
-  assign writeBack_ENV_CTRL = _zz_35;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_130;
-  assign execute_BRANCH_CTRL = _zz_36;
-  assign decode_RS2_USE = _zz_286[0];
-  assign decode_RS1_USE = _zz_287[0];
-  always @ (*) begin
-    _zz_37 = execute_REGFILE_WRITE_DATA;
-    if(_zz_224)begin
-      _zz_37 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
+  assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2667,142 +2766,142 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_119)begin
-      if((_zz_120 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_121;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
-        if(_zz_123)begin
-          decode_RS2 = _zz_57;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_227)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_125)begin
-          decode_RS2 = _zz_38;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_228)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_127)begin
-          decode_RS2 = _zz_37;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_119)begin
-      if((_zz_120 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_121;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
-        if(_zz_122)begin
-          decode_RS1 = _zz_57;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_227)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_124)begin
-          decode_RS1 = _zz_38;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_228)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_126)begin
-          decode_RS1 = _zz_37;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_38 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_38 = _zz_116;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_38 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_229)begin
-      _zz_38 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      _zz_38 = memory_CfuPlugin_rsp_payload_outputs_0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_39;
-  assign execute_SHIFT_CTRL = _zz_40;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_41 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_42;
-  assign execute_SRC1_CTRL = _zz_43;
-  assign decode_SRC_USE_SUB_LESS = _zz_288[0];
-  assign decode_SRC_ADD_ZERO = _zz_289[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_44;
-  assign execute_SRC2 = _zz_114;
-  assign execute_SRC1 = _zz_109;
-  assign execute_ALU_BITWISE_CTRL = _zz_45;
-  assign _zz_46 = writeBack_INSTRUCTION;
-  assign _zz_47 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_48 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_48 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_290[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_364) == 32'h00000003),{(_zz_365 == _zz_366),{_zz_367,{_zz_368,_zz_369}}}}}}} != 22'h0);
-  always @ (*) begin
-    _zz_57 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_57 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_262)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_57 = _zz_334;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_57 = _zz_335;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2814,214 +2913,205 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_291[0];
-  assign decode_FLUSH_ALL = _zz_292[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[4];
+  assign decode_FLUSH_ALL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_230)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_231)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_232)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_233)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_58;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_59 = execute_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_59 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_execute_to_memory_FORMAL_PC_NEXT = execute_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_execute_to_memory_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_60 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_60 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_117 || _zz_118)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_234)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_234)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_219 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_235)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_224)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if((CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready)))begin
+    if(when_CfuPlugin_l175) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(_zz_236)begin
+    if(_zz_when_1) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_236)begin
+    if(_zz_when_1) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_229)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      if((! memory_CfuPlugin_rsp_valid))begin
+    if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
+      if(when_CfuPlugin_l208) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(CfuPlugin_joinException_valid)begin
-      memory_arbitration_removeIt = 1'b1;
-    end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
-    memory_arbitration_flushNext = 1'b0;
-    if(CfuPlugin_joinException_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
-  end
-
-  always @ (*) begin
+  assign memory_arbitration_flushNext = 1'b0;
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_237)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_238)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3030,51 +3120,53 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_237)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_238)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_235)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_237)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_238)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_237)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_238)begin
-      case(_zz_239)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3087,59 +3179,65 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_61 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_62 = (_zz_61 & (~ _zz_293));
-  assign _zz_63 = _zz_62[3];
-  assign _zz_64 = (_zz_62[1] || _zz_63);
-  assign _zz_65 = (_zz_62[2] || _zz_63);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_223;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_295);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3147,265 +3245,280 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_66 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_66);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_66);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_67 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_67);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_67);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_68 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_68);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_68);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_69;
-  assign _zz_69 = ((1'b0 && (! _zz_70)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_70 = _zz_71;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_70;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_72)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_72 = _zz_73;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_72;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_74;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_75 = _zz_296[11];
-  always @ (*) begin
-    _zz_76[18] = _zz_75;
-    _zz_76[17] = _zz_75;
-    _zz_76[16] = _zz_75;
-    _zz_76[15] = _zz_75;
-    _zz_76[14] = _zz_75;
-    _zz_76[13] = _zz_75;
-    _zz_76[12] = _zz_75;
-    _zz_76[11] = _zz_75;
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7] = _zz_75;
-    _zz_76[6] = _zz_75;
-    _zz_76[5] = _zz_75;
-    _zz_76[4] = _zz_75;
-    _zz_76[3] = _zz_75;
-    _zz_76[2] = _zz_75;
-    _zz_76[1] = _zz_75;
-    _zz_76[0] = _zz_75;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_297[31]));
-    if(_zz_81)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_77 = _zz_298[19];
-  always @ (*) begin
-    _zz_78[10] = _zz_77;
-    _zz_78[9] = _zz_77;
-    _zz_78[8] = _zz_77;
-    _zz_78[7] = _zz_77;
-    _zz_78[6] = _zz_77;
-    _zz_78[5] = _zz_77;
-    _zz_78[4] = _zz_77;
-    _zz_78[3] = _zz_77;
-    _zz_78[2] = _zz_77;
-    _zz_78[1] = _zz_77;
-    _zz_78[0] = _zz_77;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_79 = _zz_299[11];
-  always @ (*) begin
-    _zz_80[18] = _zz_79;
-    _zz_80[17] = _zz_79;
-    _zz_80[16] = _zz_79;
-    _zz_80[15] = _zz_79;
-    _zz_80[14] = _zz_79;
-    _zz_80[13] = _zz_79;
-    _zz_80[12] = _zz_79;
-    _zz_80[11] = _zz_79;
-    _zz_80[10] = _zz_79;
-    _zz_80[9] = _zz_79;
-    _zz_80[8] = _zz_79;
-    _zz_80[7] = _zz_79;
-    _zz_80[6] = _zz_79;
-    _zz_80[5] = _zz_79;
-    _zz_80[4] = _zz_79;
-    _zz_80[3] = _zz_79;
-    _zz_80[2] = _zz_79;
-    _zz_80[1] = _zz_79;
-    _zz_80[0] = _zz_79;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_81 = _zz_300[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_81 = _zz_301[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_82 = _zz_302[19];
-  always @ (*) begin
-    _zz_83[10] = _zz_82;
-    _zz_83[9] = _zz_82;
-    _zz_83[8] = _zz_82;
-    _zz_83[7] = _zz_82;
-    _zz_83[6] = _zz_82;
-    _zz_83[5] = _zz_82;
-    _zz_83[4] = _zz_82;
-    _zz_83[3] = _zz_82;
-    _zz_83[2] = _zz_82;
-    _zz_83[1] = _zz_82;
-    _zz_83[0] = _zz_82;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_84 = _zz_303[11];
-  always @ (*) begin
-    _zz_85[18] = _zz_84;
-    _zz_85[17] = _zz_84;
-    _zz_85[16] = _zz_84;
-    _zz_85[15] = _zz_84;
-    _zz_85[14] = _zz_84;
-    _zz_85[13] = _zz_84;
-    _zz_85[12] = _zz_84;
-    _zz_85[11] = _zz_84;
-    _zz_85[10] = _zz_84;
-    _zz_85[9] = _zz_84;
-    _zz_85[8] = _zz_84;
-    _zz_85[7] = _zz_84;
-    _zz_85[6] = _zz_84;
-    _zz_85[5] = _zz_84;
-    _zz_85[4] = _zz_84;
-    _zz_85[3] = _zz_84;
-    _zz_85[2] = _zz_84;
-    _zz_85[1] = _zz_84;
-    _zz_85[0] = _zz_84;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_83,{{{_zz_382,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_85,{{{_zz_383,_zz_384},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_194 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_195 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_196 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_195;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_198 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_199 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_200 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_233)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_231)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_201 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_231)begin
-      _zz_201 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_232)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_230)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_232)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_230)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_193 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_220 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3413,168 +3526,178 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_202 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_203 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_88 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_88 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_88 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_219 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_204 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_205 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_204;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_205;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_206 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_206 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_207 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_208 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_209 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_240)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_240)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_240)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_304};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_305};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_89 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_90[31] = _zz_89;
-    _zz_90[30] = _zz_89;
-    _zz_90[29] = _zz_89;
-    _zz_90[28] = _zz_89;
-    _zz_90[27] = _zz_89;
-    _zz_90[26] = _zz_89;
-    _zz_90[25] = _zz_89;
-    _zz_90[24] = _zz_89;
-    _zz_90[23] = _zz_89;
-    _zz_90[22] = _zz_89;
-    _zz_90[21] = _zz_89;
-    _zz_90[20] = _zz_89;
-    _zz_90[19] = _zz_89;
-    _zz_90[18] = _zz_89;
-    _zz_90[17] = _zz_89;
-    _zz_90[16] = _zz_89;
-    _zz_90[15] = _zz_89;
-    _zz_90[14] = _zz_89;
-    _zz_90[13] = _zz_89;
-    _zz_90[12] = _zz_89;
-    _zz_90[11] = _zz_89;
-    _zz_90[10] = _zz_89;
-    _zz_90[9] = _zz_89;
-    _zz_90[8] = _zz_89;
-    _zz_90[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_91 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_92[31] = _zz_91;
-    _zz_92[30] = _zz_91;
-    _zz_92[29] = _zz_91;
-    _zz_92[28] = _zz_91;
-    _zz_92[27] = _zz_91;
-    _zz_92[26] = _zz_91;
-    _zz_92[25] = _zz_91;
-    _zz_92[24] = _zz_91;
-    _zz_92[23] = _zz_91;
-    _zz_92[22] = _zz_91;
-    _zz_92[21] = _zz_91;
-    _zz_92[20] = _zz_91;
-    _zz_92[19] = _zz_91;
-    _zz_92[18] = _zz_91;
-    _zz_92[17] = _zz_91;
-    _zz_92[16] = _zz_91;
-    _zz_92[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_260)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_90;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_92;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3593,62 +3716,63 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_94 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_95 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_96 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_97 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_98 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_93 = {1'b0,{(_zz_97 != 1'b0),{(_zz_98 != 1'b0),{(_zz_98 != 1'b0),{(_zz_385 != _zz_386),{_zz_387,{_zz_388,_zz_389}}}}}}};
-  assign _zz_99 = _zz_93[2 : 1];
-  assign _zz_56 = _zz_99;
-  assign _zz_100 = _zz_93[7 : 6];
-  assign _zz_55 = _zz_100;
-  assign _zz_101 = _zz_93[9 : 8];
-  assign _zz_54 = _zz_101;
-  assign _zz_102 = _zz_93[19 : 18];
-  assign _zz_53 = _zz_102;
-  assign _zz_103 = _zz_93[22 : 21];
-  assign _zz_52 = _zz_103;
-  assign _zz_104 = _zz_93[24 : 23];
-  assign _zz_51 = _zz_104;
-  assign _zz_105 = _zz_93[27 : 26];
-  assign _zz_50 = _zz_105;
-  assign _zz_106 = _zz_93[33 : 33];
-  assign _zz_49 = _zz_106;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_221;
-  assign decode_RegFilePlugin_rs2Data = _zz_222;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_47 && writeBack_arbitration_isFiring);
-    if(_zz_107)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_46[11 : 7];
-    if(_zz_107)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_57;
-    if(_zz_107)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3657,353 +3781,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_108 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_108 = {31'd0, _zz_306};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_108 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_109 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_109 = {29'd0, _zz_307};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_109 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_109 = {27'd0, _zz_308};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_110 = _zz_309[11];
-  always @ (*) begin
-    _zz_111[19] = _zz_110;
-    _zz_111[18] = _zz_110;
-    _zz_111[17] = _zz_110;
-    _zz_111[16] = _zz_110;
-    _zz_111[15] = _zz_110;
-    _zz_111[14] = _zz_110;
-    _zz_111[13] = _zz_110;
-    _zz_111[12] = _zz_110;
-    _zz_111[11] = _zz_110;
-    _zz_111[10] = _zz_110;
-    _zz_111[9] = _zz_110;
-    _zz_111[8] = _zz_110;
-    _zz_111[7] = _zz_110;
-    _zz_111[6] = _zz_110;
-    _zz_111[5] = _zz_110;
-    _zz_111[4] = _zz_110;
-    _zz_111[3] = _zz_110;
-    _zz_111[2] = _zz_110;
-    _zz_111[1] = _zz_110;
-    _zz_111[0] = _zz_110;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_112 = _zz_310[11];
-  always @ (*) begin
-    _zz_113[19] = _zz_112;
-    _zz_113[18] = _zz_112;
-    _zz_113[17] = _zz_112;
-    _zz_113[16] = _zz_112;
-    _zz_113[15] = _zz_112;
-    _zz_113[14] = _zz_112;
-    _zz_113[13] = _zz_112;
-    _zz_113[12] = _zz_112;
-    _zz_113[11] = _zz_112;
-    _zz_113[10] = _zz_112;
-    _zz_113[9] = _zz_112;
-    _zz_113[8] = _zz_112;
-    _zz_113[7] = _zz_112;
-    _zz_113[6] = _zz_112;
-    _zz_113[5] = _zz_112;
-    _zz_113[4] = _zz_112;
-    _zz_113[3] = _zz_112;
-    _zz_113[2] = _zz_112;
-    _zz_113[1] = _zz_112;
-    _zz_113[0] = _zz_112;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_114 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_114 = {_zz_111,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_114 = {_zz_113,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_114 = _zz_41;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_311;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_115[0] = execute_SRC1[31];
-    _zz_115[1] = execute_SRC1[30];
-    _zz_115[2] = execute_SRC1[29];
-    _zz_115[3] = execute_SRC1[28];
-    _zz_115[4] = execute_SRC1[27];
-    _zz_115[5] = execute_SRC1[26];
-    _zz_115[6] = execute_SRC1[25];
-    _zz_115[7] = execute_SRC1[24];
-    _zz_115[8] = execute_SRC1[23];
-    _zz_115[9] = execute_SRC1[22];
-    _zz_115[10] = execute_SRC1[21];
-    _zz_115[11] = execute_SRC1[20];
-    _zz_115[12] = execute_SRC1[19];
-    _zz_115[13] = execute_SRC1[18];
-    _zz_115[14] = execute_SRC1[17];
-    _zz_115[15] = execute_SRC1[16];
-    _zz_115[16] = execute_SRC1[15];
-    _zz_115[17] = execute_SRC1[14];
-    _zz_115[18] = execute_SRC1[13];
-    _zz_115[19] = execute_SRC1[12];
-    _zz_115[20] = execute_SRC1[11];
-    _zz_115[21] = execute_SRC1[10];
-    _zz_115[22] = execute_SRC1[9];
-    _zz_115[23] = execute_SRC1[8];
-    _zz_115[24] = execute_SRC1[7];
-    _zz_115[25] = execute_SRC1[6];
-    _zz_115[26] = execute_SRC1[5];
-    _zz_115[27] = execute_SRC1[4];
-    _zz_115[28] = execute_SRC1[3];
-    _zz_115[29] = execute_SRC1[2];
-    _zz_115[30] = execute_SRC1[1];
-    _zz_115[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_115 : execute_SRC1);
-  always @ (*) begin
-    _zz_116[0] = memory_SHIFT_RIGHT[31];
-    _zz_116[1] = memory_SHIFT_RIGHT[30];
-    _zz_116[2] = memory_SHIFT_RIGHT[29];
-    _zz_116[3] = memory_SHIFT_RIGHT[28];
-    _zz_116[4] = memory_SHIFT_RIGHT[27];
-    _zz_116[5] = memory_SHIFT_RIGHT[26];
-    _zz_116[6] = memory_SHIFT_RIGHT[25];
-    _zz_116[7] = memory_SHIFT_RIGHT[24];
-    _zz_116[8] = memory_SHIFT_RIGHT[23];
-    _zz_116[9] = memory_SHIFT_RIGHT[22];
-    _zz_116[10] = memory_SHIFT_RIGHT[21];
-    _zz_116[11] = memory_SHIFT_RIGHT[20];
-    _zz_116[12] = memory_SHIFT_RIGHT[19];
-    _zz_116[13] = memory_SHIFT_RIGHT[18];
-    _zz_116[14] = memory_SHIFT_RIGHT[17];
-    _zz_116[15] = memory_SHIFT_RIGHT[16];
-    _zz_116[16] = memory_SHIFT_RIGHT[15];
-    _zz_116[17] = memory_SHIFT_RIGHT[14];
-    _zz_116[18] = memory_SHIFT_RIGHT[13];
-    _zz_116[19] = memory_SHIFT_RIGHT[12];
-    _zz_116[20] = memory_SHIFT_RIGHT[11];
-    _zz_116[21] = memory_SHIFT_RIGHT[10];
-    _zz_116[22] = memory_SHIFT_RIGHT[9];
-    _zz_116[23] = memory_SHIFT_RIGHT[8];
-    _zz_116[24] = memory_SHIFT_RIGHT[7];
-    _zz_116[25] = memory_SHIFT_RIGHT[6];
-    _zz_116[26] = memory_SHIFT_RIGHT[5];
-    _zz_116[27] = memory_SHIFT_RIGHT[4];
-    _zz_116[28] = memory_SHIFT_RIGHT[3];
-    _zz_116[29] = memory_SHIFT_RIGHT[2];
-    _zz_116[30] = memory_SHIFT_RIGHT[1];
-    _zz_116[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_117 = 1'b0;
-    if(_zz_241)begin
-      if(_zz_242)begin
-        if(_zz_122)begin
-          _zz_117 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_243)begin
-      if(_zz_244)begin
-        if(_zz_124)begin
-          _zz_117 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_245)begin
-      if(_zz_246)begin
-        if(_zz_126)begin
-          _zz_117 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_117 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_118 = 1'b0;
-    if(_zz_241)begin
-      if(_zz_242)begin
-        if(_zz_123)begin
-          _zz_118 = 1'b1;
-        end
-      end
-    end
-    if(_zz_243)begin
-      if(_zz_244)begin
-        if(_zz_125)begin
-          _zz_118 = 1'b1;
-        end
-      end
-    end
-    if(_zz_245)begin
-      if(_zz_246)begin
-        if(_zz_127)begin
-          _zz_118 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_118 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_122 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_123 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_124 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_125 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_126 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_127 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_128 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_128 == 3'b000)) begin
-        _zz_129 = execute_BranchPlugin_eq;
-    end else if((_zz_128 == 3'b001)) begin
-        _zz_129 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_128 & 3'b101) == 3'b101))) begin
-        _zz_129 = (! execute_SRC_LESS);
-    end else begin
-        _zz_129 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_130 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_130 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_130 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_130 = _zz_129;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_131 = _zz_318[11];
-  always @ (*) begin
-    _zz_132[19] = _zz_131;
-    _zz_132[18] = _zz_131;
-    _zz_132[17] = _zz_131;
-    _zz_132[16] = _zz_131;
-    _zz_132[15] = _zz_131;
-    _zz_132[14] = _zz_131;
-    _zz_132[13] = _zz_131;
-    _zz_132[12] = _zz_131;
-    _zz_132[11] = _zz_131;
-    _zz_132[10] = _zz_131;
-    _zz_132[9] = _zz_131;
-    _zz_132[8] = _zz_131;
-    _zz_132[7] = _zz_131;
-    _zz_132[6] = _zz_131;
-    _zz_132[5] = _zz_131;
-    _zz_132[4] = _zz_131;
-    _zz_132[3] = _zz_131;
-    _zz_132[2] = _zz_131;
-    _zz_132[1] = _zz_131;
-    _zz_132[0] = _zz_131;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_133 = _zz_319[19];
-  always @ (*) begin
-    _zz_134[10] = _zz_133;
-    _zz_134[9] = _zz_133;
-    _zz_134[8] = _zz_133;
-    _zz_134[7] = _zz_133;
-    _zz_134[6] = _zz_133;
-    _zz_134[5] = _zz_133;
-    _zz_134[4] = _zz_133;
-    _zz_134[3] = _zz_133;
-    _zz_134[2] = _zz_133;
-    _zz_134[1] = _zz_133;
-    _zz_134[0] = _zz_133;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_135 = _zz_320[11];
-  always @ (*) begin
-    _zz_136[18] = _zz_135;
-    _zz_136[17] = _zz_135;
-    _zz_136[16] = _zz_135;
-    _zz_136[15] = _zz_135;
-    _zz_136[14] = _zz_135;
-    _zz_136[13] = _zz_135;
-    _zz_136[12] = _zz_135;
-    _zz_136[11] = _zz_135;
-    _zz_136[10] = _zz_135;
-    _zz_136[9] = _zz_135;
-    _zz_136[8] = _zz_135;
-    _zz_136[7] = _zz_135;
-    _zz_136[6] = _zz_135;
-    _zz_136[5] = _zz_135;
-    _zz_136[4] = _zz_135;
-    _zz_136[3] = _zz_135;
-    _zz_136[2] = _zz_135;
-    _zz_136[1] = _zz_135;
-    _zz_136[0] = _zz_135;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_137 = (_zz_321[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_137 = _zz_322[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_137 = _zz_323[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_137);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -4014,183 +4161,195 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_138 = _zz_324[11];
-  always @ (*) begin
-    _zz_139[19] = _zz_138;
-    _zz_139[18] = _zz_138;
-    _zz_139[17] = _zz_138;
-    _zz_139[16] = _zz_138;
-    _zz_139[15] = _zz_138;
-    _zz_139[14] = _zz_138;
-    _zz_139[13] = _zz_138;
-    _zz_139[12] = _zz_138;
-    _zz_139[11] = _zz_138;
-    _zz_139[10] = _zz_138;
-    _zz_139[9] = _zz_138;
-    _zz_139[8] = _zz_138;
-    _zz_139[7] = _zz_138;
-    _zz_139[6] = _zz_138;
-    _zz_139[5] = _zz_138;
-    _zz_139[4] = _zz_138;
-    _zz_139[3] = _zz_138;
-    _zz_139[2] = _zz_138;
-    _zz_139[1] = _zz_138;
-    _zz_139[0] = _zz_138;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_139,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_141,{{{_zz_552,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_143,{{{_zz_553,_zz_554},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_327};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_140 = _zz_325[19];
-  always @ (*) begin
-    _zz_141[10] = _zz_140;
-    _zz_141[9] = _zz_140;
-    _zz_141[8] = _zz_140;
-    _zz_141[7] = _zz_140;
-    _zz_141[6] = _zz_140;
-    _zz_141[5] = _zz_140;
-    _zz_141[4] = _zz_140;
-    _zz_141[3] = _zz_140;
-    _zz_141[2] = _zz_140;
-    _zz_141[1] = _zz_140;
-    _zz_141[0] = _zz_140;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_142 = _zz_326[11];
-  always @ (*) begin
-    _zz_143[18] = _zz_142;
-    _zz_143[17] = _zz_142;
-    _zz_143[16] = _zz_142;
-    _zz_143[15] = _zz_142;
-    _zz_143[14] = _zz_142;
-    _zz_143[13] = _zz_142;
-    _zz_143[12] = _zz_142;
-    _zz_143[11] = _zz_142;
-    _zz_143[10] = _zz_142;
-    _zz_143[9] = _zz_142;
-    _zz_143[8] = _zz_142;
-    _zz_143[7] = _zz_142;
-    _zz_143[6] = _zz_142;
-    _zz_143[5] = _zz_142;
-    _zz_143[4] = _zz_142;
-    _zz_143[3] = _zz_142;
-    _zz_143[2] = _zz_142;
-    _zz_143[1] = _zz_142;
-    _zz_143[0] = _zz_142;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
-  always @ (*) begin
+  always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(1'b0)begin
+    if(when_BranchPlugin_l296) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
+  assign when_BranchPlugin_l296 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_144 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_145 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_146 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_147 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_148 = _zz_328[0];
-  assign _zz_149 = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
-  assign _zz_150 = _zz_330[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_234)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(_zz_236)begin
+    if(_zz_when_1) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(CfuPlugin_joinException_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
-    end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4201,8 +4360,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4212,135 +4371,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_247)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_248)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_249)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_248)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_249)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4353,39 +4521,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_247)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_247)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_261)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_250)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4398,8 +4576,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_250)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4418,149 +4596,215 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_332) + $signed(_zz_333));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_229)begin
-      if(_zz_251)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_252)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_337);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_151 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_151[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_338);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_339 : _zz_340);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_341[31:0];
-  assign _zz_152 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_153 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_154 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_155[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_155[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_157 = (_zz_156 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_157 != 32'h0);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
   assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign when_CfuPlugin_l171 = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
+  assign when_CfuPlugin_l171_1 = (! execute_arbitration_isStuckByOthers);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign execute_CfuPlugin_functionsIds_0 = _zz_351;
+  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
-  assign _zz_158 = _zz_352[7];
-  always @ (*) begin
-    _zz_159[23] = _zz_158;
-    _zz_159[22] = _zz_158;
-    _zz_159[21] = _zz_158;
-    _zz_159[20] = _zz_158;
-    _zz_159[19] = _zz_158;
-    _zz_159[18] = _zz_158;
-    _zz_159[17] = _zz_158;
-    _zz_159[16] = _zz_158;
-    _zz_159[15] = _zz_158;
-    _zz_159[14] = _zz_158;
-    _zz_159[13] = _zz_158;
-    _zz_159[12] = _zz_158;
-    _zz_159[11] = _zz_158;
-    _zz_159[10] = _zz_158;
-    _zz_159[9] = _zz_158;
-    _zz_159[8] = _zz_158;
-    _zz_159[7] = _zz_158;
-    _zz_159[6] = _zz_158;
-    _zz_159[5] = _zz_158;
-    _zz_159[4] = _zz_158;
-    _zz_159[3] = _zz_158;
-    _zz_159[2] = _zz_158;
-    _zz_159[1] = _zz_158;
-    _zz_159[0] = _zz_158;
+  assign _zz_CfuPlugin_bus_cmd_payload_inputs_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[23] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[22] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[21] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[20] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[19] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[18] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[17] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[16] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[15] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[14] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[13] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[12] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[11] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[10] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[9] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[8] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[7] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[6] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[5] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[4] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[3] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[2] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[1] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[0] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
       `Input2Kind_defaultEncoding_RS : begin
-        _zz_160 = execute_RS2;
+        _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
-        _zz_160 = {_zz_159,execute_INSTRUCTION[31 : 24]};
+        _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = {_zz_CfuPlugin_bus_cmd_payload_inputs_1_1,execute_INSTRUCTION[31 : 24]};
       end
     endcase
   end
 
-  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_160;
+  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_s2mPipe_rValid);
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_s2mPipe_rValid);
-  assign memory_CfuPlugin_rsp_payload_response_ok = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_response_ok : CfuPlugin_bus_rsp_payload_response_ok);
   assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
-  always @ (*) begin
-    CfuPlugin_joinException_valid = 1'b0;
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      if(memory_arbitration_isValid)begin
-        CfuPlugin_joinException_valid = (! memory_CfuPlugin_rsp_payload_response_ok);
-      end
-    end
-  end
-
-  assign CfuPlugin_joinException_payload_code = 4'b1111;
-  assign CfuPlugin_joinException_payload_badAddr = 32'h0;
-  always @ (*) begin
+  assign when_Stream_l365_1 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
+  always @(*) begin
     memory_CfuPlugin_rsp_ready = 1'b0;
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+    if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
       memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign _zz_29 = decode_SRC1_CTRL;
-  assign _zz_27 = _zz_56;
-  assign _zz_43 = decode_to_execute_SRC1_CTRL;
-  assign _zz_26 = decode_ALU_CTRL;
-  assign _zz_24 = _zz_55;
-  assign _zz_44 = decode_to_execute_ALU_CTRL;
-  assign _zz_23 = decode_SRC2_CTRL;
-  assign _zz_21 = _zz_54;
-  assign _zz_42 = decode_to_execute_SRC2_CTRL;
-  assign _zz_20 = decode_ALU_BITWISE_CTRL;
-  assign _zz_18 = _zz_53;
-  assign _zz_45 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_17 = decode_SHIFT_CTRL;
-  assign _zz_14 = execute_SHIFT_CTRL;
-  assign _zz_15 = _zz_52;
-  assign _zz_40 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_39 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_12 = decode_BRANCH_CTRL;
-  assign _zz_58 = _zz_51;
-  assign _zz_36 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_10 = decode_ENV_CTRL;
-  assign _zz_7 = execute_ENV_CTRL;
-  assign _zz_5 = memory_ENV_CTRL;
-  assign _zz_8 = _zz_50;
-  assign _zz_34 = decode_to_execute_ENV_CTRL;
-  assign _zz_33 = execute_to_memory_ENV_CTRL;
-  assign _zz_35 = memory_to_writeBack_ENV_CTRL;
-  assign _zz_3 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_1 = _zz_49;
-  assign _zz_32 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  assign when_CfuPlugin_l208 = (! memory_CfuPlugin_rsp_valid);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4581,240 +4825,274 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_161 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_161[12 : 0] = 13'h1000;
-      _zz_161[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_162 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_162[3 : 0] = 4'b1011;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
     end
   end
 
-  always @ (*) begin
-    _zz_163 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_163[4 : 0] = 5'h16;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
     end
   end
 
-  always @ (*) begin
-    _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_164[5 : 0] = 6'h21;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
     end
   end
 
-  always @ (*) begin
-    _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_165[31 : 30] = CsrPlugin_misa_base;
-      _zz_165[25 : 0] = CsrPlugin_misa_extensions;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_166[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_166[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_166[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_167[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_167[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_167[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_168[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_168[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_168[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_169[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_169[1 : 0] = CsrPlugin_mtvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_170[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_171[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_172[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_172[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_173[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_174 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_174[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_175[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_176[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_177[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_178[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_179[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_180[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_181[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_182[31 : 0] = _zz_156;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_183 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_183[31 : 0] = _zz_157;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_161 | _zz_162) | (_zz_163 | _zz_164)) | ((_zz_555 | _zz_165) | (_zz_166 | _zz_167))) | (((_zz_168 | _zz_169) | (_zz_170 | _zz_171)) | ((_zz_172 | _zz_173) | (_zz_174 | _zz_175)))) | (((_zz_176 | _zz_177) | (_zz_178 | _zz_179)) | ((_zz_180 | _zz_181) | (_zz_182 | _zz_183))));
-  assign iBusWishbone_ADR = {_zz_360,_zz_184};
-  assign iBusWishbone_CTI = ((_zz_184 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_253)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_253)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_185;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_191 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_187 = dBus_cmd_valid;
-  assign _zz_189 = dBus_cmd_payload_wr;
-  assign _zz_190 = (_zz_186 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_188 && (_zz_189 || _zz_190));
-  assign dBusWishbone_ADR = ((_zz_191 ? {{dBus_cmd_payload_address[31 : 5],_zz_186},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_191 ? (_zz_190 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_189 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_189;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_188 = (_zz_187 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_187;
-  assign dBusWishbone_STB = _zz_187;
-  assign dBus_rsp_valid = _zz_192;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_71 <= 1'b0;
-      _zz_73 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_86;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_87;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_107 <= 1'b1;
-      _zz_119 <= 1'b0;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4835,7 +5113,7 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_156 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_CfuPlugin_hold <= 1'b0;
       execute_CfuPlugin_fired <= 1'b0;
       CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
@@ -4843,155 +5121,155 @@ module VexRiscv (
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
-      _zz_184 <= 3'b000;
-      _zz_185 <= 1'b0;
-      _zz_186 <= 3'b000;
-      _zz_192 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_71 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_69)begin
-        _zz_71 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_73 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_73 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_254)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_107 <= 1'b0;
-      _zz_119 <= (_zz_47 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_255)begin
-        if(_zz_256)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_257)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_258)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_237)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5002,8 +5280,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_238)begin
-        case(_zz_239)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5013,162 +5291,158 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_146,{_zz_145,_zz_144}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(execute_CfuPlugin_schedule)begin
+      if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
       end
-      if(CfuPlugin_bus_cmd_ready)begin
+      if(CfuPlugin_bus_cmd_ready) begin
         execute_CfuPlugin_hold <= 1'b0;
       end
-      if((CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready))begin
+      if(when_CfuPlugin_l171) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if((! execute_arbitration_isStuckByOthers))begin
+      if(when_CfuPlugin_l171_1) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
-      if(memory_CfuPlugin_rsp_ready)begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_259)begin
+      if(when_Stream_l365_1) begin
         CfuPlugin_bus_rsp_s2mPipe_rValid <= CfuPlugin_bus_rsp_valid;
       end
-      if((! memory_arbitration_isStuck))begin
-        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_31;
+      if(when_Pipeline_l124_61) begin
+        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_353[0];
-          CsrPlugin_mstatus_MIE <= _zz_354[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_356[0];
-          CsrPlugin_mie_MTIE <= _zz_357[0];
-          CsrPlugin_mie_MSIE <= _zz_358[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_156 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_253)begin
-        if(iBusWishbone_ACK)begin
-          _zz_184 <= (_zz_184 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_185 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_187 && _zz_188))begin
-        _zz_186 <= (_zz_186 + 3'b001);
-        if(_zz_190)begin
-          _zz_186 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_192 <= ((_zz_187 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_74 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_254)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_120 <= _zz_46[11 : 7];
-    _zz_121 <= _zz_57;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_234)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_148 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_148 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(_zz_236)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_150 ? BranchPlugin_branchExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_150 ? BranchPlugin_branchExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
+    if(_zz_when_1) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? BranchPlugin_branchExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? BranchPlugin_branchExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
     end
-    if(CfuPlugin_joinException_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CfuPlugin_joinException_payload_code;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CfuPlugin_joinException_payload_badAddr;
-    end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_255)begin
-      if(_zz_256)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_257)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_258)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_237)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -5176,343 +5450,342 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_229)begin
-      if(_zz_251)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_342[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_252)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_154 ? (~ _zz_155) : _zz_155) + _zz_348);
-      memory_DivPlugin_rs2 <= ((_zz_153 ? (~ execute_RS2) : execute_RS2) + _zz_350);
-      memory_DivPlugin_div_needRevert <= ((_zz_154 ^ (_zz_153 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if(_zz_259)begin
-      CfuPlugin_bus_rsp_s2mPipe_rData_response_ok <= CfuPlugin_bus_rsp_payload_response_ok;
+    if(when_Stream_l365_1) begin
       CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_41;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_60;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_59;
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_execute_to_memory_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_8) begin
       memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_28;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_25;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_22;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_19;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_16;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_11;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_9;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_4;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_2;
+    if(when_Pipeline_l124_44) begin
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_51) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_52) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_37;
+    if(when_Pipeline_l124_53) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_38;
+    if(when_Pipeline_l124_54) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_30;
+    if(when_Pipeline_l124_62) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_63) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_355[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_359[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -5525,9 +5798,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -5549,6 +5821,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5564,9 +5837,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5574,7 +5848,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5583,24 +5857,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5625,40 +5890,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5668,23 +5941,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5692,10 +5975,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5707,59 +5998,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -5774,274 +6060,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6049,89 +6354,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -6139,12 +6428,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6155,20 +6444,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6176,45 +6485,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6225,46 +6536,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6272,50 +6574,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6365,13 +6668,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6380,8 +6679,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6395,22 +6699,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -6420,82 +6727,85 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6511,30 +6821,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6542,51 +6857,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -6597,10 +6912,10 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define Input2Kind_defaultEncoding_type [0:0]
@@ -20,15 +20,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -67,7 +67,6 @@ module VexRiscv (
   output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
   input               CfuPlugin_bus_rsp_valid,
   output              CfuPlugin_bus_rsp_ready,
-  input               CfuPlugin_bus_rsp_payload_response_ok,
   input      [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
   output reg          iBusWishbone_CYC,
   output reg          iBusWishbone_STB,
@@ -95,37 +94,37 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  reg                 _zz_204;
-  wire                _zz_205;
-  wire       [31:0]   _zz_206;
-  wire                _zz_207;
-  wire       [31:0]   _zz_208;
-  reg                 _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire       [31:0]   _zz_212;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire       [3:0]    _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  reg        [31:0]   _zz_224;
-  reg        [31:0]   _zz_225;
-  reg        [31:0]   _zz_226;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -148,6 +147,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -156,347 +156,283 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_227;
-  wire                _zz_228;
-  wire                _zz_229;
-  wire                _zz_230;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  wire                _zz_240;
-  wire                _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire                _zz_244;
-  wire       [1:0]    _zz_245;
-  wire                _zz_246;
-  wire                _zz_247;
-  wire                _zz_248;
-  wire                _zz_249;
-  wire                _zz_250;
-  wire                _zz_251;
-  wire                _zz_252;
-  wire                _zz_253;
-  wire                _zz_254;
-  wire                _zz_255;
-  wire       [1:0]    _zz_256;
-  wire                _zz_257;
-  wire                _zz_258;
-  wire       [5:0]    _zz_259;
-  wire                _zz_260;
-  wire                _zz_261;
-  wire                _zz_262;
-  wire                _zz_263;
-  wire                _zz_264;
-  wire                _zz_265;
-  wire                _zz_266;
-  wire       [1:0]    _zz_267;
-  wire                _zz_268;
-  wire       [1:0]    _zz_269;
-  wire       [51:0]   _zz_270;
-  wire       [51:0]   _zz_271;
-  wire       [51:0]   _zz_272;
-  wire       [32:0]   _zz_273;
-  wire       [51:0]   _zz_274;
-  wire       [49:0]   _zz_275;
-  wire       [51:0]   _zz_276;
-  wire       [49:0]   _zz_277;
-  wire       [51:0]   _zz_278;
-  wire       [32:0]   _zz_279;
-  wire       [31:0]   _zz_280;
-  wire       [32:0]   _zz_281;
-  wire       [0:0]    _zz_282;
-  wire       [0:0]    _zz_283;
-  wire       [0:0]    _zz_284;
-  wire       [0:0]    _zz_285;
-  wire       [0:0]    _zz_286;
-  wire       [0:0]    _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [0:0]    _zz_289;
-  wire       [0:0]    _zz_290;
-  wire       [0:0]    _zz_291;
-  wire       [0:0]    _zz_292;
-  wire       [0:0]    _zz_293;
-  wire       [0:0]    _zz_294;
-  wire       [0:0]    _zz_295;
-  wire       [0:0]    _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [0:0]    _zz_298;
-  wire       [0:0]    _zz_299;
-  wire       [0:0]    _zz_300;
-  wire       [3:0]    _zz_301;
-  wire       [2:0]    _zz_302;
-  wire       [31:0]   _zz_303;
-  wire       [11:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [19:0]   _zz_306;
-  wire       [11:0]   _zz_307;
-  wire       [31:0]   _zz_308;
-  wire       [31:0]   _zz_309;
-  wire       [19:0]   _zz_310;
-  wire       [11:0]   _zz_311;
-  wire       [2:0]    _zz_312;
-  wire       [2:0]    _zz_313;
-  wire       [0:0]    _zz_314;
-  wire       [2:0]    _zz_315;
-  wire       [4:0]    _zz_316;
-  wire       [11:0]   _zz_317;
-  wire       [11:0]   _zz_318;
-  wire       [31:0]   _zz_319;
-  wire       [31:0]   _zz_320;
-  wire       [31:0]   _zz_321;
-  wire       [31:0]   _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [31:0]   _zz_324;
-  wire       [31:0]   _zz_325;
-  wire       [11:0]   _zz_326;
-  wire       [19:0]   _zz_327;
-  wire       [11:0]   _zz_328;
-  wire       [31:0]   _zz_329;
-  wire       [31:0]   _zz_330;
-  wire       [31:0]   _zz_331;
-  wire       [11:0]   _zz_332;
-  wire       [19:0]   _zz_333;
-  wire       [11:0]   _zz_334;
-  wire       [2:0]    _zz_335;
-  wire       [1:0]    _zz_336;
-  wire       [1:0]    _zz_337;
-  wire       [1:0]    _zz_338;
-  wire       [1:0]    _zz_339;
-  wire       [65:0]   _zz_340;
-  wire       [65:0]   _zz_341;
-  wire       [31:0]   _zz_342;
-  wire       [31:0]   _zz_343;
-  wire       [0:0]    _zz_344;
-  wire       [5:0]    _zz_345;
-  wire       [32:0]   _zz_346;
-  wire       [31:0]   _zz_347;
-  wire       [31:0]   _zz_348;
-  wire       [32:0]   _zz_349;
-  wire       [32:0]   _zz_350;
-  wire       [32:0]   _zz_351;
-  wire       [32:0]   _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [32:0]   _zz_354;
-  wire       [0:0]    _zz_355;
-  wire       [32:0]   _zz_356;
-  wire       [0:0]    _zz_357;
-  wire       [31:0]   _zz_358;
-  wire       [9:0]    _zz_359;
-  wire       [7:0]    _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [0:0]    _zz_362;
-  wire       [0:0]    _zz_363;
-  wire       [0:0]    _zz_364;
-  wire       [0:0]    _zz_365;
-  wire       [0:0]    _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [26:0]   _zz_368;
-  wire                _zz_369;
-  wire                _zz_370;
-  wire       [1:0]    _zz_371;
-  wire       [31:0]   _zz_372;
-  wire       [31:0]   _zz_373;
-  wire       [31:0]   _zz_374;
-  wire                _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [14:0]   _zz_377;
-  wire       [31:0]   _zz_378;
-  wire       [31:0]   _zz_379;
-  wire       [31:0]   _zz_380;
-  wire                _zz_381;
-  wire       [0:0]    _zz_382;
-  wire       [8:0]    _zz_383;
-  wire       [31:0]   _zz_384;
-  wire       [31:0]   _zz_385;
-  wire       [31:0]   _zz_386;
-  wire                _zz_387;
-  wire       [0:0]    _zz_388;
-  wire       [2:0]    _zz_389;
-  wire                _zz_390;
-  wire                _zz_391;
-  wire                _zz_392;
-  wire       [31:0]   _zz_393;
-  wire       [31:0]   _zz_394;
-  wire       [0:0]    _zz_395;
-  wire       [0:0]    _zz_396;
-  wire                _zz_397;
-  wire       [0:0]    _zz_398;
-  wire       [27:0]   _zz_399;
-  wire       [31:0]   _zz_400;
-  wire                _zz_401;
-  wire                _zz_402;
-  wire                _zz_403;
-  wire       [1:0]    _zz_404;
-  wire       [1:0]    _zz_405;
-  wire                _zz_406;
-  wire       [0:0]    _zz_407;
-  wire       [22:0]   _zz_408;
-  wire       [31:0]   _zz_409;
-  wire       [31:0]   _zz_410;
-  wire       [31:0]   _zz_411;
-  wire       [31:0]   _zz_412;
-  wire                _zz_413;
-  wire                _zz_414;
-  wire       [1:0]    _zz_415;
-  wire       [1:0]    _zz_416;
-  wire                _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [19:0]   _zz_419;
-  wire       [31:0]   _zz_420;
-  wire       [31:0]   _zz_421;
-  wire       [31:0]   _zz_422;
-  wire       [31:0]   _zz_423;
-  wire                _zz_424;
-  wire       [0:0]    _zz_425;
-  wire       [0:0]    _zz_426;
-  wire                _zz_427;
-  wire       [0:0]    _zz_428;
-  wire       [0:0]    _zz_429;
-  wire                _zz_430;
-  wire       [0:0]    _zz_431;
-  wire       [16:0]   _zz_432;
-  wire       [31:0]   _zz_433;
-  wire       [31:0]   _zz_434;
-  wire       [31:0]   _zz_435;
-  wire       [31:0]   _zz_436;
-  wire       [31:0]   _zz_437;
-  wire       [0:0]    _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [0:0]    _zz_441;
-  wire                _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [13:0]   _zz_444;
-  wire       [31:0]   _zz_445;
-  wire       [31:0]   _zz_446;
-  wire       [31:0]   _zz_447;
-  wire       [0:0]    _zz_448;
-  wire       [0:0]    _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [3:0]    _zz_451;
-  wire       [0:0]    _zz_452;
-  wire       [0:0]    _zz_453;
-  wire                _zz_454;
-  wire       [0:0]    _zz_455;
-  wire       [10:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire       [31:0]   _zz_458;
-  wire       [31:0]   _zz_459;
-  wire       [31:0]   _zz_460;
-  wire       [31:0]   _zz_461;
-  wire                _zz_462;
-  wire       [0:0]    _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [31:0]   _zz_465;
-  wire                _zz_466;
-  wire       [0:0]    _zz_467;
-  wire       [3:0]    _zz_468;
-  wire       [0:0]    _zz_469;
-  wire       [3:0]    _zz_470;
-  wire       [5:0]    _zz_471;
-  wire       [5:0]    _zz_472;
-  wire                _zz_473;
-  wire       [0:0]    _zz_474;
-  wire       [7:0]    _zz_475;
-  wire       [31:0]   _zz_476;
-  wire       [31:0]   _zz_477;
-  wire       [31:0]   _zz_478;
-  wire       [31:0]   _zz_479;
-  wire       [31:0]   _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire       [31:0]   _zz_483;
-  wire       [0:0]    _zz_484;
-  wire       [1:0]    _zz_485;
-  wire                _zz_486;
-  wire       [0:0]    _zz_487;
-  wire       [1:0]    _zz_488;
-  wire       [0:0]    _zz_489;
-  wire       [3:0]    _zz_490;
-  wire       [0:0]    _zz_491;
-  wire       [0:0]    _zz_492;
-  wire       [1:0]    _zz_493;
-  wire       [1:0]    _zz_494;
-  wire                _zz_495;
-  wire       [0:0]    _zz_496;
-  wire       [5:0]    _zz_497;
-  wire       [31:0]   _zz_498;
-  wire       [31:0]   _zz_499;
-  wire                _zz_500;
-  wire                _zz_501;
-  wire       [31:0]   _zz_502;
-  wire       [31:0]   _zz_503;
-  wire       [31:0]   _zz_504;
-  wire                _zz_505;
-  wire                _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [31:0]   _zz_508;
-  wire                _zz_509;
-  wire       [0:0]    _zz_510;
-  wire       [1:0]    _zz_511;
-  wire       [31:0]   _zz_512;
-  wire       [31:0]   _zz_513;
-  wire                _zz_514;
-  wire                _zz_515;
-  wire       [0:0]    _zz_516;
-  wire       [0:0]    _zz_517;
-  wire                _zz_518;
-  wire       [0:0]    _zz_519;
-  wire       [3:0]    _zz_520;
-  wire       [31:0]   _zz_521;
-  wire       [31:0]   _zz_522;
-  wire       [31:0]   _zz_523;
-  wire       [31:0]   _zz_524;
-  wire       [31:0]   _zz_525;
-  wire       [31:0]   _zz_526;
-  wire       [31:0]   _zz_527;
-  wire                _zz_528;
-  wire                _zz_529;
-  wire       [31:0]   _zz_530;
-  wire       [31:0]   _zz_531;
-  wire       [31:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire       [0:0]    _zz_534;
-  wire       [2:0]    _zz_535;
-  wire       [0:0]    _zz_536;
-  wire       [0:0]    _zz_537;
-  wire                _zz_538;
-  wire       [0:0]    _zz_539;
-  wire       [1:0]    _zz_540;
-  wire       [31:0]   _zz_541;
-  wire       [31:0]   _zz_542;
-  wire       [31:0]   _zz_543;
-  wire                _zz_544;
-  wire                _zz_545;
-  wire       [31:0]   _zz_546;
-  wire                _zz_547;
-  wire       [0:0]    _zz_548;
-  wire       [0:0]    _zz_549;
-  wire       [0:0]    _zz_550;
-  wire       [0:0]    _zz_551;
-  wire       [1:0]    _zz_552;
-  wire       [1:0]    _zz_553;
-  wire       [0:0]    _zz_554;
-  wire       [0:0]    _zz_555;
-  wire       [31:0]   _zz_556;
-  wire       [31:0]   _zz_557;
-  wire       [31:0]   _zz_558;
-  wire       [31:0]   _zz_559;
-  wire       [31:0]   _zz_560;
-  wire       [31:0]   _zz_561;
-  wire                _zz_562;
-  wire                _zz_563;
-  wire                _zz_564;
-  wire       [31:0]   _zz_565;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [14:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [8:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [2:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
+  wire       [27:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1;
+  wire                _zz_when;
+  wire                _zz_when_1;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [9:0]    _zz_execute_CfuPlugin_functionsIds_0;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
   wire                execute_CfuPlugin_CFU_IN_FLIGHT;
@@ -507,17 +443,17 @@ module VexRiscv (
   wire       [31:0]   execute_MUL_LL;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
   wire       `Input2Kind_defaultEncoding_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_defaultEncoding_type _zz_1;
-  wire       `Input2Kind_defaultEncoding_type _zz_2;
-  wire       `Input2Kind_defaultEncoding_type _zz_3;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -525,27 +461,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -554,28 +490,28 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_25;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_26;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_28;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_29;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire       [31:0]   memory_PC;
-  reg                 _zz_30;
-  reg                 _zz_31;
+  reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
   wire       `Input2Kind_defaultEncoding_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_defaultEncoding_type _zz_32;
+  wire       `Input2Kind_defaultEncoding_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
@@ -593,11 +529,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -605,10 +541,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_36;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_37;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -618,46 +554,46 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_38;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_39;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_40;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_41;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_42;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_43;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_45;
-  wire       [31:0]   _zz_46;
-  wire                _zz_47;
-  reg                 _zz_48;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_defaultEncoding_type _zz_49;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_50;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_52;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_53;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_54;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_55;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_56;
-  reg        [31:0]   _zz_57;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -676,10 +612,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_58;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_59;
-  reg        [31:0]   _zz_60;
+  reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -709,7 +645,7 @@ module VexRiscv (
   wire                memory_arbitration_haltByOther;
   reg                 memory_arbitration_removeIt;
   wire                memory_arbitration_flushIt;
-  reg                 memory_arbitration_flushNext;
+  wire                memory_arbitration_flushNext;
   reg                 memory_arbitration_isValid;
   wire                memory_arbitration_isStuck;
   wire                memory_arbitration_isStuckByOthers;
@@ -766,7 +702,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -792,7 +728,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_61;
+  reg                 _zz_when_DBusCachedPlugin_l386;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -801,6 +737,11 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -818,34 +759,37 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
-  reg                 CfuPlugin_joinException_valid;
-  wire       [3:0]    CfuPlugin_joinException_payload_code;
-  wire       [31:0]   CfuPlugin_joinException_payload_badAddr;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_62;
-  wire       [3:0]    _zz_63;
-  wire                _zz_64;
-  wire                _zz_65;
-  wire                _zz_66;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -868,16 +812,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_67;
-  wire                _zz_68;
-  wire                _zz_69;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_70;
-  wire                _zz_71;
-  reg                 _zz_72;
-  wire                _zz_73;
-  reg                 _zz_74;
-  reg        [31:0]   _zz_75;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -885,22 +831,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_76;
-  reg        [18:0]   _zz_77;
-  wire                _zz_78;
-  reg        [10:0]   _zz_79;
-  wire                _zz_80;
-  reg        [18:0]   _zz_81;
-  reg                 _zz_82;
-  wire                _zz_83;
-  reg        [10:0]   _zz_84;
-  wire                _zz_85;
-  reg        [18:0]   _zz_86;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -908,7 +861,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_87;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -916,6 +869,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -923,7 +881,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -931,8 +889,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -940,40 +899,54 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_88;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_89;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_90;
-  reg        [31:0]   _zz_91;
-  wire                _zz_92;
-  reg        [31:0]   _zz_93;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [34:0]   _zz_94;
-  wire                _zz_95;
-  wire                _zz_96;
-  wire                _zz_97;
-  wire                _zz_98;
-  wire                _zz_99;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_100;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_101;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_102;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_103;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_104;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_105;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_106;
-  wire       `Input2Kind_defaultEncoding_type _zz_107;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [34:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire       `Input2Kind_defaultEncoding_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -981,53 +954,72 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_108;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_109;
-  reg        [31:0]   _zz_110;
-  wire                _zz_111;
-  reg        [19:0]   _zz_112;
-  wire                _zz_113;
-  reg        [19:0]   _zz_114;
-  reg        [31:0]   _zz_115;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_116;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_117;
-  reg                 _zz_118;
-  reg                 _zz_119;
-  reg                 _zz_120;
-  reg        [4:0]    _zz_121;
-  reg        [31:0]   _zz_122;
-  wire                _zz_123;
-  wire                _zz_124;
-  wire                _zz_125;
-  wire                _zz_126;
-  wire                _zz_127;
-  wire                _zz_128;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_129;
-  reg                 _zz_130;
-  reg                 _zz_131;
-  wire                _zz_132;
-  reg        [19:0]   _zz_133;
-  wire                _zz_134;
-  reg        [10:0]   _zz_135;
-  wire                _zz_136;
-  reg        [18:0]   _zz_137;
-  reg                 _zz_138;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_139;
-  reg        [19:0]   _zz_140;
-  wire                _zz_141;
-  reg        [10:0]   _zz_142;
-  wire                _zz_143;
-  reg        [18:0]   _zz_144;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
+  wire                when_BranchPlugin_l296;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1048,9 +1040,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_145;
-  wire                _zz_146;
-  wire                _zz_147;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1063,42 +1055,69 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_148;
-  wire                _zz_149;
-  wire       [1:0]    _zz_150;
-  wire                _zz_151;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1106,6 +1125,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1118,19 +1139,26 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_152;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_153;
-  wire                _zz_154;
-  wire                _zz_155;
-  reg        [32:0]   _zz_156;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_157;
-  wire       [31:0]   _zz_158;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1138,232 +1166,352 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_159;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
   wire                execute_CfuPlugin_schedule;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
+  wire                when_CfuPlugin_l171;
+  wire                when_CfuPlugin_l171_1;
+  wire                when_CfuPlugin_l175;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
-  wire                _zz_160;
-  reg        [23:0]   _zz_161;
-  reg        [31:0]   _zz_162;
+  wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+  reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
+  reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   wire                memory_CfuPlugin_rsp_valid;
   reg                 memory_CfuPlugin_rsp_ready;
-  wire                memory_CfuPlugin_rsp_payload_response_ok;
   wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_s2mPipe_rValid;
-  reg                 CfuPlugin_bus_rsp_s2mPipe_rData_response_ok;
   reg        [31:0]   CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0;
+  wire                when_Stream_l365_1;
+  wire                when_CfuPlugin_l208;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  wire                when_Pipeline_l124_44;
   reg        `Input2Kind_defaultEncoding_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire                when_Pipeline_l124_45;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_46;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_50;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_51;
   reg                 decode_to_execute_DO_EBREAK;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_52;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_53;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_54;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_55;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_62;
   reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_63;
   reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_64;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_163;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_164;
-  reg        [31:0]   _zz_165;
-  reg        [31:0]   _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  reg        [31:0]   _zz_172;
-  reg        [31:0]   _zz_173;
-  reg        [31:0]   _zz_174;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [31:0]   _zz_183;
-  reg        [31:0]   _zz_184;
-  reg        [31:0]   _zz_185;
-  reg        [31:0]   _zz_186;
-  reg        [2:0]    _zz_187;
-  reg                 _zz_188;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_189;
-  wire                _zz_190;
-  wire                _zz_191;
-  wire                _zz_192;
-  wire                _zz_193;
-  wire                _zz_194;
-  reg                 _zz_195;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
   reg [39:0] decode_CfuPlugin_CFU_INPUT_2_KIND_string;
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_8_string;
-  reg [39:0] _zz_9_string;
-  reg [39:0] _zz_10_string;
-  reg [31:0] _zz_11_string;
-  reg [31:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_15_string;
-  reg [71:0] _zz_16_string;
-  reg [71:0] _zz_17_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_18_string;
-  reg [39:0] _zz_19_string;
-  reg [39:0] _zz_20_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_21_string;
-  reg [23:0] _zz_22_string;
-  reg [23:0] _zz_23_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_24_string;
-  reg [63:0] _zz_25_string;
-  reg [63:0] _zz_26_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_27_string;
-  reg [95:0] _zz_28_string;
-  reg [95:0] _zz_29_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
-  reg [39:0] _zz_32_string;
+  reg [39:0] _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_33_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_34_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_35_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_36_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_39_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_40_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_42_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_43_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_44_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_45_string;
-  reg [39:0] _zz_49_string;
-  reg [39:0] _zz_50_string;
-  reg [31:0] _zz_51_string;
-  reg [71:0] _zz_52_string;
-  reg [39:0] _zz_53_string;
-  reg [23:0] _zz_54_string;
-  reg [63:0] _zz_55_string;
-  reg [95:0] _zz_56_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_58_string;
-  reg [95:0] _zz_100_string;
-  reg [63:0] _zz_101_string;
-  reg [23:0] _zz_102_string;
-  reg [39:0] _zz_103_string;
-  reg [71:0] _zz_104_string;
-  reg [31:0] _zz_105_string;
-  reg [39:0] _zz_106_string;
-  reg [39:0] _zz_107_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1373,481 +1521,441 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_227 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_228 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_229 = 1'b1;
-  assign _zz_230 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_231 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_232 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_233 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_234 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_235 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_236 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_237 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_238 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_239 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_240 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
-  assign _zz_241 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_242 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_243 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_244 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_245 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_246 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_247 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_248 = (1'b0 || (! 1'b1));
-  assign _zz_249 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_250 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_251 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_252 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_253 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_254 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_255 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_256 = execute_INSTRUCTION[13 : 12];
-  assign _zz_257 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_258 = (! memory_arbitration_isStuck);
-  assign _zz_259 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_260 = (iBus_cmd_valid || (_zz_187 != 3'b000));
-  assign _zz_261 = (_zz_223 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_262 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_263 = ((_zz_145 && 1'b1) && (! 1'b0));
-  assign _zz_264 = ((_zz_146 && 1'b1) && (! 1'b0));
-  assign _zz_265 = ((_zz_147 && 1'b1) && (! 1'b0));
-  assign _zz_266 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
-  assign _zz_267 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_268 = execute_INSTRUCTION[13];
-  assign _zz_269 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_270 = ($signed(_zz_271) + $signed(_zz_276));
-  assign _zz_271 = ($signed(_zz_272) + $signed(_zz_274));
-  assign _zz_272 = 52'h0;
-  assign _zz_273 = {1'b0,memory_MUL_LL};
-  assign _zz_274 = {{19{_zz_273[32]}}, _zz_273};
-  assign _zz_275 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_276 = {{2{_zz_275[49]}}, _zz_275};
-  assign _zz_277 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_278 = {{2{_zz_277[49]}}, _zz_277};
-  assign _zz_279 = ($signed(_zz_281) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_280 = _zz_279[31 : 0];
-  assign _zz_281 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_282 = _zz_94[33 : 33];
-  assign _zz_283 = _zz_94[31 : 31];
-  assign _zz_284 = _zz_94[30 : 30];
-  assign _zz_285 = _zz_94[29 : 29];
-  assign _zz_286 = _zz_94[28 : 28];
-  assign _zz_287 = _zz_94[25 : 25];
-  assign _zz_288 = _zz_94[17 : 17];
-  assign _zz_289 = _zz_94[16 : 16];
-  assign _zz_290 = _zz_94[13 : 13];
-  assign _zz_291 = _zz_94[12 : 12];
-  assign _zz_292 = _zz_94[11 : 11];
-  assign _zz_293 = _zz_94[32 : 32];
-  assign _zz_294 = _zz_94[15 : 15];
-  assign _zz_295 = _zz_94[5 : 5];
-  assign _zz_296 = _zz_94[3 : 3];
-  assign _zz_297 = _zz_94[20 : 20];
-  assign _zz_298 = _zz_94[10 : 10];
-  assign _zz_299 = _zz_94[4 : 4];
-  assign _zz_300 = _zz_94[0 : 0];
-  assign _zz_301 = (_zz_62 - 4'b0001);
-  assign _zz_302 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_303 = {29'd0, _zz_302};
-  assign _zz_304 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_305 = {{_zz_77,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_306 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_307 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_308 = {{_zz_79,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_309 = {{_zz_81,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_310 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_311 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_312 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_313 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_314 = execute_SRC_LESS;
-  assign _zz_315 = 3'b100;
-  assign _zz_316 = execute_INSTRUCTION[19 : 15];
-  assign _zz_317 = execute_INSTRUCTION[31 : 20];
-  assign _zz_318 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_319 = ($signed(_zz_320) + $signed(_zz_323));
-  assign _zz_320 = ($signed(_zz_321) + $signed(_zz_322));
-  assign _zz_321 = execute_SRC1;
-  assign _zz_322 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_323 = (execute_SRC_USE_SUB_LESS ? _zz_324 : _zz_325);
-  assign _zz_324 = 32'h00000001;
-  assign _zz_325 = 32'h0;
-  assign _zz_326 = execute_INSTRUCTION[31 : 20];
-  assign _zz_327 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_328 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_329 = {_zz_133,execute_INSTRUCTION[31 : 20]};
-  assign _zz_330 = {{_zz_135,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_331 = {{_zz_137,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_332 = execute_INSTRUCTION[31 : 20];
-  assign _zz_333 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_334 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_335 = 3'b100;
-  assign _zz_336 = (_zz_148 & (~ _zz_337));
-  assign _zz_337 = (_zz_148 - 2'b01);
-  assign _zz_338 = (_zz_150 & (~ _zz_339));
-  assign _zz_339 = (_zz_150 - 2'b01);
-  assign _zz_340 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_341 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_342 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_343 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_344 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_345 = {5'd0, _zz_344};
-  assign _zz_346 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_347 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_348 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_349 = {_zz_152,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_350 = _zz_351;
-  assign _zz_351 = _zz_352;
-  assign _zz_352 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_153) : _zz_153)} + _zz_354);
-  assign _zz_353 = memory_DivPlugin_div_needRevert;
-  assign _zz_354 = {32'd0, _zz_353};
-  assign _zz_355 = _zz_155;
-  assign _zz_356 = {32'd0, _zz_355};
-  assign _zz_357 = _zz_154;
-  assign _zz_358 = {31'd0, _zz_357};
-  assign _zz_359 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
-  assign _zz_360 = execute_INSTRUCTION[31 : 24];
-  assign _zz_361 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_362 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_363 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_364 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_365 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_366 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_367 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_368 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_369 = 1'b1;
-  assign _zz_370 = 1'b1;
-  assign _zz_371 = {_zz_66,_zz_65};
-  assign _zz_372 = 32'h0000106f;
-  assign _zz_373 = (decode_INSTRUCTION & 32'h0000107f);
-  assign _zz_374 = 32'h00001073;
-  assign _zz_375 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
-  assign _zz_376 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_377 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_378) == 32'h00000003),{(_zz_379 == _zz_380),{_zz_381,{_zz_382,_zz_383}}}}}};
-  assign _zz_378 = 32'h0000207f;
-  assign _zz_379 = (decode_INSTRUCTION & 32'h0000505f);
-  assign _zz_380 = 32'h00000003;
-  assign _zz_381 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
-  assign _zz_382 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_383 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_384) == 32'h00005013),{(_zz_385 == _zz_386),{_zz_387,{_zz_388,_zz_389}}}}}};
-  assign _zz_384 = 32'hbc00707f;
-  assign _zz_385 = (decode_INSTRUCTION & 32'hfc00307f);
-  assign _zz_386 = 32'h00001013;
-  assign _zz_387 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_388 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_389 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}};
-  assign _zz_390 = decode_INSTRUCTION[31];
-  assign _zz_391 = decode_INSTRUCTION[31];
-  assign _zz_392 = decode_INSTRUCTION[7];
-  assign _zz_393 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_394 = 32'h00100050;
-  assign _zz_395 = _zz_99;
-  assign _zz_396 = 1'b0;
-  assign _zz_397 = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != 1'b0);
-  assign _zz_398 = (((decode_INSTRUCTION & _zz_400) == 32'h02000030) != 1'b0);
-  assign _zz_399 = {({_zz_401,_zz_402} != 2'b00),{(_zz_403 != 1'b0),{(_zz_404 != _zz_405),{_zz_406,{_zz_407,_zz_408}}}}};
-  assign _zz_400 = 32'h02004074;
-  assign _zz_401 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz_402 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_403 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz_404 = {(_zz_409 == _zz_410),(_zz_411 == _zz_412)};
-  assign _zz_405 = 2'b00;
-  assign _zz_406 = ({_zz_97,_zz_413} != 2'b00);
-  assign _zz_407 = (_zz_414 != 1'b0);
-  assign _zz_408 = {(_zz_415 != _zz_416),{_zz_417,{_zz_418,_zz_419}}};
-  assign _zz_409 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_410 = 32'h00001050;
-  assign _zz_411 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_412 = 32'h00002050;
-  assign _zz_413 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_414 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_415 = {(_zz_420 == _zz_421),(_zz_422 == _zz_423)};
-  assign _zz_416 = 2'b00;
-  assign _zz_417 = ({_zz_424,{_zz_425,_zz_426}} != 3'b000);
-  assign _zz_418 = (_zz_427 != 1'b0);
-  assign _zz_419 = {(_zz_428 != _zz_429),{_zz_430,{_zz_431,_zz_432}}};
-  assign _zz_420 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_421 = 32'h00005010;
-  assign _zz_422 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_423 = 32'h00005020;
-  assign _zz_424 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_425 = ((decode_INSTRUCTION & _zz_433) == 32'h00001010);
-  assign _zz_426 = ((decode_INSTRUCTION & _zz_434) == 32'h00001010);
-  assign _zz_427 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00001000);
-  assign _zz_429 = 1'b0;
-  assign _zz_430 = ((_zz_436 == _zz_437) != 1'b0);
-  assign _zz_431 = ({_zz_438,_zz_439} != 2'b00);
-  assign _zz_432 = {(_zz_440 != _zz_441),{_zz_442,{_zz_443,_zz_444}}};
-  assign _zz_433 = 32'h00007034;
-  assign _zz_434 = 32'h02007054;
-  assign _zz_435 = 32'h00001000;
-  assign _zz_436 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_437 = 32'h00002000;
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_445) == 32'h00002000);
-  assign _zz_439 = ((decode_INSTRUCTION & _zz_446) == 32'h00001000);
-  assign _zz_440 = ((decode_INSTRUCTION & _zz_447) == 32'h00004004);
-  assign _zz_441 = 1'b0;
-  assign _zz_442 = ({_zz_98,{_zz_448,_zz_449}} != 3'b000);
-  assign _zz_443 = ({_zz_450,_zz_451} != 5'h0);
-  assign _zz_444 = {(_zz_452 != _zz_453),{_zz_454,{_zz_455,_zz_456}}};
-  assign _zz_445 = 32'h00002010;
-  assign _zz_446 = 32'h00005000;
-  assign _zz_447 = 32'h00004054;
-  assign _zz_448 = ((decode_INSTRUCTION & _zz_457) == 32'h00000020);
-  assign _zz_449 = ((decode_INSTRUCTION & _zz_458) == 32'h00000020);
-  assign _zz_450 = ((decode_INSTRUCTION & _zz_459) == 32'h00002040);
-  assign _zz_451 = {(_zz_460 == _zz_461),{_zz_462,{_zz_463,_zz_464}}};
-  assign _zz_452 = ((decode_INSTRUCTION & _zz_465) == 32'h00000020);
-  assign _zz_453 = 1'b0;
-  assign _zz_454 = ({_zz_466,{_zz_467,_zz_468}} != 6'h0);
-  assign _zz_455 = ({_zz_469,_zz_470} != 5'h0);
-  assign _zz_456 = {(_zz_471 != _zz_472),{_zz_473,{_zz_474,_zz_475}}};
-  assign _zz_457 = 32'h00000034;
-  assign _zz_458 = 32'h00000064;
-  assign _zz_459 = 32'h00002040;
-  assign _zz_460 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_461 = 32'h00001040;
-  assign _zz_462 = ((decode_INSTRUCTION & _zz_476) == 32'h00000040);
-  assign _zz_463 = (_zz_477 == _zz_478);
-  assign _zz_464 = (_zz_479 == _zz_480);
-  assign _zz_465 = 32'h00000020;
-  assign _zz_466 = ((decode_INSTRUCTION & _zz_481) == 32'h00000008);
-  assign _zz_467 = (_zz_482 == _zz_483);
-  assign _zz_468 = {_zz_96,{_zz_484,_zz_485}};
-  assign _zz_469 = _zz_96;
-  assign _zz_470 = {_zz_486,{_zz_487,_zz_488}};
-  assign _zz_471 = {_zz_97,{_zz_489,_zz_490}};
-  assign _zz_472 = 6'h0;
-  assign _zz_473 = ({_zz_491,_zz_492} != 2'b00);
-  assign _zz_474 = (_zz_493 != _zz_494);
-  assign _zz_475 = {_zz_495,{_zz_496,_zz_497}};
-  assign _zz_476 = 32'h00100040;
-  assign _zz_477 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_478 = 32'h00000040;
-  assign _zz_479 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_480 = 32'h0;
-  assign _zz_481 = 32'h00000008;
-  assign _zz_482 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_483 = 32'h00000040;
-  assign _zz_484 = (_zz_498 == _zz_499);
-  assign _zz_485 = {_zz_500,_zz_501};
-  assign _zz_486 = ((decode_INSTRUCTION & _zz_502) == 32'h00002010);
-  assign _zz_487 = (_zz_503 == _zz_504);
-  assign _zz_488 = {_zz_505,_zz_506};
-  assign _zz_489 = (_zz_507 == _zz_508);
-  assign _zz_490 = {_zz_509,{_zz_510,_zz_511}};
-  assign _zz_491 = _zz_96;
-  assign _zz_492 = (_zz_512 == _zz_513);
-  assign _zz_493 = {_zz_96,_zz_514};
-  assign _zz_494 = 2'b00;
-  assign _zz_495 = (_zz_515 != 1'b0);
-  assign _zz_496 = (_zz_516 != _zz_517);
-  assign _zz_497 = {_zz_518,{_zz_519,_zz_520}};
-  assign _zz_498 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_499 = 32'h00004020;
-  assign _zz_500 = ((decode_INSTRUCTION & _zz_521) == 32'h00000010);
-  assign _zz_501 = ((decode_INSTRUCTION & _zz_522) == 32'h00000020);
-  assign _zz_502 = 32'h00002030;
-  assign _zz_503 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_504 = 32'h00000010;
-  assign _zz_505 = ((decode_INSTRUCTION & _zz_523) == 32'h00002020);
-  assign _zz_506 = ((decode_INSTRUCTION & _zz_524) == 32'h00000020);
-  assign _zz_507 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_508 = 32'h00001010;
-  assign _zz_509 = ((decode_INSTRUCTION & _zz_525) == 32'h00002010);
-  assign _zz_510 = (_zz_526 == _zz_527);
-  assign _zz_511 = {_zz_528,_zz_529};
-  assign _zz_512 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_513 = 32'h00000020;
-  assign _zz_514 = ((decode_INSTRUCTION & _zz_530) == 32'h0);
-  assign _zz_515 = ((decode_INSTRUCTION & _zz_531) == 32'h00004010);
-  assign _zz_516 = (_zz_532 == _zz_533);
-  assign _zz_517 = 1'b0;
-  assign _zz_518 = ({_zz_534,_zz_535} != 4'b0000);
-  assign _zz_519 = (_zz_536 != _zz_537);
-  assign _zz_520 = {_zz_538,{_zz_539,_zz_540}};
-  assign _zz_521 = 32'h00000030;
-  assign _zz_522 = 32'h02000020;
-  assign _zz_523 = 32'h02002060;
-  assign _zz_524 = 32'h02003020;
-  assign _zz_525 = 32'h00002010;
-  assign _zz_526 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_527 = 32'h00000010;
-  assign _zz_528 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_529 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz_530 = 32'h00000020;
-  assign _zz_531 = 32'h00004014;
-  assign _zz_532 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_533 = 32'h00002010;
-  assign _zz_534 = ((decode_INSTRUCTION & _zz_541) == 32'h0);
-  assign _zz_535 = {(_zz_542 == _zz_543),{_zz_544,_zz_545}};
-  assign _zz_536 = ((decode_INSTRUCTION & _zz_546) == 32'h0);
-  assign _zz_537 = 1'b0;
-  assign _zz_538 = ({_zz_547,{_zz_548,_zz_549}} != 3'b000);
-  assign _zz_539 = ({_zz_550,_zz_551} != 2'b00);
-  assign _zz_540 = {(_zz_552 != _zz_553),(_zz_554 != _zz_555)};
-  assign _zz_541 = 32'h00000044;
-  assign _zz_542 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_543 = 32'h0;
-  assign _zz_544 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_545 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_546 = 32'h00000058;
-  assign _zz_547 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_548 = ((decode_INSTRUCTION & _zz_556) == 32'h00002010);
-  assign _zz_549 = ((decode_INSTRUCTION & _zz_557) == 32'h40000030);
-  assign _zz_550 = ((decode_INSTRUCTION & _zz_558) == 32'h00000004);
-  assign _zz_551 = _zz_95;
-  assign _zz_552 = {(_zz_559 == _zz_560),_zz_95};
-  assign _zz_553 = 2'b00;
-  assign _zz_554 = ((decode_INSTRUCTION & _zz_561) == 32'h00001004);
-  assign _zz_555 = 1'b0;
-  assign _zz_556 = 32'h00002014;
-  assign _zz_557 = 32'h40000034;
-  assign _zz_558 = 32'h00000014;
-  assign _zz_559 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_560 = 32'h00000004;
-  assign _zz_561 = 32'h00005054;
-  assign _zz_562 = execute_INSTRUCTION[31];
-  assign _zz_563 = execute_INSTRUCTION[31];
-  assign _zz_564 = execute_INSTRUCTION[7];
-  assign _zz_565 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_369) begin
-      _zz_224 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_execute_CfuPlugin_functionsIds_0 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000106f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000107f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00001073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000207f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000505f);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000003;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbc00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00001013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 32'h00100050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9} != 2'b00),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21}}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h02004074;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32}} != 3'b000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h00005020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42) != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = 32'h02007054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55}} != 3'b000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60} != 5'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00005000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00004054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81}} != 6'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92} != 5'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = 6'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = 32'h00100040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 != 1'b0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141} != 4'b0000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155}} != 3'b000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160} != 2'b00);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 2'b00;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168 = 1'b0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167 = 32'h00005054;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_370) begin
-      _zz_225 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_48) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_196                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_197                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_198                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_199                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_200                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_201                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_202                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_203                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_204                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_163[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_205                                            ), //i
-    .io_cpu_execute_address                    (_zz_206[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_89[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_207                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_208[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_209                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_210                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_211                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_212[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_213                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_214                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_215                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_216                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_217                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_218                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_219                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_220                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_221[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_222                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_223                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_371)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_226 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_226 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_226 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_226 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
@@ -1861,60 +1969,60 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_1)
-      `Input2Kind_defaultEncoding_RS : _zz_1_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_1_string = "IMM_I";
-      default : _zz_1_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `Input2Kind_defaultEncoding_RS : _zz_2_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_2_string = "IMM_I";
-      default : _zz_2_string = "?????";
+    case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `Input2Kind_defaultEncoding_RS : _zz_3_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_3_string = "IMM_I";
-      default : _zz_3_string = "?????";
+    case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1927,134 +2035,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_8_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8_string = "ECALL";
-      default : _zz_8_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9_string = "ECALL";
-      default : _zz_9_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_10_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10_string = "ECALL";
-      default : _zz_10_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_11_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_11_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_11_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_11_string = "JALR";
-      default : _zz_11_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_12_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_12_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12_string = "JALR";
-      default : _zz_12_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
-      default : _zz_15_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16_string = "SRA_1    ";
-      default : _zz_16_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17_string = "SRA_1    ";
-      default : _zz_17_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
-      default : _zz_18_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19_string = "AND_1";
-      default : _zz_19_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20_string = "AND_1";
-      default : _zz_20_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2067,30 +2175,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
-      default : _zz_21_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_22_string = "PC ";
-      default : _zz_22_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
-      default : _zz_23_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2102,27 +2210,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
-      default : _zz_24_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25_string = "BITWISE ";
-      default : _zz_25_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26_string = "BITWISE ";
-      default : _zz_26_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2135,30 +2243,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
-      default : _zz_27_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_28_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_28_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_28_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_28_string = "URS1        ";
-      default : _zz_28_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_29_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_29_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_29_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_29_string = "URS1        ";
-      default : _zz_29_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2169,10 +2277,10 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_32)
-      `Input2Kind_defaultEncoding_RS : _zz_32_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_32_string = "IMM_I";
-      default : _zz_32_string = "?????";
+    case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2185,12 +2293,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_33_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_33_string = "ECALL";
-      default : _zz_33_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2203,12 +2311,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_34_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_34_string = "ECALL";
-      default : _zz_34_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2221,12 +2329,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_35_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
-      default : _zz_35_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2239,48 +2347,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_36_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_36_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_36_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_36_string = "JALR";
-      default : _zz_36_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_39_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_39_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_39_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_39_string = "SRA_1    ";
-      default : _zz_39_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_40_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_40_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_40_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_40_string = "SRA_1    ";
-      default : _zz_40_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2293,12 +2401,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_42_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_42_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_42_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_42_string = "PC ";
-      default : _zz_42_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2311,12 +2419,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_43_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_43_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_43_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_43_string = "URS1        ";
-      default : _zz_43_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2328,95 +2436,95 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_44_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_44_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_44_string = "BITWISE ";
-      default : _zz_44_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_45_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_45_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_45_string = "AND_1";
-      default : _zz_45_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Input2Kind_defaultEncoding_RS : _zz_49_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_49_string = "IMM_I";
-      default : _zz_49_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_50)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_50_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_50_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_50_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_50_string = "ECALL";
-      default : _zz_50_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_52)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_52_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_52_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_52_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_52_string = "SRA_1    ";
-      default : _zz_52_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_53)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_53_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_53_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_53_string = "AND_1";
-      default : _zz_53_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_54)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_54_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_54_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_54_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_54_string = "PC ";
-      default : _zz_54_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_55)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_55_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_55_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_55_string = "BITWISE ";
-      default : _zz_55_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_56)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_56_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_56_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_56_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_56_string = "URS1        ";
-      default : _zz_56_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2429,80 +2537,80 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_58)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_58_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_58_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_58_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_58_string = "JALR";
-      default : _zz_58_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_100)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_100_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_100_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_100_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_100_string = "URS1        ";
-      default : _zz_100_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_101)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_101_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_101_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_101_string = "BITWISE ";
-      default : _zz_101_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_102)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_102_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_102_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_102_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_102_string = "PC ";
-      default : _zz_102_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_103)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_103_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_103_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_103_string = "AND_1";
-      default : _zz_103_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_104)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_104_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_104_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_104_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_104_string = "SRA_1    ";
-      default : _zz_104_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_105)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_105_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_105_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_105_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_105_string = "JALR";
-      default : _zz_105_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_106)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_106_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_106_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_106_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_106_string = "ECALL";
-      default : _zz_106_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_107)
-      `Input2Kind_defaultEncoding_RS : _zz_107_string = "RS   ";
-      `Input2Kind_defaultEncoding_IMM_I : _zz_107_string = "IMM_I";
-      default : _zz_107_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
+      `Input2Kind_defaultEncoding_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2533,28 +2641,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2602,7 +2710,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_270) + $signed(_zz_278));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
@@ -2610,73 +2718,73 @@ module VexRiscv (
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign execute_SHIFT_RIGHT = _zz_280;
-  assign execute_REGFILE_WRITE_DATA = _zz_109;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_206[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_1;
-  assign _zz_2 = _zz_3;
-  assign decode_CfuPlugin_CFU_ENABLE = _zz_282[0];
-  assign decode_IS_RS2_SIGNED = _zz_283[0];
-  assign decode_IS_RS1_SIGNED = _zz_284[0];
-  assign decode_IS_DIV = _zz_285[0];
+  assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33];
+  assign decode_IS_RS2_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[30];
+  assign decode_IS_DIV = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_286[0];
-  assign _zz_4 = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_ENV_CTRL = _zz_8;
-  assign _zz_9 = _zz_10;
-  assign decode_IS_CSR = _zz_287[0];
-  assign _zz_11 = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_SHIFT_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_ALU_BITWISE_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_SRC_LESS_UNSIGNED = _zz_288[0];
-  assign decode_MEMORY_MANAGMENT = _zz_289[0];
+  assign decode_IS_MUL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_290[0];
+  assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_291[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_292[0];
-  assign decode_SRC2_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_ALU_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
-  assign decode_SRC1_CTRL = _zz_27;
-  assign _zz_28 = _zz_29;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
-  always @ (*) begin
-    _zz_30 = memory_CfuPlugin_CFU_IN_FLIGHT;
-    if(memory_arbitration_isStuck)begin
-      _zz_30 = 1'b0;
+  always @(*) begin
+    _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_CfuPlugin_CFU_IN_FLIGHT;
+    if(memory_arbitration_isStuck) begin
+      _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_31 = execute_CfuPlugin_CFU_IN_FLIGHT;
-    if(execute_arbitration_isStuck)begin
-      _zz_31 = 1'b0;
+  always @(*) begin
+    _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT = execute_CfuPlugin_CFU_IN_FLIGHT;
+    if(execute_arbitration_isStuck) begin
+      _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT = 1'b0;
     end
   end
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
-  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_32;
+  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_293[0];
+  assign decode_IS_EBREAK = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2690,22 +2798,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_33;
-  assign execute_ENV_CTRL = _zz_34;
-  assign writeBack_ENV_CTRL = _zz_35;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_131;
-  assign execute_BRANCH_CTRL = _zz_36;
-  assign decode_RS2_USE = _zz_294[0];
-  assign decode_RS1_USE = _zz_295[0];
-  always @ (*) begin
-    _zz_37 = execute_REGFILE_WRITE_DATA;
-    if(_zz_227)begin
-      _zz_37 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
+  assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2715,142 +2823,142 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_120)begin
-      if((_zz_121 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_122;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_228)begin
-      if(_zz_229)begin
-        if(_zz_124)begin
-          decode_RS2 = _zz_57;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_230)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_126)begin
-          decode_RS2 = _zz_38;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_231)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_128)begin
-          decode_RS2 = _zz_37;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_120)begin
-      if((_zz_121 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_122;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_228)begin
-      if(_zz_229)begin
-        if(_zz_123)begin
-          decode_RS1 = _zz_57;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_230)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_125)begin
-          decode_RS1 = _zz_38;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_231)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_127)begin
-          decode_RS1 = _zz_37;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_38 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_38 = _zz_117;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_38 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_232)begin
-      _zz_38 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      _zz_38 = memory_CfuPlugin_rsp_payload_outputs_0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_39;
-  assign execute_SHIFT_CTRL = _zz_40;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_41 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_42;
-  assign execute_SRC1_CTRL = _zz_43;
-  assign decode_SRC_USE_SUB_LESS = _zz_296[0];
-  assign decode_SRC_ADD_ZERO = _zz_297[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_44;
-  assign execute_SRC2 = _zz_115;
-  assign execute_SRC1 = _zz_110;
-  assign execute_ALU_BITWISE_CTRL = _zz_45;
-  assign _zz_46 = writeBack_INSTRUCTION;
-  assign _zz_47 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_48 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_48 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_298[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_372) == 32'h00000003),{(_zz_373 == _zz_374),{_zz_375,{_zz_376,_zz_377}}}}}}} != 22'h0);
-  always @ (*) begin
-    _zz_57 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_57 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_269)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_57 = _zz_342;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_57 = _zz_343;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2862,61 +2970,61 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_299[0];
-  assign decode_FLUSH_ALL = _zz_300[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[4];
+  assign decode_FLUSH_ALL = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_233)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_234)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_235)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_236)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_58;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_59 = execute_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_59 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_execute_to_memory_FORMAL_PC_NEXT = execute_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_execute_to_memory_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_60 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_60 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_163)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2925,174 +3033,165 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_118 || _zz_119)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_237)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_237)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_222 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_238)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_227)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if((CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready)))begin
+    if(when_CfuPlugin_l175) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_239)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(_zz_240)begin
+    if(_zz_when_1) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_239)begin
-      if(_zz_241)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_240)begin
+    if(_zz_when_1) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_239)begin
-      if(_zz_241)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_232)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      if((! memory_CfuPlugin_rsp_valid))begin
+    if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
+      if(when_CfuPlugin_l208) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(CfuPlugin_joinException_valid)begin
-      memory_arbitration_removeIt = 1'b1;
-    end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
-    memory_arbitration_flushNext = 1'b0;
-    if(CfuPlugin_joinException_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
-  end
-
-  always @ (*) begin
+  assign memory_arbitration_flushNext = 1'b0;
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_242)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3101,75 +3200,77 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_242)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_239)begin
-      if(_zz_241)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_244)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_61 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_61 = 1'b1;
+  always @(*) begin
+    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    if(DebugPlugin_godmode) begin
+      _zz_when_DBusCachedPlugin_l386 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_238)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_242)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_242)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_243)begin
-      case(_zz_245)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3179,80 +3280,92 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_62 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_63 = (_zz_62 & (~ _zz_301));
-  assign _zz_64 = _zz_63[3];
-  assign _zz_65 = (_zz_63[1] || _zz_64);
-  assign _zz_66 = (_zz_63[2] || _zz_64);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_226;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_303);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3260,66 +3373,75 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_67 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_67);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_67);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_68 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_68);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_68);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_69 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_69);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_69);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_70;
-  assign _zz_70 = ((1'b0 && (! _zz_71)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_71 = _zz_72;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_71;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_73)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_73 = _zz_74;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_73;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_75;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_163)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3331,207 +3453,213 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_76 = _zz_304[11];
-  always @ (*) begin
-    _zz_77[18] = _zz_76;
-    _zz_77[17] = _zz_76;
-    _zz_77[16] = _zz_76;
-    _zz_77[15] = _zz_76;
-    _zz_77[14] = _zz_76;
-    _zz_77[13] = _zz_76;
-    _zz_77[12] = _zz_76;
-    _zz_77[11] = _zz_76;
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_305[31]));
-    if(_zz_82)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_78 = _zz_306[19];
-  always @ (*) begin
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_80 = _zz_307[11];
-  always @ (*) begin
-    _zz_81[18] = _zz_80;
-    _zz_81[17] = _zz_80;
-    _zz_81[16] = _zz_80;
-    _zz_81[15] = _zz_80;
-    _zz_81[14] = _zz_80;
-    _zz_81[13] = _zz_80;
-    _zz_81[12] = _zz_80;
-    _zz_81[11] = _zz_80;
-    _zz_81[10] = _zz_80;
-    _zz_81[9] = _zz_80;
-    _zz_81[8] = _zz_80;
-    _zz_81[7] = _zz_80;
-    _zz_81[6] = _zz_80;
-    _zz_81[5] = _zz_80;
-    _zz_81[4] = _zz_80;
-    _zz_81[3] = _zz_80;
-    _zz_81[2] = _zz_80;
-    _zz_81[1] = _zz_80;
-    _zz_81[0] = _zz_80;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_82 = _zz_308[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_82 = _zz_309[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_83 = _zz_310[19];
-  always @ (*) begin
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7] = _zz_83;
-    _zz_84[6] = _zz_83;
-    _zz_84[5] = _zz_83;
-    _zz_84[4] = _zz_83;
-    _zz_84[3] = _zz_83;
-    _zz_84[2] = _zz_83;
-    _zz_84[1] = _zz_83;
-    _zz_84[0] = _zz_83;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_85 = _zz_311[11];
-  always @ (*) begin
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15] = _zz_85;
-    _zz_86[14] = _zz_85;
-    _zz_86[13] = _zz_85;
-    _zz_86[12] = _zz_85;
-    _zz_86[11] = _zz_85;
-    _zz_86[10] = _zz_85;
-    _zz_86[9] = _zz_85;
-    _zz_86[8] = _zz_85;
-    _zz_86[7] = _zz_85;
-    _zz_86[6] = _zz_85;
-    _zz_86[5] = _zz_85;
-    _zz_86[4] = _zz_85;
-    _zz_86[3] = _zz_85;
-    _zz_86[2] = _zz_85;
-    _zz_86[1] = _zz_85;
-    _zz_86[0] = _zz_85;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_84,{{{_zz_390,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_86,{{{_zz_391,_zz_392},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_197 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_198 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_199 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_198;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_201 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_202 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_203 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_236)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_234)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_204 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_234)begin
-      _zz_204 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_235)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_233)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_235)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_233)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_196 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_223 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3539,168 +3667,178 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_205 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_206 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_89 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_89 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_89 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_222 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_207 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_208 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_207;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_208;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_209 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_61 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_209 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_210 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_211 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_212 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_246)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_246)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_246)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_312};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_313};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_90 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_91[31] = _zz_90;
-    _zz_91[30] = _zz_90;
-    _zz_91[29] = _zz_90;
-    _zz_91[28] = _zz_90;
-    _zz_91[27] = _zz_90;
-    _zz_91[26] = _zz_90;
-    _zz_91[25] = _zz_90;
-    _zz_91[24] = _zz_90;
-    _zz_91[23] = _zz_90;
-    _zz_91[22] = _zz_90;
-    _zz_91[21] = _zz_90;
-    _zz_91[20] = _zz_90;
-    _zz_91[19] = _zz_90;
-    _zz_91[18] = _zz_90;
-    _zz_91[17] = _zz_90;
-    _zz_91[16] = _zz_90;
-    _zz_91[15] = _zz_90;
-    _zz_91[14] = _zz_90;
-    _zz_91[13] = _zz_90;
-    _zz_91[12] = _zz_90;
-    _zz_91[11] = _zz_90;
-    _zz_91[10] = _zz_90;
-    _zz_91[9] = _zz_90;
-    _zz_91[8] = _zz_90;
-    _zz_91[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_92 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_93[31] = _zz_92;
-    _zz_93[30] = _zz_92;
-    _zz_93[29] = _zz_92;
-    _zz_93[28] = _zz_92;
-    _zz_93[27] = _zz_92;
-    _zz_93[26] = _zz_92;
-    _zz_93[25] = _zz_92;
-    _zz_93[24] = _zz_92;
-    _zz_93[23] = _zz_92;
-    _zz_93[22] = _zz_92;
-    _zz_93[21] = _zz_92;
-    _zz_93[20] = _zz_92;
-    _zz_93[19] = _zz_92;
-    _zz_93[18] = _zz_92;
-    _zz_93[17] = _zz_92;
-    _zz_93[16] = _zz_92;
-    _zz_93[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_267)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_91;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_93;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3719,62 +3857,63 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_95 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_96 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_97 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_98 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_99 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_94 = {1'b0,{(_zz_98 != 1'b0),{((_zz_393 == _zz_394) != 1'b0),{(_zz_99 != 1'b0),{(_zz_395 != _zz_396),{_zz_397,{_zz_398,_zz_399}}}}}}};
-  assign _zz_100 = _zz_94[2 : 1];
-  assign _zz_56 = _zz_100;
-  assign _zz_101 = _zz_94[7 : 6];
-  assign _zz_55 = _zz_101;
-  assign _zz_102 = _zz_94[9 : 8];
-  assign _zz_54 = _zz_102;
-  assign _zz_103 = _zz_94[19 : 18];
-  assign _zz_53 = _zz_103;
-  assign _zz_104 = _zz_94[22 : 21];
-  assign _zz_52 = _zz_104;
-  assign _zz_105 = _zz_94[24 : 23];
-  assign _zz_51 = _zz_105;
-  assign _zz_106 = _zz_94[27 : 26];
-  assign _zz_50 = _zz_106;
-  assign _zz_107 = _zz_94[34 : 34];
-  assign _zz_49 = _zz_107;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1) != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_224;
-  assign decode_RegFilePlugin_rs2Data = _zz_225;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_47 && writeBack_arbitration_isFiring);
-    if(_zz_108)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_46[11 : 7];
-    if(_zz_108)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_57;
-    if(_zz_108)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3783,353 +3922,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_109 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_109 = {31'd0, _zz_314};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_109 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_110 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_110 = {29'd0, _zz_315};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_110 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_110 = {27'd0, _zz_316};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_111 = _zz_317[11];
-  always @ (*) begin
-    _zz_112[19] = _zz_111;
-    _zz_112[18] = _zz_111;
-    _zz_112[17] = _zz_111;
-    _zz_112[16] = _zz_111;
-    _zz_112[15] = _zz_111;
-    _zz_112[14] = _zz_111;
-    _zz_112[13] = _zz_111;
-    _zz_112[12] = _zz_111;
-    _zz_112[11] = _zz_111;
-    _zz_112[10] = _zz_111;
-    _zz_112[9] = _zz_111;
-    _zz_112[8] = _zz_111;
-    _zz_112[7] = _zz_111;
-    _zz_112[6] = _zz_111;
-    _zz_112[5] = _zz_111;
-    _zz_112[4] = _zz_111;
-    _zz_112[3] = _zz_111;
-    _zz_112[2] = _zz_111;
-    _zz_112[1] = _zz_111;
-    _zz_112[0] = _zz_111;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_113 = _zz_318[11];
-  always @ (*) begin
-    _zz_114[19] = _zz_113;
-    _zz_114[18] = _zz_113;
-    _zz_114[17] = _zz_113;
-    _zz_114[16] = _zz_113;
-    _zz_114[15] = _zz_113;
-    _zz_114[14] = _zz_113;
-    _zz_114[13] = _zz_113;
-    _zz_114[12] = _zz_113;
-    _zz_114[11] = _zz_113;
-    _zz_114[10] = _zz_113;
-    _zz_114[9] = _zz_113;
-    _zz_114[8] = _zz_113;
-    _zz_114[7] = _zz_113;
-    _zz_114[6] = _zz_113;
-    _zz_114[5] = _zz_113;
-    _zz_114[4] = _zz_113;
-    _zz_114[3] = _zz_113;
-    _zz_114[2] = _zz_113;
-    _zz_114[1] = _zz_113;
-    _zz_114[0] = _zz_113;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_115 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_115 = {_zz_112,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_115 = {_zz_114,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_115 = _zz_41;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_319;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_116[0] = execute_SRC1[31];
-    _zz_116[1] = execute_SRC1[30];
-    _zz_116[2] = execute_SRC1[29];
-    _zz_116[3] = execute_SRC1[28];
-    _zz_116[4] = execute_SRC1[27];
-    _zz_116[5] = execute_SRC1[26];
-    _zz_116[6] = execute_SRC1[25];
-    _zz_116[7] = execute_SRC1[24];
-    _zz_116[8] = execute_SRC1[23];
-    _zz_116[9] = execute_SRC1[22];
-    _zz_116[10] = execute_SRC1[21];
-    _zz_116[11] = execute_SRC1[20];
-    _zz_116[12] = execute_SRC1[19];
-    _zz_116[13] = execute_SRC1[18];
-    _zz_116[14] = execute_SRC1[17];
-    _zz_116[15] = execute_SRC1[16];
-    _zz_116[16] = execute_SRC1[15];
-    _zz_116[17] = execute_SRC1[14];
-    _zz_116[18] = execute_SRC1[13];
-    _zz_116[19] = execute_SRC1[12];
-    _zz_116[20] = execute_SRC1[11];
-    _zz_116[21] = execute_SRC1[10];
-    _zz_116[22] = execute_SRC1[9];
-    _zz_116[23] = execute_SRC1[8];
-    _zz_116[24] = execute_SRC1[7];
-    _zz_116[25] = execute_SRC1[6];
-    _zz_116[26] = execute_SRC1[5];
-    _zz_116[27] = execute_SRC1[4];
-    _zz_116[28] = execute_SRC1[3];
-    _zz_116[29] = execute_SRC1[2];
-    _zz_116[30] = execute_SRC1[1];
-    _zz_116[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_116 : execute_SRC1);
-  always @ (*) begin
-    _zz_117[0] = memory_SHIFT_RIGHT[31];
-    _zz_117[1] = memory_SHIFT_RIGHT[30];
-    _zz_117[2] = memory_SHIFT_RIGHT[29];
-    _zz_117[3] = memory_SHIFT_RIGHT[28];
-    _zz_117[4] = memory_SHIFT_RIGHT[27];
-    _zz_117[5] = memory_SHIFT_RIGHT[26];
-    _zz_117[6] = memory_SHIFT_RIGHT[25];
-    _zz_117[7] = memory_SHIFT_RIGHT[24];
-    _zz_117[8] = memory_SHIFT_RIGHT[23];
-    _zz_117[9] = memory_SHIFT_RIGHT[22];
-    _zz_117[10] = memory_SHIFT_RIGHT[21];
-    _zz_117[11] = memory_SHIFT_RIGHT[20];
-    _zz_117[12] = memory_SHIFT_RIGHT[19];
-    _zz_117[13] = memory_SHIFT_RIGHT[18];
-    _zz_117[14] = memory_SHIFT_RIGHT[17];
-    _zz_117[15] = memory_SHIFT_RIGHT[16];
-    _zz_117[16] = memory_SHIFT_RIGHT[15];
-    _zz_117[17] = memory_SHIFT_RIGHT[14];
-    _zz_117[18] = memory_SHIFT_RIGHT[13];
-    _zz_117[19] = memory_SHIFT_RIGHT[12];
-    _zz_117[20] = memory_SHIFT_RIGHT[11];
-    _zz_117[21] = memory_SHIFT_RIGHT[10];
-    _zz_117[22] = memory_SHIFT_RIGHT[9];
-    _zz_117[23] = memory_SHIFT_RIGHT[8];
-    _zz_117[24] = memory_SHIFT_RIGHT[7];
-    _zz_117[25] = memory_SHIFT_RIGHT[6];
-    _zz_117[26] = memory_SHIFT_RIGHT[5];
-    _zz_117[27] = memory_SHIFT_RIGHT[4];
-    _zz_117[28] = memory_SHIFT_RIGHT[3];
-    _zz_117[29] = memory_SHIFT_RIGHT[2];
-    _zz_117[30] = memory_SHIFT_RIGHT[1];
-    _zz_117[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_118 = 1'b0;
-    if(_zz_247)begin
-      if(_zz_248)begin
-        if(_zz_123)begin
-          _zz_118 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_249)begin
-      if(_zz_250)begin
-        if(_zz_125)begin
-          _zz_118 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_251)begin
-      if(_zz_252)begin
-        if(_zz_127)begin
-          _zz_118 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_118 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_119 = 1'b0;
-    if(_zz_247)begin
-      if(_zz_248)begin
-        if(_zz_124)begin
-          _zz_119 = 1'b1;
-        end
-      end
-    end
-    if(_zz_249)begin
-      if(_zz_250)begin
-        if(_zz_126)begin
-          _zz_119 = 1'b1;
-        end
-      end
-    end
-    if(_zz_251)begin
-      if(_zz_252)begin
-        if(_zz_128)begin
-          _zz_119 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_119 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_123 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_124 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_125 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_126 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_127 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_128 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_129 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_129 == 3'b000)) begin
-        _zz_130 = execute_BranchPlugin_eq;
-    end else if((_zz_129 == 3'b001)) begin
-        _zz_130 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_129 & 3'b101) == 3'b101))) begin
-        _zz_130 = (! execute_SRC_LESS);
-    end else begin
-        _zz_130 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_131 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_131 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_131 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_131 = _zz_130;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_132 = _zz_326[11];
-  always @ (*) begin
-    _zz_133[19] = _zz_132;
-    _zz_133[18] = _zz_132;
-    _zz_133[17] = _zz_132;
-    _zz_133[16] = _zz_132;
-    _zz_133[15] = _zz_132;
-    _zz_133[14] = _zz_132;
-    _zz_133[13] = _zz_132;
-    _zz_133[12] = _zz_132;
-    _zz_133[11] = _zz_132;
-    _zz_133[10] = _zz_132;
-    _zz_133[9] = _zz_132;
-    _zz_133[8] = _zz_132;
-    _zz_133[7] = _zz_132;
-    _zz_133[6] = _zz_132;
-    _zz_133[5] = _zz_132;
-    _zz_133[4] = _zz_132;
-    _zz_133[3] = _zz_132;
-    _zz_133[2] = _zz_132;
-    _zz_133[1] = _zz_132;
-    _zz_133[0] = _zz_132;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_134 = _zz_327[19];
-  always @ (*) begin
-    _zz_135[10] = _zz_134;
-    _zz_135[9] = _zz_134;
-    _zz_135[8] = _zz_134;
-    _zz_135[7] = _zz_134;
-    _zz_135[6] = _zz_134;
-    _zz_135[5] = _zz_134;
-    _zz_135[4] = _zz_134;
-    _zz_135[3] = _zz_134;
-    _zz_135[2] = _zz_134;
-    _zz_135[1] = _zz_134;
-    _zz_135[0] = _zz_134;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_136 = _zz_328[11];
-  always @ (*) begin
-    _zz_137[18] = _zz_136;
-    _zz_137[17] = _zz_136;
-    _zz_137[16] = _zz_136;
-    _zz_137[15] = _zz_136;
-    _zz_137[14] = _zz_136;
-    _zz_137[13] = _zz_136;
-    _zz_137[12] = _zz_136;
-    _zz_137[11] = _zz_136;
-    _zz_137[10] = _zz_136;
-    _zz_137[9] = _zz_136;
-    _zz_137[8] = _zz_136;
-    _zz_137[7] = _zz_136;
-    _zz_137[6] = _zz_136;
-    _zz_137[5] = _zz_136;
-    _zz_137[4] = _zz_136;
-    _zz_137[3] = _zz_136;
-    _zz_137[2] = _zz_136;
-    _zz_137[1] = _zz_136;
-    _zz_137[0] = _zz_136;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_138 = (_zz_329[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_138 = _zz_330[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_138 = _zz_331[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_138);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -4140,183 +4302,195 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_139 = _zz_332[11];
-  always @ (*) begin
-    _zz_140[19] = _zz_139;
-    _zz_140[18] = _zz_139;
-    _zz_140[17] = _zz_139;
-    _zz_140[16] = _zz_139;
-    _zz_140[15] = _zz_139;
-    _zz_140[14] = _zz_139;
-    _zz_140[13] = _zz_139;
-    _zz_140[12] = _zz_139;
-    _zz_140[11] = _zz_139;
-    _zz_140[10] = _zz_139;
-    _zz_140[9] = _zz_139;
-    _zz_140[8] = _zz_139;
-    _zz_140[7] = _zz_139;
-    _zz_140[6] = _zz_139;
-    _zz_140[5] = _zz_139;
-    _zz_140[4] = _zz_139;
-    _zz_140[3] = _zz_139;
-    _zz_140[2] = _zz_139;
-    _zz_140[1] = _zz_139;
-    _zz_140[0] = _zz_139;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_140,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_142,{{{_zz_562,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_144,{{{_zz_563,_zz_564},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_335};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_141 = _zz_333[19];
-  always @ (*) begin
-    _zz_142[10] = _zz_141;
-    _zz_142[9] = _zz_141;
-    _zz_142[8] = _zz_141;
-    _zz_142[7] = _zz_141;
-    _zz_142[6] = _zz_141;
-    _zz_142[5] = _zz_141;
-    _zz_142[4] = _zz_141;
-    _zz_142[3] = _zz_141;
-    _zz_142[2] = _zz_141;
-    _zz_142[1] = _zz_141;
-    _zz_142[0] = _zz_141;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_143 = _zz_334[11];
-  always @ (*) begin
-    _zz_144[18] = _zz_143;
-    _zz_144[17] = _zz_143;
-    _zz_144[16] = _zz_143;
-    _zz_144[15] = _zz_143;
-    _zz_144[14] = _zz_143;
-    _zz_144[13] = _zz_143;
-    _zz_144[12] = _zz_143;
-    _zz_144[11] = _zz_143;
-    _zz_144[10] = _zz_143;
-    _zz_144[9] = _zz_143;
-    _zz_144[8] = _zz_143;
-    _zz_144[7] = _zz_143;
-    _zz_144[6] = _zz_143;
-    _zz_144[5] = _zz_143;
-    _zz_144[4] = _zz_143;
-    _zz_144[3] = _zz_143;
-    _zz_144[2] = _zz_143;
-    _zz_144[1] = _zz_143;
-    _zz_144[0] = _zz_143;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
-  always @ (*) begin
+  always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(1'b0)begin
+    if(when_BranchPlugin_l296) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
+  assign when_BranchPlugin_l296 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_145 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_146 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_147 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_148 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_149 = _zz_336[0];
-  assign _zz_150 = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
-  assign _zz_151 = _zz_338[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_237)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(_zz_240)begin
+    if(_zz_when_1) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(CfuPlugin_joinException_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
-    end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4327,8 +4501,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4338,135 +4512,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_253)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_254)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_255)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_254)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_255)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4479,39 +4662,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_253)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_253)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_268)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_256)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4524,8 +4717,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_256)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4544,58 +4737,69 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_340) + $signed(_zz_341));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_232)begin
-      if(_zz_257)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_258)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_345);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_152 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_152[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_346);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_347 : _zz_348);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_349[31:0];
-  assign _zz_153 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_154 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_155 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_156[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_156[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_158 = (_zz_157 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_158 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_259)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -4605,9 +4809,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_159))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4616,12 +4820,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_259)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -4632,105 +4837,175 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
   assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign when_CfuPlugin_l171 = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
+  assign when_CfuPlugin_l171_1 = (! execute_arbitration_isStuckByOthers);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign execute_CfuPlugin_functionsIds_0 = _zz_359;
+  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
-  assign _zz_160 = _zz_360[7];
-  always @ (*) begin
-    _zz_161[23] = _zz_160;
-    _zz_161[22] = _zz_160;
-    _zz_161[21] = _zz_160;
-    _zz_161[20] = _zz_160;
-    _zz_161[19] = _zz_160;
-    _zz_161[18] = _zz_160;
-    _zz_161[17] = _zz_160;
-    _zz_161[16] = _zz_160;
-    _zz_161[15] = _zz_160;
-    _zz_161[14] = _zz_160;
-    _zz_161[13] = _zz_160;
-    _zz_161[12] = _zz_160;
-    _zz_161[11] = _zz_160;
-    _zz_161[10] = _zz_160;
-    _zz_161[9] = _zz_160;
-    _zz_161[8] = _zz_160;
-    _zz_161[7] = _zz_160;
-    _zz_161[6] = _zz_160;
-    _zz_161[5] = _zz_160;
-    _zz_161[4] = _zz_160;
-    _zz_161[3] = _zz_160;
-    _zz_161[2] = _zz_160;
-    _zz_161[1] = _zz_160;
-    _zz_161[0] = _zz_160;
+  assign _zz_CfuPlugin_bus_cmd_payload_inputs_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[23] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[22] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[21] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[20] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[19] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[18] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[17] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[16] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[15] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[14] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[13] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[12] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[11] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[10] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[9] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[8] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[7] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[6] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[5] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[4] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[3] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[2] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[1] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
+    _zz_CfuPlugin_bus_cmd_payload_inputs_1_1[0] = _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
       `Input2Kind_defaultEncoding_RS : begin
-        _zz_162 = execute_RS2;
+        _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
-        _zz_162 = {_zz_161,execute_INSTRUCTION[31 : 24]};
+        _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = {_zz_CfuPlugin_bus_cmd_payload_inputs_1_1,execute_INSTRUCTION[31 : 24]};
       end
     endcase
   end
 
-  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_162;
+  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_s2mPipe_rValid);
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_s2mPipe_rValid);
-  assign memory_CfuPlugin_rsp_payload_response_ok = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_response_ok : CfuPlugin_bus_rsp_payload_response_ok);
   assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
-  always @ (*) begin
-    CfuPlugin_joinException_valid = 1'b0;
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
-      if(memory_arbitration_isValid)begin
-        CfuPlugin_joinException_valid = (! memory_CfuPlugin_rsp_payload_response_ok);
-      end
-    end
-  end
-
-  assign CfuPlugin_joinException_payload_code = 4'b1111;
-  assign CfuPlugin_joinException_payload_badAddr = 32'h0;
-  always @ (*) begin
+  assign when_Stream_l365_1 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
+  always @(*) begin
     memory_CfuPlugin_rsp_ready = 1'b0;
-    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+    if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
       memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign _zz_29 = decode_SRC1_CTRL;
-  assign _zz_27 = _zz_56;
-  assign _zz_43 = decode_to_execute_SRC1_CTRL;
-  assign _zz_26 = decode_ALU_CTRL;
-  assign _zz_24 = _zz_55;
-  assign _zz_44 = decode_to_execute_ALU_CTRL;
-  assign _zz_23 = decode_SRC2_CTRL;
-  assign _zz_21 = _zz_54;
-  assign _zz_42 = decode_to_execute_SRC2_CTRL;
-  assign _zz_20 = decode_ALU_BITWISE_CTRL;
-  assign _zz_18 = _zz_53;
-  assign _zz_45 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_17 = decode_SHIFT_CTRL;
-  assign _zz_14 = execute_SHIFT_CTRL;
-  assign _zz_15 = _zz_52;
-  assign _zz_40 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_39 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_12 = decode_BRANCH_CTRL;
-  assign _zz_58 = _zz_51;
-  assign _zz_36 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_10 = decode_ENV_CTRL;
-  assign _zz_7 = execute_ENV_CTRL;
-  assign _zz_5 = memory_ENV_CTRL;
-  assign _zz_8 = _zz_50;
-  assign _zz_34 = decode_to_execute_ENV_CTRL;
-  assign _zz_33 = execute_to_memory_ENV_CTRL;
-  assign _zz_35 = memory_to_writeBack_ENV_CTRL;
-  assign _zz_3 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_1 = _zz_49;
-  assign _zz_32 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  assign when_CfuPlugin_l208 = (! memory_CfuPlugin_rsp_valid);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4751,9 +5026,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_163)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -4762,240 +5043,269 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_164[12 : 0] = 13'h1000;
-      _zz_164[25 : 20] = 6'h20;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_165[3 : 0] = 4'b1011;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
     end
   end
 
-  always @ (*) begin
-    _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_166[4 : 0] = 5'h16;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
     end
   end
 
-  always @ (*) begin
-    _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_167[5 : 0] = 6'h21;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
     end
   end
 
-  always @ (*) begin
-    _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_168[31 : 30] = CsrPlugin_misa_base;
-      _zz_168[25 : 0] = CsrPlugin_misa_extensions;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_169[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_169[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_169[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_170[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_170[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_170[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_171[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_171[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_171[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_172[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_172[1 : 0] = CsrPlugin_mtvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_173[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_174 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_174[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_175[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_175[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_176[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_177[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_178[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_179[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_180[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_181[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_182[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_183 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_183[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_184 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_184[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_185 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_185[31 : 0] = _zz_157;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_186 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_186[31 : 0] = _zz_158;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_164 | _zz_165) | (_zz_166 | _zz_167)) | ((_zz_565 | _zz_168) | (_zz_169 | _zz_170))) | (((_zz_171 | _zz_172) | (_zz_173 | _zz_174)) | ((_zz_175 | _zz_176) | (_zz_177 | _zz_178)))) | (((_zz_179 | _zz_180) | (_zz_181 | _zz_182)) | ((_zz_183 | _zz_184) | (_zz_185 | _zz_186))));
-  assign iBusWishbone_ADR = {_zz_368,_zz_187};
-  assign iBusWishbone_CTI = ((_zz_187 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_260)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_260)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_188;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_194 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_190 = dBus_cmd_valid;
-  assign _zz_192 = dBus_cmd_payload_wr;
-  assign _zz_193 = (_zz_189 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_191 && (_zz_192 || _zz_193));
-  assign dBusWishbone_ADR = ((_zz_194 ? {{dBus_cmd_payload_address[31 : 5],_zz_189},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_194 ? (_zz_193 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_192 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_192;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_191 = (_zz_190 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_190;
-  assign dBusWishbone_STB = _zz_190;
-  assign dBus_rsp_valid = _zz_195;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_72 <= 1'b0;
-      _zz_74 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_87;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_88;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_108 <= 1'b1;
-      _zz_120 <= 1'b0;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5016,164 +5326,164 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_157 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_CfuPlugin_hold <= 1'b0;
       execute_CfuPlugin_fired <= 1'b0;
       CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_163 <= 3'b000;
+      switch_Fetcher_l362 <= 3'b000;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
-      _zz_187 <= 3'b000;
-      _zz_188 <= 1'b0;
-      _zz_189 <= 3'b000;
-      _zz_195 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_72 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_70)begin
-        _zz_72 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_74 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_74 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_261)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_108 <= 1'b0;
-      _zz_120 <= (_zz_47 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_262)begin
-        if(_zz_263)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_264)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_265)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_242)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5184,8 +5494,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_243)begin
-        case(_zz_245)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5195,185 +5505,181 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_147,{_zz_146,_zz_145}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(execute_CfuPlugin_schedule)begin
+      if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
       end
-      if(CfuPlugin_bus_cmd_ready)begin
+      if(CfuPlugin_bus_cmd_ready) begin
         execute_CfuPlugin_hold <= 1'b0;
       end
-      if((CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready))begin
+      if(when_CfuPlugin_l171) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if((! execute_arbitration_isStuckByOthers))begin
+      if(when_CfuPlugin_l171_1) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
-      if(memory_CfuPlugin_rsp_ready)begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_266)begin
+      if(when_Stream_l365_1) begin
         CfuPlugin_bus_rsp_s2mPipe_rValid <= CfuPlugin_bus_rsp_valid;
       end
-      if((! memory_arbitration_isStuck))begin
-        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_31;
+      if(when_Pipeline_l124_62) begin
+        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_163)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_163 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_163 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_163 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_163 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_163 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_361[0];
-          CsrPlugin_mstatus_MIE <= _zz_362[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_364[0];
-          CsrPlugin_mie_MTIE <= _zz_365[0];
-          CsrPlugin_mie_MSIE <= _zz_366[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_157 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_260)begin
-        if(iBusWishbone_ACK)begin
-          _zz_187 <= (_zz_187 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_188 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_190 && _zz_191))begin
-        _zz_189 <= (_zz_189 + 3'b001);
-        if(_zz_193)begin
-          _zz_189 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_195 <= ((_zz_190 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_75 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_261)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_121 <= _zz_46[11 : 7];
-    _zz_122 <= _zz_57;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_237)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(_zz_240)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_151 ? BranchPlugin_branchExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_151 ? BranchPlugin_branchExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
+    if(_zz_when_1) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? BranchPlugin_branchExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? BranchPlugin_branchExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
     end
-    if(CfuPlugin_joinException_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CfuPlugin_joinException_payload_code;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CfuPlugin_joinException_payload_badAddr;
-    end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_262)begin
-      if(_zz_263)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_264)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_265)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_242)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -5381,402 +5687,412 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_232)begin
-      if(_zz_257)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_350[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_258)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_155 ? (~ _zz_156) : _zz_156) + _zz_356);
-      memory_DivPlugin_rs2 <= ((_zz_154 ? (~ execute_RS2) : execute_RS2) + _zz_358);
-      memory_DivPlugin_div_needRevert <= ((_zz_155 ^ (_zz_154 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if(_zz_266)begin
-      CfuPlugin_bus_rsp_s2mPipe_rData_response_ok <= CfuPlugin_bus_rsp_payload_response_ok;
+    if(when_Stream_l365_1) begin
       CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_41;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_60;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_59;
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_execute_to_memory_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_8) begin
       memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_28;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_25;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_22;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_19;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_16;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_11;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_9;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_4;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_2;
+    if(when_Pipeline_l124_44) begin
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_52) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_53) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_37;
+    if(when_Pipeline_l124_54) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_38;
+    if(when_Pipeline_l124_55) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_30;
+    if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_64) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_363[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_367[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_57;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_159 <= debug_bus_cmd_payload_address[2];
-    if(_zz_239)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_259)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -5784,14 +6100,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_239)begin
-        if(_zz_241)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_244)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -5804,9 +6120,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -5828,6 +6143,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5843,9 +6159,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5853,7 +6170,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5862,24 +6179,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5904,40 +6212,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5947,23 +6263,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5971,10 +6297,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5986,59 +6320,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -6053,274 +6382,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6328,89 +6676,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -6418,12 +6750,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6434,20 +6766,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6455,45 +6807,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6504,46 +6858,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6551,50 +6896,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6641,18 +6987,14 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
+  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [21:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [21:0]   _zz_17;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6661,8 +7003,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6676,22 +7023,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -6701,82 +7051,86 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
+  wire                when_Fetcher_l398;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_13 = (! lineLoader_flushCounter[7]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6792,30 +7146,36 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6823,51 +7183,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_14)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -6878,14 +7238,14 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
+    if(when_Fetcher_l398) begin
+      io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -82,37 +82,37 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  reg                 _zz_190;
-  wire                _zz_191;
-  wire       [31:0]   _zz_192;
-  wire                _zz_193;
-  wire       [31:0]   _zz_194;
-  reg                 _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire       [31:0]   _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  wire       [3:0]    _zz_207;
-  wire                _zz_208;
-  wire                _zz_209;
-  reg        [31:0]   _zz_210;
-  reg        [31:0]   _zz_211;
-  reg        [31:0]   _zz_212;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -135,6 +135,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -143,335 +144,274 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire                _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire                _zz_228;
-  wire                _zz_229;
-  wire       [1:0]    _zz_230;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  wire                _zz_240;
-  wire       [1:0]    _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire       [5:0]    _zz_244;
-  wire                _zz_245;
-  wire                _zz_246;
-  wire                _zz_247;
-  wire                _zz_248;
-  wire                _zz_249;
-  wire                _zz_250;
-  wire       [1:0]    _zz_251;
-  wire                _zz_252;
-  wire       [1:0]    _zz_253;
-  wire       [51:0]   _zz_254;
-  wire       [51:0]   _zz_255;
-  wire       [51:0]   _zz_256;
-  wire       [32:0]   _zz_257;
-  wire       [51:0]   _zz_258;
-  wire       [49:0]   _zz_259;
-  wire       [51:0]   _zz_260;
-  wire       [49:0]   _zz_261;
-  wire       [51:0]   _zz_262;
-  wire       [32:0]   _zz_263;
-  wire       [31:0]   _zz_264;
-  wire       [32:0]   _zz_265;
-  wire       [0:0]    _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [0:0]    _zz_268;
-  wire       [0:0]    _zz_269;
-  wire       [0:0]    _zz_270;
-  wire       [0:0]    _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [0:0]    _zz_273;
-  wire       [0:0]    _zz_274;
-  wire       [0:0]    _zz_275;
-  wire       [0:0]    _zz_276;
-  wire       [0:0]    _zz_277;
-  wire       [0:0]    _zz_278;
-  wire       [0:0]    _zz_279;
-  wire       [0:0]    _zz_280;
-  wire       [0:0]    _zz_281;
-  wire       [0:0]    _zz_282;
-  wire       [0:0]    _zz_283;
-  wire       [3:0]    _zz_284;
-  wire       [2:0]    _zz_285;
-  wire       [31:0]   _zz_286;
-  wire       [11:0]   _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [19:0]   _zz_289;
-  wire       [11:0]   _zz_290;
-  wire       [31:0]   _zz_291;
-  wire       [31:0]   _zz_292;
-  wire       [19:0]   _zz_293;
-  wire       [11:0]   _zz_294;
-  wire       [2:0]    _zz_295;
-  wire       [2:0]    _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [2:0]    _zz_298;
-  wire       [4:0]    _zz_299;
-  wire       [11:0]   _zz_300;
-  wire       [11:0]   _zz_301;
-  wire       [31:0]   _zz_302;
-  wire       [31:0]   _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [31:0]   _zz_306;
-  wire       [31:0]   _zz_307;
-  wire       [31:0]   _zz_308;
-  wire       [11:0]   _zz_309;
-  wire       [19:0]   _zz_310;
-  wire       [11:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  wire       [31:0]   _zz_314;
-  wire       [11:0]   _zz_315;
-  wire       [19:0]   _zz_316;
-  wire       [11:0]   _zz_317;
-  wire       [2:0]    _zz_318;
-  wire       [1:0]    _zz_319;
-  wire       [1:0]    _zz_320;
-  wire       [65:0]   _zz_321;
-  wire       [65:0]   _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [31:0]   _zz_324;
-  wire       [0:0]    _zz_325;
-  wire       [5:0]    _zz_326;
-  wire       [32:0]   _zz_327;
-  wire       [31:0]   _zz_328;
-  wire       [31:0]   _zz_329;
-  wire       [32:0]   _zz_330;
-  wire       [32:0]   _zz_331;
-  wire       [32:0]   _zz_332;
-  wire       [32:0]   _zz_333;
-  wire       [0:0]    _zz_334;
-  wire       [32:0]   _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [32:0]   _zz_337;
-  wire       [0:0]    _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [0:0]    _zz_340;
-  wire       [0:0]    _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [0:0]    _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [0:0]    _zz_346;
-  wire       [26:0]   _zz_347;
-  wire                _zz_348;
-  wire                _zz_349;
-  wire       [1:0]    _zz_350;
-  wire       [31:0]   _zz_351;
-  wire       [31:0]   _zz_352;
-  wire       [31:0]   _zz_353;
-  wire                _zz_354;
-  wire       [0:0]    _zz_355;
-  wire       [13:0]   _zz_356;
-  wire       [31:0]   _zz_357;
-  wire       [31:0]   _zz_358;
-  wire       [31:0]   _zz_359;
-  wire                _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [7:0]    _zz_362;
-  wire       [31:0]   _zz_363;
-  wire       [31:0]   _zz_364;
-  wire       [31:0]   _zz_365;
-  wire                _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [1:0]    _zz_368;
-  wire                _zz_369;
-  wire                _zz_370;
-  wire                _zz_371;
-  wire       [31:0]   _zz_372;
-  wire       [0:0]    _zz_373;
-  wire       [0:0]    _zz_374;
-  wire                _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [26:0]   _zz_377;
-  wire       [31:0]   _zz_378;
-  wire                _zz_379;
-  wire                _zz_380;
-  wire                _zz_381;
-  wire       [1:0]    _zz_382;
-  wire       [1:0]    _zz_383;
-  wire                _zz_384;
-  wire       [0:0]    _zz_385;
-  wire       [22:0]   _zz_386;
-  wire       [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
-  wire       [31:0]   _zz_390;
-  wire                _zz_391;
-  wire                _zz_392;
-  wire       [1:0]    _zz_393;
-  wire       [1:0]    _zz_394;
-  wire                _zz_395;
-  wire       [0:0]    _zz_396;
-  wire       [19:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [31:0]   _zz_399;
-  wire       [31:0]   _zz_400;
-  wire       [31:0]   _zz_401;
-  wire                _zz_402;
-  wire       [0:0]    _zz_403;
-  wire       [0:0]    _zz_404;
-  wire                _zz_405;
-  wire       [0:0]    _zz_406;
-  wire       [0:0]    _zz_407;
-  wire                _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [16:0]   _zz_410;
-  wire       [31:0]   _zz_411;
-  wire       [31:0]   _zz_412;
-  wire       [31:0]   _zz_413;
-  wire       [31:0]   _zz_414;
-  wire       [31:0]   _zz_415;
-  wire       [0:0]    _zz_416;
-  wire       [0:0]    _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [0:0]    _zz_419;
-  wire                _zz_420;
-  wire       [0:0]    _zz_421;
-  wire       [13:0]   _zz_422;
-  wire       [31:0]   _zz_423;
-  wire       [31:0]   _zz_424;
-  wire       [31:0]   _zz_425;
-  wire                _zz_426;
-  wire                _zz_427;
-  wire       [0:0]    _zz_428;
-  wire       [3:0]    _zz_429;
-  wire       [0:0]    _zz_430;
-  wire       [0:0]    _zz_431;
-  wire                _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [10:0]   _zz_434;
-  wire       [31:0]   _zz_435;
-  wire       [31:0]   _zz_436;
-  wire       [31:0]   _zz_437;
-  wire                _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [31:0]   _zz_441;
-  wire                _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [2:0]    _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [3:0]    _zz_446;
-  wire       [5:0]    _zz_447;
-  wire       [5:0]    _zz_448;
-  wire                _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [7:0]    _zz_451;
-  wire       [31:0]   _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire                _zz_458;
-  wire       [0:0]    _zz_459;
-  wire       [0:0]    _zz_460;
-  wire                _zz_461;
-  wire       [0:0]    _zz_462;
-  wire       [1:0]    _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [3:0]    _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [0:0]    _zz_467;
-  wire       [1:0]    _zz_468;
-  wire       [1:0]    _zz_469;
-  wire                _zz_470;
-  wire       [0:0]    _zz_471;
-  wire       [5:0]    _zz_472;
-  wire       [31:0]   _zz_473;
-  wire       [31:0]   _zz_474;
-  wire       [31:0]   _zz_475;
-  wire       [31:0]   _zz_476;
-  wire       [31:0]   _zz_477;
-  wire       [31:0]   _zz_478;
-  wire       [31:0]   _zz_479;
-  wire       [31:0]   _zz_480;
-  wire                _zz_481;
-  wire                _zz_482;
-  wire       [31:0]   _zz_483;
-  wire       [31:0]   _zz_484;
-  wire                _zz_485;
-  wire       [0:0]    _zz_486;
-  wire       [1:0]    _zz_487;
-  wire       [31:0]   _zz_488;
-  wire       [31:0]   _zz_489;
-  wire                _zz_490;
-  wire                _zz_491;
-  wire       [0:0]    _zz_492;
-  wire       [0:0]    _zz_493;
-  wire                _zz_494;
-  wire       [0:0]    _zz_495;
-  wire       [3:0]    _zz_496;
-  wire       [31:0]   _zz_497;
-  wire       [31:0]   _zz_498;
-  wire       [31:0]   _zz_499;
-  wire       [31:0]   _zz_500;
-  wire       [31:0]   _zz_501;
-  wire                _zz_502;
-  wire                _zz_503;
-  wire       [31:0]   _zz_504;
-  wire       [31:0]   _zz_505;
-  wire       [31:0]   _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [0:0]    _zz_508;
-  wire       [2:0]    _zz_509;
-  wire       [0:0]    _zz_510;
-  wire       [0:0]    _zz_511;
-  wire                _zz_512;
-  wire       [0:0]    _zz_513;
-  wire       [1:0]    _zz_514;
-  wire       [31:0]   _zz_515;
-  wire       [31:0]   _zz_516;
-  wire       [31:0]   _zz_517;
-  wire                _zz_518;
-  wire                _zz_519;
-  wire       [31:0]   _zz_520;
-  wire                _zz_521;
-  wire       [0:0]    _zz_522;
-  wire       [0:0]    _zz_523;
-  wire       [0:0]    _zz_524;
-  wire       [0:0]    _zz_525;
-  wire       [1:0]    _zz_526;
-  wire       [1:0]    _zz_527;
-  wire       [0:0]    _zz_528;
-  wire       [0:0]    _zz_529;
-  wire       [31:0]   _zz_530;
-  wire       [31:0]   _zz_531;
-  wire       [31:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire                _zz_536;
-  wire                _zz_537;
-  wire                _zz_538;
-  wire       [31:0]   _zz_539;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire       [26:0]   _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [16:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -482,8 +422,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
@@ -495,27 +435,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -524,17 +464,17 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -557,11 +497,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -569,10 +509,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -582,45 +522,45 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -639,10 +579,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -729,7 +669,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -755,7 +695,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_54;
+  reg                 _zz_when_DBusCachedPlugin_l386;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -764,6 +704,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -781,31 +726,37 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -828,16 +779,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63;
-  wire                _zz_64;
-  reg                 _zz_65;
-  wire                _zz_66;
-  reg                 _zz_67;
-  reg        [31:0]   _zz_68;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -845,22 +798,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69;
-  reg        [18:0]   _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
-  reg                 _zz_75;
-  wire                _zz_76;
-  reg        [10:0]   _zz_77;
-  wire                _zz_78;
-  reg        [18:0]   _zz_79;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -868,7 +828,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -876,6 +836,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -883,7 +848,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -891,8 +856,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -900,38 +866,52 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83;
-  reg        [31:0]   _zz_84;
-  wire                _zz_85;
-  reg        [31:0]   _zz_86;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
-  wire                _zz_90;
-  wire                _zz_91;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_92;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_94;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_96;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_97;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_98;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -939,52 +919,70 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100;
-  reg        [31:0]   _zz_101;
-  wire                _zz_102;
-  reg        [19:0]   _zz_103;
-  wire                _zz_104;
-  reg        [19:0]   _zz_105;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_107;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
-  reg                 _zz_111;
-  reg        [4:0]    _zz_112;
-  reg        [31:0]   _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire                _zz_118;
-  wire                _zz_119;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_120;
-  reg                 _zz_121;
-  reg                 _zz_122;
-  wire                _zz_123;
-  reg        [19:0]   _zz_124;
-  wire                _zz_125;
-  reg        [10:0]   _zz_126;
-  wire                _zz_127;
-  reg        [18:0]   _zz_128;
-  reg                 _zz_129;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_130;
-  reg        [19:0]   _zz_131;
-  wire                _zz_132;
-  reg        [10:0]   _zz_133;
-  wire                _zz_134;
-  reg        [18:0]   _zz_135;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1006,9 +1004,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1021,40 +1019,67 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_139;
-  wire                _zz_140;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1062,6 +1087,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1074,19 +1101,26 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_141;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
-  reg        [32:0]   _zz_145;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_146;
-  wire       [31:0]   _zz_147;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1094,208 +1128,323 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_148;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_DO_EBREAK;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_50;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_51;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_54;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_55;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_62;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_149;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [31:0]   _zz_156;
-  reg        [31:0]   _zz_157;
-  reg        [31:0]   _zz_158;
-  reg        [31:0]   _zz_159;
-  reg        [31:0]   _zz_160;
-  reg        [31:0]   _zz_161;
-  reg        [31:0]   _zz_162;
-  reg        [31:0]   _zz_163;
-  reg        [31:0]   _zz_164;
-  reg        [31:0]   _zz_165;
-  reg        [31:0]   _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  reg        [31:0]   _zz_172;
-  reg        [2:0]    _zz_173;
-  reg                 _zz_174;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_175;
-  wire                _zz_176;
-  wire                _zz_177;
-  wire                _zz_178;
-  wire                _zz_179;
-  wire                _zz_180;
-  reg                 _zz_181;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_51_string;
-  reg [95:0] _zz_92_string;
-  reg [63:0] _zz_93_string;
-  reg [23:0] _zz_94_string;
-  reg [39:0] _zz_95_string;
-  reg [71:0] _zz_96_string;
-  reg [31:0] _zz_97_string;
-  reg [39:0] _zz_98_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1304,508 +1453,471 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_213 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_214 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_215 = 1'b1;
-  assign _zz_216 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_217 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_218 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_219 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_220 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_221 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_222 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_223 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_224 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_225 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_226 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_227 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_228 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_229 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_230 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_231 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_232 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_233 = (1'b0 || (! 1'b1));
-  assign _zz_234 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_235 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_236 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_237 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_238 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_239 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_240 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_241 = execute_INSTRUCTION[13 : 12];
-  assign _zz_242 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_243 = (! memory_arbitration_isStuck);
-  assign _zz_244 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_245 = (iBus_cmd_valid || (_zz_173 != 3'b000));
-  assign _zz_246 = (_zz_209 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_247 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_248 = ((_zz_136 && 1'b1) && (! 1'b0));
-  assign _zz_249 = ((_zz_137 && 1'b1) && (! 1'b0));
-  assign _zz_250 = ((_zz_138 && 1'b1) && (! 1'b0));
-  assign _zz_251 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_252 = execute_INSTRUCTION[13];
-  assign _zz_253 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_254 = ($signed(_zz_255) + $signed(_zz_260));
-  assign _zz_255 = ($signed(_zz_256) + $signed(_zz_258));
-  assign _zz_256 = 52'h0;
-  assign _zz_257 = {1'b0,memory_MUL_LL};
-  assign _zz_258 = {{19{_zz_257[32]}}, _zz_257};
-  assign _zz_259 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_260 = {{2{_zz_259[49]}}, _zz_259};
-  assign _zz_261 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_262 = {{2{_zz_261[49]}}, _zz_261};
-  assign _zz_263 = ($signed(_zz_265) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_264 = _zz_263[31 : 0];
-  assign _zz_265 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_266 = _zz_87[31 : 31];
-  assign _zz_267 = _zz_87[30 : 30];
-  assign _zz_268 = _zz_87[29 : 29];
-  assign _zz_269 = _zz_87[28 : 28];
-  assign _zz_270 = _zz_87[25 : 25];
-  assign _zz_271 = _zz_87[17 : 17];
-  assign _zz_272 = _zz_87[16 : 16];
-  assign _zz_273 = _zz_87[13 : 13];
-  assign _zz_274 = _zz_87[12 : 12];
-  assign _zz_275 = _zz_87[11 : 11];
-  assign _zz_276 = _zz_87[32 : 32];
-  assign _zz_277 = _zz_87[15 : 15];
-  assign _zz_278 = _zz_87[5 : 5];
-  assign _zz_279 = _zz_87[3 : 3];
-  assign _zz_280 = _zz_87[20 : 20];
-  assign _zz_281 = _zz_87[10 : 10];
-  assign _zz_282 = _zz_87[4 : 4];
-  assign _zz_283 = _zz_87[0 : 0];
-  assign _zz_284 = (_zz_55 - 4'b0001);
-  assign _zz_285 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_286 = {29'd0, _zz_285};
-  assign _zz_287 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_288 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_289 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_290 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_291 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_292 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_293 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_294 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_295 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_296 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_297 = execute_SRC_LESS;
-  assign _zz_298 = 3'b100;
-  assign _zz_299 = execute_INSTRUCTION[19 : 15];
-  assign _zz_300 = execute_INSTRUCTION[31 : 20];
-  assign _zz_301 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_302 = ($signed(_zz_303) + $signed(_zz_306));
-  assign _zz_303 = ($signed(_zz_304) + $signed(_zz_305));
-  assign _zz_304 = execute_SRC1;
-  assign _zz_305 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_306 = (execute_SRC_USE_SUB_LESS ? _zz_307 : _zz_308);
-  assign _zz_307 = 32'h00000001;
-  assign _zz_308 = 32'h0;
-  assign _zz_309 = execute_INSTRUCTION[31 : 20];
-  assign _zz_310 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_311 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_312 = {_zz_124,execute_INSTRUCTION[31 : 20]};
-  assign _zz_313 = {{_zz_126,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_314 = {{_zz_128,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_315 = execute_INSTRUCTION[31 : 20];
-  assign _zz_316 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_317 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_318 = 3'b100;
-  assign _zz_319 = (_zz_139 & (~ _zz_320));
-  assign _zz_320 = (_zz_139 - 2'b01);
-  assign _zz_321 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_322 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_323 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_324 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_325 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_326 = {5'd0, _zz_325};
-  assign _zz_327 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_328 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_329 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_330 = {_zz_141,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_331 = _zz_332;
-  assign _zz_332 = _zz_333;
-  assign _zz_333 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_142) : _zz_142)} + _zz_335);
-  assign _zz_334 = memory_DivPlugin_div_needRevert;
-  assign _zz_335 = {32'd0, _zz_334};
-  assign _zz_336 = _zz_144;
-  assign _zz_337 = {32'd0, _zz_336};
-  assign _zz_338 = _zz_143;
-  assign _zz_339 = {31'd0, _zz_338};
-  assign _zz_340 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_341 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_342 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_343 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_344 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_345 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_346 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_347 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_348 = 1'b1;
-  assign _zz_349 = 1'b1;
-  assign _zz_350 = {_zz_59,_zz_58};
-  assign _zz_351 = 32'h0000107f;
-  assign _zz_352 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_353 = 32'h00002073;
-  assign _zz_354 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_355 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_356 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_357) == 32'h00000003),{(_zz_358 == _zz_359),{_zz_360,{_zz_361,_zz_362}}}}}};
-  assign _zz_357 = 32'h0000505f;
-  assign _zz_358 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_359 = 32'h00000063;
-  assign _zz_360 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_361 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_362 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_363) == 32'h00001013),{(_zz_364 == _zz_365),{_zz_366,{_zz_367,_zz_368}}}}}};
-  assign _zz_363 = 32'hfc00307f;
-  assign _zz_364 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_365 = 32'h00005033;
-  assign _zz_366 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_367 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_368 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_369 = decode_INSTRUCTION[31];
-  assign _zz_370 = decode_INSTRUCTION[31];
-  assign _zz_371 = decode_INSTRUCTION[7];
-  assign _zz_372 = 32'h10103050;
-  assign _zz_373 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_374 = 1'b0;
-  assign _zz_375 = (((decode_INSTRUCTION & _zz_378) == 32'h02000030) != 1'b0);
-  assign _zz_376 = ({_zz_379,_zz_380} != 2'b00);
-  assign _zz_377 = {(_zz_381 != 1'b0),{(_zz_382 != _zz_383),{_zz_384,{_zz_385,_zz_386}}}};
-  assign _zz_378 = 32'h02004074;
-  assign _zz_379 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz_380 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_381 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz_382 = {(_zz_387 == _zz_388),(_zz_389 == _zz_390)};
-  assign _zz_383 = 2'b00;
-  assign _zz_384 = ({_zz_90,_zz_391} != 2'b00);
-  assign _zz_385 = (_zz_392 != 1'b0);
-  assign _zz_386 = {(_zz_393 != _zz_394),{_zz_395,{_zz_396,_zz_397}}};
-  assign _zz_387 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_388 = 32'h00001050;
-  assign _zz_389 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_390 = 32'h00002050;
-  assign _zz_391 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_392 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_393 = {(_zz_398 == _zz_399),(_zz_400 == _zz_401)};
-  assign _zz_394 = 2'b00;
-  assign _zz_395 = ({_zz_402,{_zz_403,_zz_404}} != 3'b000);
-  assign _zz_396 = (_zz_405 != 1'b0);
-  assign _zz_397 = {(_zz_406 != _zz_407),{_zz_408,{_zz_409,_zz_410}}};
-  assign _zz_398 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_399 = 32'h00005010;
-  assign _zz_400 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_401 = 32'h00005020;
-  assign _zz_402 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_403 = ((decode_INSTRUCTION & _zz_411) == 32'h00001010);
-  assign _zz_404 = ((decode_INSTRUCTION & _zz_412) == 32'h00001010);
-  assign _zz_405 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_406 = ((decode_INSTRUCTION & _zz_413) == 32'h00001000);
-  assign _zz_407 = 1'b0;
-  assign _zz_408 = ((_zz_414 == _zz_415) != 1'b0);
-  assign _zz_409 = ({_zz_416,_zz_417} != 2'b00);
-  assign _zz_410 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
-  assign _zz_411 = 32'h00007034;
-  assign _zz_412 = 32'h02007054;
-  assign _zz_413 = 32'h00001000;
-  assign _zz_414 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_415 = 32'h00002000;
-  assign _zz_416 = ((decode_INSTRUCTION & _zz_423) == 32'h00002000);
-  assign _zz_417 = ((decode_INSTRUCTION & _zz_424) == 32'h00001000);
-  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h00004008);
-  assign _zz_419 = 1'b0;
-  assign _zz_420 = ({_zz_426,_zz_427} != 2'b00);
-  assign _zz_421 = ({_zz_428,_zz_429} != 5'h0);
-  assign _zz_422 = {(_zz_430 != _zz_431),{_zz_432,{_zz_433,_zz_434}}};
-  assign _zz_423 = 32'h00002010;
-  assign _zz_424 = 32'h00005000;
-  assign _zz_425 = 32'h00004048;
-  assign _zz_426 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_427 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00002040);
-  assign _zz_429 = {(_zz_436 == _zz_437),{_zz_438,{_zz_439,_zz_440}}};
-  assign _zz_430 = ((decode_INSTRUCTION & _zz_441) == 32'h00000020);
-  assign _zz_431 = 1'b0;
-  assign _zz_432 = ({_zz_442,{_zz_443,_zz_444}} != 5'h0);
-  assign _zz_433 = ({_zz_445,_zz_446} != 5'h0);
-  assign _zz_434 = {(_zz_447 != _zz_448),{_zz_449,{_zz_450,_zz_451}}};
-  assign _zz_435 = 32'h00002040;
-  assign _zz_436 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_437 = 32'h00001040;
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_452) == 32'h00000040);
-  assign _zz_439 = (_zz_453 == _zz_454);
-  assign _zz_440 = (_zz_455 == _zz_456);
-  assign _zz_441 = 32'h00000020;
-  assign _zz_442 = ((decode_INSTRUCTION & _zz_457) == 32'h00000040);
-  assign _zz_443 = _zz_89;
-  assign _zz_444 = {_zz_458,{_zz_459,_zz_460}};
-  assign _zz_445 = _zz_89;
-  assign _zz_446 = {_zz_461,{_zz_462,_zz_463}};
-  assign _zz_447 = {_zz_90,{_zz_464,_zz_465}};
-  assign _zz_448 = 6'h0;
-  assign _zz_449 = ({_zz_466,_zz_467} != 2'b00);
-  assign _zz_450 = (_zz_468 != _zz_469);
-  assign _zz_451 = {_zz_470,{_zz_471,_zz_472}};
-  assign _zz_452 = 32'h00100040;
-  assign _zz_453 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_454 = 32'h00000040;
-  assign _zz_455 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_456 = 32'h0;
-  assign _zz_457 = 32'h00000040;
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_473) == 32'h00004020);
-  assign _zz_459 = (_zz_474 == _zz_475);
-  assign _zz_460 = (_zz_476 == _zz_477);
-  assign _zz_461 = ((decode_INSTRUCTION & _zz_478) == 32'h00002010);
-  assign _zz_462 = (_zz_479 == _zz_480);
-  assign _zz_463 = {_zz_481,_zz_482};
-  assign _zz_464 = (_zz_483 == _zz_484);
-  assign _zz_465 = {_zz_485,{_zz_486,_zz_487}};
-  assign _zz_466 = _zz_89;
-  assign _zz_467 = (_zz_488 == _zz_489);
-  assign _zz_468 = {_zz_89,_zz_490};
-  assign _zz_469 = 2'b00;
-  assign _zz_470 = (_zz_491 != 1'b0);
-  assign _zz_471 = (_zz_492 != _zz_493);
-  assign _zz_472 = {_zz_494,{_zz_495,_zz_496}};
-  assign _zz_473 = 32'h00004020;
-  assign _zz_474 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_475 = 32'h00000010;
-  assign _zz_476 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_477 = 32'h00000020;
-  assign _zz_478 = 32'h00002030;
-  assign _zz_479 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_480 = 32'h00000010;
-  assign _zz_481 = ((decode_INSTRUCTION & _zz_497) == 32'h00002020);
-  assign _zz_482 = ((decode_INSTRUCTION & _zz_498) == 32'h00000020);
-  assign _zz_483 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_484 = 32'h00001010;
-  assign _zz_485 = ((decode_INSTRUCTION & _zz_499) == 32'h00002010);
-  assign _zz_486 = (_zz_500 == _zz_501);
-  assign _zz_487 = {_zz_502,_zz_503};
-  assign _zz_488 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_489 = 32'h00000020;
-  assign _zz_490 = ((decode_INSTRUCTION & _zz_504) == 32'h0);
-  assign _zz_491 = ((decode_INSTRUCTION & _zz_505) == 32'h00004010);
-  assign _zz_492 = (_zz_506 == _zz_507);
-  assign _zz_493 = 1'b0;
-  assign _zz_494 = ({_zz_508,_zz_509} != 4'b0000);
-  assign _zz_495 = (_zz_510 != _zz_511);
-  assign _zz_496 = {_zz_512,{_zz_513,_zz_514}};
-  assign _zz_497 = 32'h02002060;
-  assign _zz_498 = 32'h02003020;
-  assign _zz_499 = 32'h00002010;
-  assign _zz_500 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_501 = 32'h00000010;
-  assign _zz_502 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_503 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_504 = 32'h00000020;
-  assign _zz_505 = 32'h00004014;
-  assign _zz_506 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_507 = 32'h00002010;
-  assign _zz_508 = ((decode_INSTRUCTION & _zz_515) == 32'h0);
-  assign _zz_509 = {(_zz_516 == _zz_517),{_zz_518,_zz_519}};
-  assign _zz_510 = ((decode_INSTRUCTION & _zz_520) == 32'h0);
-  assign _zz_511 = 1'b0;
-  assign _zz_512 = ({_zz_521,{_zz_522,_zz_523}} != 3'b000);
-  assign _zz_513 = ({_zz_524,_zz_525} != 2'b00);
-  assign _zz_514 = {(_zz_526 != _zz_527),(_zz_528 != _zz_529)};
-  assign _zz_515 = 32'h00000044;
-  assign _zz_516 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_517 = 32'h0;
-  assign _zz_518 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_519 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_520 = 32'h00000058;
-  assign _zz_521 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_522 = ((decode_INSTRUCTION & _zz_530) == 32'h00002010);
-  assign _zz_523 = ((decode_INSTRUCTION & _zz_531) == 32'h40000030);
-  assign _zz_524 = ((decode_INSTRUCTION & _zz_532) == 32'h00000004);
-  assign _zz_525 = _zz_88;
-  assign _zz_526 = {(_zz_533 == _zz_534),_zz_88};
-  assign _zz_527 = 2'b00;
-  assign _zz_528 = ((decode_INSTRUCTION & _zz_535) == 32'h00001008);
-  assign _zz_529 = 1'b0;
-  assign _zz_530 = 32'h00002014;
-  assign _zz_531 = 32'h40000034;
-  assign _zz_532 = 32'h00000014;
-  assign _zz_533 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_534 = 32'h00000004;
-  assign _zz_535 = 32'h00005048;
-  assign _zz_536 = execute_INSTRUCTION[31];
-  assign _zz_537 = execute_INSTRUCTION[31];
-  assign _zz_538 = execute_INSTRUCTION[7];
-  assign _zz_539 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_348) begin
-      _zz_210 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_RS2_SIGNED = 32'h10103050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_4) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = ({_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_7} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = {(_zz__zz_decode_IS_RS2_SIGNED_9 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_10 != _zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_16,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_20}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h02004074;
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(_zz__zz_decode_IS_RS2_SIGNED_11 == _zz__zz_decode_IS_RS2_SIGNED_12),(_zz__zz_decode_IS_RS2_SIGNED_13 == _zz__zz_decode_IS_RS2_SIGNED_14)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ({_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_17} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (_zz__zz_decode_IS_RS2_SIGNED_19 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = {(_zz__zz_decode_IS_RS2_SIGNED_21 != _zz__zz_decode_IS_RS2_SIGNED_26),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ({_zz__zz_decode_IS_RS2_SIGNED_28,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_31}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (_zz__zz_decode_IS_RS2_SIGNED_34 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(_zz__zz_decode_IS_RS2_SIGNED_36 != _zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_39,{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_47}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00005020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_32) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((_zz__zz_decode_IS_RS2_SIGNED_40 == _zz__zz_decode_IS_RS2_SIGNED_41) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ({_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = {(_zz__zz_decode_IS_RS2_SIGNED_48 != _zz__zz_decode_IS_RS2_SIGNED_50),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_68}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00007034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_46) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ({_zz__zz_decode_IS_RS2_SIGNED_52,_zz__zz_decode_IS_RS2_SIGNED_53} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = ({_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_57} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = {(_zz__zz_decode_IS_RS2_SIGNED_69 != _zz__zz_decode_IS_RS2_SIGNED_71),{_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_98}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {(_zz__zz_decode_IS_RS2_SIGNED_58 == _zz__zz_decode_IS_RS2_SIGNED_59),{_zz__zz_decode_IS_RS2_SIGNED_60,{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_65}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_70) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ({_zz__zz_decode_IS_RS2_SIGNED_73,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_76}} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = ({_zz__zz_decode_IS_RS2_SIGNED_86,_zz__zz_decode_IS_RS2_SIGNED_87} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = {(_zz__zz_decode_IS_RS2_SIGNED_99 != _zz__zz_decode_IS_RS2_SIGNED_112),{_zz__zz_decode_IS_RS2_SIGNED_113,{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_123}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_61) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (_zz__zz_decode_IS_RS2_SIGNED_66 == _zz__zz_decode_IS_RS2_SIGNED_67);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = {_zz__zz_decode_IS_RS2_SIGNED_77,{_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_82}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz__zz_decode_IS_RS2_SIGNED_88,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_93}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_100,_zz__zz_decode_IS_RS2_SIGNED_103}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 6'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = ({_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_115} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (_zz__zz_decode_IS_RS2_SIGNED_119 != _zz__zz_decode_IS_RS2_SIGNED_122);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {_zz__zz_decode_IS_RS2_SIGNED_124,{_zz__zz_decode_IS_RS2_SIGNED_127,_zz__zz_decode_IS_RS2_SIGNED_132}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_78) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = (_zz__zz_decode_IS_RS2_SIGNED_80 == _zz__zz_decode_IS_RS2_SIGNED_81);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = (_zz__zz_decode_IS_RS2_SIGNED_83 == _zz__zz_decode_IS_RS2_SIGNED_84);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,_zz__zz_decode_IS_RS2_SIGNED_96};
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (_zz__zz_decode_IS_RS2_SIGNED_101 == _zz__zz_decode_IS_RS2_SIGNED_102);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz__zz_decode_IS_RS2_SIGNED_104,{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_109}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (_zz__zz_decode_IS_RS2_SIGNED_116 == _zz__zz_decode_IS_RS2_SIGNED_117);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_120};
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (_zz__zz_decode_IS_RS2_SIGNED_125 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (_zz__zz_decode_IS_RS2_SIGNED_128 != _zz__zz_decode_IS_RS2_SIGNED_131);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = {_zz__zz_decode_IS_RS2_SIGNED_133,{_zz__zz_decode_IS_RS2_SIGNED_141,_zz__zz_decode_IS_RS2_SIGNED_145}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_95) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_97) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_105) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (_zz__zz_decode_IS_RS2_SIGNED_107 == _zz__zz_decode_IS_RS2_SIGNED_108);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_111};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_121) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (_zz__zz_decode_IS_RS2_SIGNED_129 == _zz__zz_decode_IS_RS2_SIGNED_130);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ({_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_136} != 4'b0000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (_zz__zz_decode_IS_RS2_SIGNED_142 != _zz__zz_decode_IS_RS2_SIGNED_144);
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = {_zz__zz_decode_IS_RS2_SIGNED_146,{_zz__zz_decode_IS_RS2_SIGNED_152,_zz__zz_decode_IS_RS2_SIGNED_156}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h02002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_135) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {(_zz__zz_decode_IS_RS2_SIGNED_137 == _zz__zz_decode_IS_RS2_SIGNED_138),{_zz__zz_decode_IS_RS2_SIGNED_139,_zz__zz_decode_IS_RS2_SIGNED_140}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = ({_zz__zz_decode_IS_RS2_SIGNED_147,{_zz__zz_decode_IS_RS2_SIGNED_148,_zz__zz_decode_IS_RS2_SIGNED_150}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ({_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_155} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = {(_zz__zz_decode_IS_RS2_SIGNED_157 != _zz__zz_decode_IS_RS2_SIGNED_160),(_zz__zz_decode_IS_RS2_SIGNED_161 != _zz__zz_decode_IS_RS2_SIGNED_163)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_149) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_151) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_154) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = {(_zz__zz_decode_IS_RS2_SIGNED_158 == _zz__zz_decode_IS_RS2_SIGNED_159),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_162) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = 32'h00000014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = 32'h00005048;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_349) begin
-      _zz_211 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_182                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_183                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_184                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_185                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_186                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_187                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_188                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_189                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_190                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_149[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_191                                            ), //i
-    .io_cpu_execute_address                    (_zz_192[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_193                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_194[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_195                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_196                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_197                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_198[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_199                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_200                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_201                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_202                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_203                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_204                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_205                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_206                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_207[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_208                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_209                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_350)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_212 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_212 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_212 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_212 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1818,134 +1930,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1958,30 +2070,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1993,27 +2105,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2026,30 +2138,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2062,12 +2174,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2080,12 +2192,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2098,12 +2210,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2116,48 +2228,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2170,12 +2282,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2188,12 +2300,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2205,88 +2317,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2299,73 +2411,73 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_92_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_92_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_92_string = "URS1        ";
-      default : _zz_92_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_93_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_93_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_93_string = "BITWISE ";
-      default : _zz_93_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_94_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_94_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_94_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_94_string = "PC ";
-      default : _zz_94_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_95_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_95_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_95_string = "AND_1";
-      default : _zz_95_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_96_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_96_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_96_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_96_string = "SRA_1    ";
-      default : _zz_96_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_97)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_97_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_97_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97_string = "JALR";
-      default : _zz_97_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_98_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_98_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_98_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_98_string = "ECALL";
-      default : _zz_98_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2396,28 +2508,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2458,7 +2570,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_254) + $signed(_zz_262));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2466,45 +2578,45 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_264;
-  assign execute_REGFILE_WRITE_DATA = _zz_100;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_192[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_266[0];
-  assign decode_IS_RS1_SIGNED = _zz_267[0];
-  assign decode_IS_DIV = _zz_268[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[30];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_269[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_270[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_271[0];
-  assign decode_MEMORY_MANAGMENT = _zz_272[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_273[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_274[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_275[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -2512,7 +2624,7 @@ module VexRiscv (
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_276[0];
+  assign decode_IS_EBREAK = _zz_decode_IS_RS2_SIGNED[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2526,22 +2638,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_122;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_277[0];
-  assign decode_RS1_USE = _zz_278[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_213)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2551,139 +2663,139 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_113;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_214)begin
-      if(_zz_215)begin
-        if(_zz_115)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_216)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_217)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_113;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_214)begin
-      if(_zz_215)begin
-        if(_zz_114)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_216)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_217)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_108;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_218)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_279[0];
-  assign decode_SRC_ADD_ZERO = _zz_280[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_106;
-  assign execute_SRC1 = _zz_101;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_281[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_351) == 32'h00001073),{(_zz_352 == _zz_353),{_zz_354,{_zz_355,_zz_356}}}}}}} != 21'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_253)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_323;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_324;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2695,61 +2807,61 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_282[0];
-  assign decode_FLUSH_ALL = _zz_283[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_219)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_220)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_221)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_222)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_149)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2758,166 +2870,166 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_109 || _zz_110)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_223)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_223)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_208 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_224)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_213)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_225)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_225)begin
-      if(_zz_226)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_218)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_227)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_228)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2926,75 +3038,77 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_227)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_228)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_229)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_54 = 1'b1;
+  always @(*) begin
+    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    if(DebugPlugin_godmode) begin
+      _zz_when_DBusCachedPlugin_l386 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_224)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_227)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_228)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_227)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_228)begin
-      case(_zz_230)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3004,80 +3118,92 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_284));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_212;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_286);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3085,66 +3211,75 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
-  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64 = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_149)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3156,207 +3291,213 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_69 = _zz_287[11];
-  always @ (*) begin
-    _zz_70[18] = _zz_69;
-    _zz_70[17] = _zz_69;
-    _zz_70[16] = _zz_69;
-    _zz_70[15] = _zz_69;
-    _zz_70[14] = _zz_69;
-    _zz_70[13] = _zz_69;
-    _zz_70[12] = _zz_69;
-    _zz_70[11] = _zz_69;
-    _zz_70[10] = _zz_69;
-    _zz_70[9] = _zz_69;
-    _zz_70[8] = _zz_69;
-    _zz_70[7] = _zz_69;
-    _zz_70[6] = _zz_69;
-    _zz_70[5] = _zz_69;
-    _zz_70[4] = _zz_69;
-    _zz_70[3] = _zz_69;
-    _zz_70[2] = _zz_69;
-    _zz_70[1] = _zz_69;
-    _zz_70[0] = _zz_69;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_288[31]));
-    if(_zz_75)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_71 = _zz_289[19];
-  always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_73 = _zz_290[11];
-  always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75 = _zz_291[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_75 = _zz_292[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76 = _zz_293[19];
-  always @ (*) begin
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_78 = _zz_294[11];
-  always @ (*) begin
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15] = _zz_78;
-    _zz_79[14] = _zz_78;
-    _zz_79[13] = _zz_78;
-    _zz_79[12] = _zz_78;
-    _zz_79[11] = _zz_78;
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_369,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_370,_zz_371},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_183 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_184 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_185 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_184;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_187 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_188 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_189 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_222)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_220)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_190 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_220)begin
-      _zz_190 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_221)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_219)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_221)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_219)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_182 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_209 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3364,168 +3505,178 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_191 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_192 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_208 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_193 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_194 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_193;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_194;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_195 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_195 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_196 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_197 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_198 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_231)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_231)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_231)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_295};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_296};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_84[31] = _zz_83;
-    _zz_84[30] = _zz_83;
-    _zz_84[29] = _zz_83;
-    _zz_84[28] = _zz_83;
-    _zz_84[27] = _zz_83;
-    _zz_84[26] = _zz_83;
-    _zz_84[25] = _zz_83;
-    _zz_84[24] = _zz_83;
-    _zz_84[23] = _zz_83;
-    _zz_84[22] = _zz_83;
-    _zz_84[21] = _zz_83;
-    _zz_84[20] = _zz_83;
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_86[31] = _zz_85;
-    _zz_86[30] = _zz_85;
-    _zz_86[29] = _zz_85;
-    _zz_86[28] = _zz_85;
-    _zz_86[27] = _zz_85;
-    _zz_86[26] = _zz_85;
-    _zz_86[25] = _zz_85;
-    _zz_86[24] = _zz_85;
-    _zz_86[23] = _zz_85;
-    _zz_86[22] = _zz_85;
-    _zz_86[21] = _zz_85;
-    _zz_86[20] = _zz_85;
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_251)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3544,59 +3695,60 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_90 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_91 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_87 = {(((decode_INSTRUCTION & _zz_372) == 32'h00100050) != 1'b0),{(_zz_91 != 1'b0),{(_zz_91 != 1'b0),{(_zz_373 != _zz_374),{_zz_375,{_zz_376,_zz_377}}}}}};
-  assign _zz_92 = _zz_87[2 : 1];
-  assign _zz_49 = _zz_92;
-  assign _zz_93 = _zz_87[7 : 6];
-  assign _zz_48 = _zz_93;
-  assign _zz_94 = _zz_87[9 : 8];
-  assign _zz_47 = _zz_94;
-  assign _zz_95 = _zz_87[19 : 18];
-  assign _zz_46 = _zz_95;
-  assign _zz_96 = _zz_87[22 : 21];
-  assign _zz_45 = _zz_96;
-  assign _zz_97 = _zz_87[24 : 23];
-  assign _zz_44 = _zz_97;
-  assign _zz_98 = _zz_87[27 : 26];
-  assign _zz_43 = _zz_98;
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED) == 32'h00100050) != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_1 != _zz__zz_decode_IS_RS2_SIGNED_2),{_zz__zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_8}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_210;
-  assign decode_RegFilePlugin_rs2Data = _zz_211;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_99)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_99)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_99)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3605,353 +3757,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100 = {31'd0, _zz_297};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_100 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101 = {29'd0, _zz_298};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101 = {27'd0, _zz_299};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_102 = _zz_300[11];
-  always @ (*) begin
-    _zz_103[19] = _zz_102;
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_104 = _zz_301[11];
-  always @ (*) begin
-    _zz_105[19] = _zz_104;
-    _zz_105[18] = _zz_104;
-    _zz_105[17] = _zz_104;
-    _zz_105[16] = _zz_104;
-    _zz_105[15] = _zz_104;
-    _zz_105[14] = _zz_104;
-    _zz_105[13] = _zz_104;
-    _zz_105[12] = _zz_104;
-    _zz_105[11] = _zz_104;
-    _zz_105[10] = _zz_104;
-    _zz_105[9] = _zz_104;
-    _zz_105[8] = _zz_104;
-    _zz_105[7] = _zz_104;
-    _zz_105[6] = _zz_104;
-    _zz_105[5] = _zz_104;
-    _zz_105[4] = _zz_104;
-    _zz_105[3] = _zz_104;
-    _zz_105[2] = _zz_104;
-    _zz_105[1] = _zz_104;
-    _zz_105[0] = _zz_104;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106 = {_zz_103,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106 = {_zz_105,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_302;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_107[0] = execute_SRC1[31];
-    _zz_107[1] = execute_SRC1[30];
-    _zz_107[2] = execute_SRC1[29];
-    _zz_107[3] = execute_SRC1[28];
-    _zz_107[4] = execute_SRC1[27];
-    _zz_107[5] = execute_SRC1[26];
-    _zz_107[6] = execute_SRC1[25];
-    _zz_107[7] = execute_SRC1[24];
-    _zz_107[8] = execute_SRC1[23];
-    _zz_107[9] = execute_SRC1[22];
-    _zz_107[10] = execute_SRC1[21];
-    _zz_107[11] = execute_SRC1[20];
-    _zz_107[12] = execute_SRC1[19];
-    _zz_107[13] = execute_SRC1[18];
-    _zz_107[14] = execute_SRC1[17];
-    _zz_107[15] = execute_SRC1[16];
-    _zz_107[16] = execute_SRC1[15];
-    _zz_107[17] = execute_SRC1[14];
-    _zz_107[18] = execute_SRC1[13];
-    _zz_107[19] = execute_SRC1[12];
-    _zz_107[20] = execute_SRC1[11];
-    _zz_107[21] = execute_SRC1[10];
-    _zz_107[22] = execute_SRC1[9];
-    _zz_107[23] = execute_SRC1[8];
-    _zz_107[24] = execute_SRC1[7];
-    _zz_107[25] = execute_SRC1[6];
-    _zz_107[26] = execute_SRC1[5];
-    _zz_107[27] = execute_SRC1[4];
-    _zz_107[28] = execute_SRC1[3];
-    _zz_107[29] = execute_SRC1[2];
-    _zz_107[30] = execute_SRC1[1];
-    _zz_107[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107 : execute_SRC1);
-  always @ (*) begin
-    _zz_108[0] = memory_SHIFT_RIGHT[31];
-    _zz_108[1] = memory_SHIFT_RIGHT[30];
-    _zz_108[2] = memory_SHIFT_RIGHT[29];
-    _zz_108[3] = memory_SHIFT_RIGHT[28];
-    _zz_108[4] = memory_SHIFT_RIGHT[27];
-    _zz_108[5] = memory_SHIFT_RIGHT[26];
-    _zz_108[6] = memory_SHIFT_RIGHT[25];
-    _zz_108[7] = memory_SHIFT_RIGHT[24];
-    _zz_108[8] = memory_SHIFT_RIGHT[23];
-    _zz_108[9] = memory_SHIFT_RIGHT[22];
-    _zz_108[10] = memory_SHIFT_RIGHT[21];
-    _zz_108[11] = memory_SHIFT_RIGHT[20];
-    _zz_108[12] = memory_SHIFT_RIGHT[19];
-    _zz_108[13] = memory_SHIFT_RIGHT[18];
-    _zz_108[14] = memory_SHIFT_RIGHT[17];
-    _zz_108[15] = memory_SHIFT_RIGHT[16];
-    _zz_108[16] = memory_SHIFT_RIGHT[15];
-    _zz_108[17] = memory_SHIFT_RIGHT[14];
-    _zz_108[18] = memory_SHIFT_RIGHT[13];
-    _zz_108[19] = memory_SHIFT_RIGHT[12];
-    _zz_108[20] = memory_SHIFT_RIGHT[11];
-    _zz_108[21] = memory_SHIFT_RIGHT[10];
-    _zz_108[22] = memory_SHIFT_RIGHT[9];
-    _zz_108[23] = memory_SHIFT_RIGHT[8];
-    _zz_108[24] = memory_SHIFT_RIGHT[7];
-    _zz_108[25] = memory_SHIFT_RIGHT[6];
-    _zz_108[26] = memory_SHIFT_RIGHT[5];
-    _zz_108[27] = memory_SHIFT_RIGHT[4];
-    _zz_108[28] = memory_SHIFT_RIGHT[3];
-    _zz_108[29] = memory_SHIFT_RIGHT[2];
-    _zz_108[30] = memory_SHIFT_RIGHT[1];
-    _zz_108[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_109 = 1'b0;
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_114)begin
-          _zz_109 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_234)begin
-      if(_zz_235)begin
-        if(_zz_116)begin
-          _zz_109 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_118)begin
-          _zz_109 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_109 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_110 = 1'b0;
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_115)begin
-          _zz_110 = 1'b1;
-        end
-      end
-    end
-    if(_zz_234)begin
-      if(_zz_235)begin
-        if(_zz_117)begin
-          _zz_110 = 1'b1;
-        end
-      end
-    end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_119)begin
-          _zz_110 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_110 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_115 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_117 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_119 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_120 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_120 == 3'b000)) begin
-        _zz_121 = execute_BranchPlugin_eq;
-    end else if((_zz_120 == 3'b001)) begin
-        _zz_121 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_120 & 3'b101) == 3'b101))) begin
-        _zz_121 = (! execute_SRC_LESS);
-    end else begin
-        _zz_121 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_122 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_122 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_122 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_122 = _zz_121;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_123 = _zz_309[11];
-  always @ (*) begin
-    _zz_124[19] = _zz_123;
-    _zz_124[18] = _zz_123;
-    _zz_124[17] = _zz_123;
-    _zz_124[16] = _zz_123;
-    _zz_124[15] = _zz_123;
-    _zz_124[14] = _zz_123;
-    _zz_124[13] = _zz_123;
-    _zz_124[12] = _zz_123;
-    _zz_124[11] = _zz_123;
-    _zz_124[10] = _zz_123;
-    _zz_124[9] = _zz_123;
-    _zz_124[8] = _zz_123;
-    _zz_124[7] = _zz_123;
-    _zz_124[6] = _zz_123;
-    _zz_124[5] = _zz_123;
-    _zz_124[4] = _zz_123;
-    _zz_124[3] = _zz_123;
-    _zz_124[2] = _zz_123;
-    _zz_124[1] = _zz_123;
-    _zz_124[0] = _zz_123;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_125 = _zz_310[19];
-  always @ (*) begin
-    _zz_126[10] = _zz_125;
-    _zz_126[9] = _zz_125;
-    _zz_126[8] = _zz_125;
-    _zz_126[7] = _zz_125;
-    _zz_126[6] = _zz_125;
-    _zz_126[5] = _zz_125;
-    _zz_126[4] = _zz_125;
-    _zz_126[3] = _zz_125;
-    _zz_126[2] = _zz_125;
-    _zz_126[1] = _zz_125;
-    _zz_126[0] = _zz_125;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_127 = _zz_311[11];
-  always @ (*) begin
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_129 = (_zz_312[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_129 = _zz_313[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_129 = _zz_314[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -3962,80 +4137,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_130 = _zz_315[11];
-  always @ (*) begin
-    _zz_131[19] = _zz_130;
-    _zz_131[18] = _zz_130;
-    _zz_131[17] = _zz_130;
-    _zz_131[16] = _zz_130;
-    _zz_131[15] = _zz_130;
-    _zz_131[14] = _zz_130;
-    _zz_131[13] = _zz_130;
-    _zz_131[12] = _zz_130;
-    _zz_131[11] = _zz_130;
-    _zz_131[10] = _zz_130;
-    _zz_131[9] = _zz_130;
-    _zz_131[8] = _zz_130;
-    _zz_131[7] = _zz_130;
-    _zz_131[6] = _zz_130;
-    _zz_131[5] = _zz_130;
-    _zz_131[4] = _zz_130;
-    _zz_131[3] = _zz_130;
-    _zz_131[2] = _zz_130;
-    _zz_131[1] = _zz_130;
-    _zz_131[0] = _zz_130;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_131,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133,{{{_zz_536,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135,{{{_zz_537,_zz_538},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_318};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_132 = _zz_316[19];
-  always @ (*) begin
-    _zz_133[10] = _zz_132;
-    _zz_133[9] = _zz_132;
-    _zz_133[8] = _zz_132;
-    _zz_133[7] = _zz_132;
-    _zz_133[6] = _zz_132;
-    _zz_133[5] = _zz_132;
-    _zz_133[4] = _zz_132;
-    _zz_133[3] = _zz_132;
-    _zz_133[2] = _zz_132;
-    _zz_133[1] = _zz_132;
-    _zz_133[0] = _zz_132;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_134 = _zz_317[11];
-  always @ (*) begin
-    _zz_135[18] = _zz_134;
-    _zz_135[17] = _zz_134;
-    _zz_135[16] = _zz_134;
-    _zz_135[15] = _zz_134;
-    _zz_135[14] = _zz_134;
-    _zz_135[13] = _zz_134;
-    _zz_135[12] = _zz_134;
-    _zz_135[11] = _zz_134;
-    _zz_135[10] = _zz_134;
-    _zz_135[9] = _zz_134;
-    _zz_135[8] = _zz_134;
-    _zz_135[7] = _zz_134;
-    _zz_135[6] = _zz_134;
-    _zz_135[5] = _zz_134;
-    _zz_135[4] = _zz_134;
-    _zz_135[3] = _zz_134;
-    _zz_135[2] = _zz_134;
-    _zz_135[1] = _zz_134;
-    _zz_135[0] = _zz_134;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -4045,92 +4220,106 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_136 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_137 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_138 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_139 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_140 = _zz_319[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_223)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4141,8 +4330,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4152,135 +4341,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_238)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_239)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_240)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_239)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_240)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4293,39 +4491,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_238)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_238)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_252)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_241)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4338,8 +4546,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_241)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4358,58 +4566,69 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_321) + $signed(_zz_322));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_218)begin
-      if(_zz_242)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_243)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_326);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_141 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_327);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_328 : _zz_329);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_330[31:0];
-  assign _zz_142 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_143 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_144 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_145[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_145[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_147 = (_zz_146 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_147 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_244)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -4419,9 +4638,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_148))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4430,12 +4649,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_244)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -4446,35 +4666,110 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4495,9 +4790,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_149)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -4506,240 +4807,269 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_150[12 : 0] = 13'h1000;
-      _zz_150[25 : 20] = 6'h20;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_151[3 : 0] = 4'b1011;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
     end
   end
 
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_152[4 : 0] = 5'h16;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
     end
   end
 
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_153[5 : 0] = 6'h21;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
     end
   end
 
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_154[31 : 30] = CsrPlugin_misa_base;
-      _zz_154[25 : 0] = CsrPlugin_misa_extensions;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_155[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_155[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_155[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_156 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_156[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_156[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_156[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_157 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_157[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_157[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_157[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_158 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_158[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_158[1 : 0] = CsrPlugin_mtvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_159 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_159[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_160 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_160[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_161 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_161[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_161[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_162 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_162[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_163 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_163[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_164[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_165[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_166[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_167[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_168[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_169[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_170[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_171[31 : 0] = _zz_146;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_172[31 : 0] = _zz_147;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_150 | _zz_151) | (_zz_152 | _zz_153)) | ((_zz_539 | _zz_154) | (_zz_155 | _zz_156))) | (((_zz_157 | _zz_158) | (_zz_159 | _zz_160)) | ((_zz_161 | _zz_162) | (_zz_163 | _zz_164)))) | (((_zz_165 | _zz_166) | (_zz_167 | _zz_168)) | ((_zz_169 | _zz_170) | (_zz_171 | _zz_172))));
-  assign iBusWishbone_ADR = {_zz_347,_zz_173};
-  assign iBusWishbone_CTI = ((_zz_173 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_245)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_245)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_174;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_180 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_176 = dBus_cmd_valid;
-  assign _zz_178 = dBus_cmd_payload_wr;
-  assign _zz_179 = (_zz_175 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_177 && (_zz_178 || _zz_179));
-  assign dBusWishbone_ADR = ((_zz_180 ? {{dBus_cmd_payload_address[31 : 5],_zz_175},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_180 ? (_zz_179 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_178 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_178;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_177 = (_zz_176 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_176;
-  assign dBusWishbone_STB = _zz_176;
-  assign dBus_rsp_valid = _zz_181;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65 <= 1'b0;
-      _zz_67 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99 <= 1'b1;
-      _zz_111 <= 1'b0;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4760,160 +5090,160 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_146 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_149 <= 3'b000;
-      _zz_173 <= 3'b000;
-      _zz_174 <= 1'b0;
-      _zz_175 <= 3'b000;
-      _zz_181 <= 1'b0;
+      switch_Fetcher_l362 <= 3'b000;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_63)begin
-        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_246)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99 <= 1'b0;
-      _zz_111 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_247)begin
-        if(_zz_248)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_249)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_250)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_227)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4924,8 +5254,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_228)begin
-        case(_zz_230)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4935,164 +5265,164 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_138,{_zz_137,_zz_136}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_149)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_149 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_149 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_149 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_149 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_149 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_340[0];
-          CsrPlugin_mstatus_MIE <= _zz_341[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_343[0];
-          CsrPlugin_mie_MTIE <= _zz_344[0];
-          CsrPlugin_mie_MSIE <= _zz_345[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_146 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_245)begin
-        if(iBusWishbone_ACK)begin
-          _zz_173 <= (_zz_173 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_174 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_176 && _zz_177))begin
-        _zz_175 <= (_zz_175 + 3'b001);
-        if(_zz_179)begin
-          _zz_175 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_181 <= ((_zz_176 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_246)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_112 <= _zz_40[11 : 7];
-    _zz_113 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_223)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_247)begin
-      if(_zz_248)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_249)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_250)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_227)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -5100,395 +5430,406 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_218)begin
-      if(_zz_242)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_331[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_243)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_144 ? (~ _zz_145) : _zz_145) + _zz_337);
-      memory_DivPlugin_rs2 <= ((_zz_143 ? (~ execute_RS2) : execute_RS2) + _zz_339);
-      memory_DivPlugin_div_needRevert <= ((_zz_144 ^ (_zz_143 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_50) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_51) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_52) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_53) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_342[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_346[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_148 <= debug_bus_cmd_payload_address[2];
-    if(_zz_225)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_244)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -5496,14 +5837,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_225)begin
-        if(_zz_226)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_229)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -5516,9 +5857,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -5540,6 +5880,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5555,9 +5896,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5565,7 +5907,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5574,24 +5916,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5616,40 +5949,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5659,23 +6000,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5683,10 +6034,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5698,59 +6057,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -5765,274 +6119,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6040,89 +6413,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -6130,12 +6487,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6146,20 +6503,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6167,45 +6544,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6216,46 +6595,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -6263,50 +6633,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6353,18 +6724,14 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
+  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [21:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [21:0]   _zz_17;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6373,8 +6740,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6388,22 +6760,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -6413,82 +6788,86 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
+  wire                when_Fetcher_l398;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_13 = (! lineLoader_flushCounter[7]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6504,30 +6883,36 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6535,51 +6920,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_14)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -6590,14 +6975,14 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
+    if(when_Fetcher_l398) begin
+      io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_IMAC.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_IMAC.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -74,39 +74,39 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire       [31:0]   _zz_206;
-  reg                 _zz_207;
-  wire                _zz_208;
-  wire       [31:0]   _zz_209;
-  reg                 _zz_210;
-  wire                _zz_211;
-  wire       [31:0]   _zz_212;
-  reg                 _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire       [31:0]   _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire                _zz_224;
-  wire       [3:0]    _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  reg        [31:0]   _zz_228;
-  reg        [31:0]   _zz_229;
-  reg        [31:0]   _zz_230;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isUser;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_pc;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  reg                 dataCache_1_io_cpu_execute_args_isLrsc;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_error;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling;
@@ -129,6 +129,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -137,364 +138,304 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  wire                _zz_240;
-  wire                _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire                _zz_244;
-  wire       [1:0]    _zz_245;
-  wire                _zz_246;
-  wire                _zz_247;
-  wire                _zz_248;
-  wire                _zz_249;
-  wire                _zz_250;
-  wire                _zz_251;
-  wire                _zz_252;
-  wire                _zz_253;
-  wire                _zz_254;
-  wire                _zz_255;
-  wire                _zz_256;
-  wire       [1:0]    _zz_257;
-  wire                _zz_258;
-  wire                _zz_259;
-  wire                _zz_260;
-  wire                _zz_261;
-  wire                _zz_262;
-  wire                _zz_263;
-  wire                _zz_264;
-  wire                _zz_265;
-  wire                _zz_266;
-  wire       [4:0]    _zz_267;
-  wire       [1:0]    _zz_268;
-  wire       [1:0]    _zz_269;
-  wire       [1:0]    _zz_270;
-  wire                _zz_271;
-  wire       [1:0]    _zz_272;
-  wire       [51:0]   _zz_273;
-  wire       [51:0]   _zz_274;
-  wire       [51:0]   _zz_275;
-  wire       [32:0]   _zz_276;
-  wire       [51:0]   _zz_277;
-  wire       [49:0]   _zz_278;
-  wire       [51:0]   _zz_279;
-  wire       [49:0]   _zz_280;
-  wire       [51:0]   _zz_281;
-  wire       [32:0]   _zz_282;
-  wire       [31:0]   _zz_283;
-  wire       [32:0]   _zz_284;
-  wire       [0:0]    _zz_285;
-  wire       [0:0]    _zz_286;
-  wire       [0:0]    _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [0:0]    _zz_289;
-  wire       [0:0]    _zz_290;
-  wire       [0:0]    _zz_291;
-  wire       [0:0]    _zz_292;
-  wire       [0:0]    _zz_293;
-  wire       [0:0]    _zz_294;
-  wire       [2:0]    _zz_295;
-  wire       [31:0]   _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [0:0]    _zz_298;
-  wire       [0:0]    _zz_299;
-  wire       [0:0]    _zz_300;
-  wire       [0:0]    _zz_301;
-  wire       [0:0]    _zz_302;
-  wire       [0:0]    _zz_303;
-  wire       [0:0]    _zz_304;
-  wire       [3:0]    _zz_305;
-  wire       [2:0]    _zz_306;
-  wire       [31:0]   _zz_307;
-  wire       [2:0]    _zz_308;
-  wire       [31:0]   _zz_309;
-  wire       [31:0]   _zz_310;
-  wire       [11:0]   _zz_311;
-  wire       [11:0]   _zz_312;
-  wire       [11:0]   _zz_313;
-  wire       [31:0]   _zz_314;
-  wire       [19:0]   _zz_315;
-  wire       [11:0]   _zz_316;
-  wire       [2:0]    _zz_317;
-  wire       [2:0]    _zz_318;
-  wire       [0:0]    _zz_319;
-  wire       [2:0]    _zz_320;
-  wire       [4:0]    _zz_321;
-  wire       [11:0]   _zz_322;
-  wire       [11:0]   _zz_323;
-  wire       [31:0]   _zz_324;
-  wire       [31:0]   _zz_325;
-  wire       [31:0]   _zz_326;
-  wire       [31:0]   _zz_327;
-  wire       [31:0]   _zz_328;
-  wire       [31:0]   _zz_329;
-  wire       [31:0]   _zz_330;
-  wire       [11:0]   _zz_331;
-  wire       [19:0]   _zz_332;
-  wire       [11:0]   _zz_333;
-  wire       [2:0]    _zz_334;
-  wire       [1:0]    _zz_335;
-  wire       [1:0]    _zz_336;
-  wire       [65:0]   _zz_337;
-  wire       [65:0]   _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire       [0:0]    _zz_341;
-  wire       [5:0]    _zz_342;
-  wire       [32:0]   _zz_343;
-  wire       [31:0]   _zz_344;
-  wire       [31:0]   _zz_345;
-  wire       [32:0]   _zz_346;
-  wire       [32:0]   _zz_347;
-  wire       [32:0]   _zz_348;
-  wire       [32:0]   _zz_349;
-  wire       [0:0]    _zz_350;
-  wire       [32:0]   _zz_351;
-  wire       [0:0]    _zz_352;
-  wire       [32:0]   _zz_353;
-  wire       [0:0]    _zz_354;
-  wire       [31:0]   _zz_355;
-  wire       [0:0]    _zz_356;
-  wire       [0:0]    _zz_357;
-  wire       [0:0]    _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [0:0]    _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [0:0]    _zz_362;
-  wire       [26:0]   _zz_363;
-  wire                _zz_364;
-  wire                _zz_365;
-  wire       [1:0]    _zz_366;
-  wire       [31:0]   _zz_367;
-  wire       [31:0]   _zz_368;
-  wire       [31:0]   _zz_369;
-  wire                _zz_370;
-  wire       [0:0]    _zz_371;
-  wire       [15:0]   _zz_372;
-  wire       [31:0]   _zz_373;
-  wire       [31:0]   _zz_374;
-  wire       [31:0]   _zz_375;
-  wire                _zz_376;
-  wire       [0:0]    _zz_377;
-  wire       [9:0]    _zz_378;
-  wire       [31:0]   _zz_379;
-  wire       [31:0]   _zz_380;
-  wire       [31:0]   _zz_381;
-  wire                _zz_382;
-  wire       [0:0]    _zz_383;
-  wire       [3:0]    _zz_384;
-  wire                _zz_385;
-  wire                _zz_386;
-  wire       [6:0]    _zz_387;
-  wire       [4:0]    _zz_388;
-  wire                _zz_389;
-  wire       [4:0]    _zz_390;
-  wire       [0:0]    _zz_391;
-  wire       [7:0]    _zz_392;
-  wire                _zz_393;
-  wire       [0:0]    _zz_394;
-  wire       [0:0]    _zz_395;
-  wire       [31:0]   _zz_396;
-  wire       [31:0]   _zz_397;
-  wire                _zz_398;
-  wire       [0:0]    _zz_399;
-  wire       [0:0]    _zz_400;
-  wire                _zz_401;
-  wire       [0:0]    _zz_402;
-  wire       [25:0]   _zz_403;
-  wire       [31:0]   _zz_404;
-  wire                _zz_405;
-  wire                _zz_406;
-  wire       [0:0]    _zz_407;
-  wire       [0:0]    _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [0:0]    _zz_410;
-  wire                _zz_411;
-  wire       [0:0]    _zz_412;
-  wire       [21:0]   _zz_413;
-  wire       [31:0]   _zz_414;
-  wire       [31:0]   _zz_415;
-  wire                _zz_416;
-  wire                _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [1:0]    _zz_419;
-  wire       [0:0]    _zz_420;
-  wire       [0:0]    _zz_421;
-  wire                _zz_422;
-  wire       [0:0]    _zz_423;
-  wire       [18:0]   _zz_424;
-  wire       [31:0]   _zz_425;
-  wire       [31:0]   _zz_426;
-  wire       [31:0]   _zz_427;
-  wire       [31:0]   _zz_428;
-  wire       [31:0]   _zz_429;
-  wire       [31:0]   _zz_430;
-  wire       [31:0]   _zz_431;
-  wire       [31:0]   _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [0:0]    _zz_434;
-  wire       [0:0]    _zz_435;
-  wire       [0:0]    _zz_436;
-  wire                _zz_437;
-  wire       [0:0]    _zz_438;
-  wire       [15:0]   _zz_439;
-  wire       [31:0]   _zz_440;
-  wire       [31:0]   _zz_441;
-  wire       [31:0]   _zz_442;
-  wire       [31:0]   _zz_443;
-  wire       [31:0]   _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [1:0]    _zz_446;
-  wire       [0:0]    _zz_447;
-  wire       [0:0]    _zz_448;
-  wire                _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [12:0]   _zz_451;
-  wire       [31:0]   _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire                _zz_458;
-  wire       [0:0]    _zz_459;
-  wire       [3:0]    _zz_460;
-  wire       [0:0]    _zz_461;
-  wire       [0:0]    _zz_462;
-  wire       [4:0]    _zz_463;
-  wire       [4:0]    _zz_464;
-  wire                _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [9:0]    _zz_467;
-  wire       [31:0]   _zz_468;
-  wire       [31:0]   _zz_469;
-  wire       [31:0]   _zz_470;
-  wire                _zz_471;
-  wire       [0:0]    _zz_472;
-  wire       [1:0]    _zz_473;
-  wire       [31:0]   _zz_474;
-  wire       [31:0]   _zz_475;
-  wire       [31:0]   _zz_476;
-  wire       [31:0]   _zz_477;
-  wire                _zz_478;
-  wire       [0:0]    _zz_479;
-  wire       [2:0]    _zz_480;
-  wire       [0:0]    _zz_481;
-  wire       [3:0]    _zz_482;
-  wire       [6:0]    _zz_483;
-  wire       [6:0]    _zz_484;
-  wire                _zz_485;
-  wire       [0:0]    _zz_486;
-  wire       [7:0]    _zz_487;
-  wire       [31:0]   _zz_488;
-  wire       [31:0]   _zz_489;
-  wire       [31:0]   _zz_490;
-  wire                _zz_491;
-  wire                _zz_492;
-  wire       [31:0]   _zz_493;
-  wire       [31:0]   _zz_494;
-  wire       [31:0]   _zz_495;
-  wire                _zz_496;
-  wire       [0:0]    _zz_497;
-  wire       [0:0]    _zz_498;
-  wire                _zz_499;
-  wire       [0:0]    _zz_500;
-  wire       [1:0]    _zz_501;
-  wire       [0:0]    _zz_502;
-  wire       [4:0]    _zz_503;
-  wire       [0:0]    _zz_504;
-  wire       [0:0]    _zz_505;
-  wire       [1:0]    _zz_506;
-  wire       [1:0]    _zz_507;
-  wire                _zz_508;
-  wire       [0:0]    _zz_509;
-  wire       [5:0]    _zz_510;
-  wire       [31:0]   _zz_511;
-  wire       [31:0]   _zz_512;
-  wire       [31:0]   _zz_513;
-  wire       [31:0]   _zz_514;
-  wire       [31:0]   _zz_515;
-  wire       [31:0]   _zz_516;
-  wire       [31:0]   _zz_517;
-  wire       [31:0]   _zz_518;
-  wire                _zz_519;
-  wire                _zz_520;
-  wire       [31:0]   _zz_521;
-  wire       [31:0]   _zz_522;
-  wire                _zz_523;
-  wire       [0:0]    _zz_524;
-  wire       [2:0]    _zz_525;
-  wire       [31:0]   _zz_526;
-  wire       [31:0]   _zz_527;
-  wire                _zz_528;
-  wire                _zz_529;
-  wire       [0:0]    _zz_530;
-  wire       [0:0]    _zz_531;
-  wire                _zz_532;
-  wire       [0:0]    _zz_533;
-  wire       [3:0]    _zz_534;
-  wire       [31:0]   _zz_535;
-  wire       [31:0]   _zz_536;
-  wire       [31:0]   _zz_537;
-  wire       [31:0]   _zz_538;
-  wire       [31:0]   _zz_539;
-  wire                _zz_540;
-  wire       [0:0]    _zz_541;
-  wire       [0:0]    _zz_542;
-  wire       [31:0]   _zz_543;
-  wire       [31:0]   _zz_544;
-  wire       [31:0]   _zz_545;
-  wire       [31:0]   _zz_546;
-  wire       [0:0]    _zz_547;
-  wire       [3:0]    _zz_548;
-  wire       [1:0]    _zz_549;
-  wire       [1:0]    _zz_550;
-  wire                _zz_551;
-  wire       [0:0]    _zz_552;
-  wire       [1:0]    _zz_553;
-  wire       [31:0]   _zz_554;
-  wire       [31:0]   _zz_555;
-  wire       [31:0]   _zz_556;
-  wire       [31:0]   _zz_557;
-  wire       [31:0]   _zz_558;
-  wire                _zz_559;
-  wire       [0:0]    _zz_560;
-  wire       [1:0]    _zz_561;
-  wire                _zz_562;
-  wire       [0:0]    _zz_563;
-  wire       [1:0]    _zz_564;
-  wire       [2:0]    _zz_565;
-  wire       [2:0]    _zz_566;
-  wire                _zz_567;
-  wire                _zz_568;
-  wire       [31:0]   _zz_569;
-  wire       [31:0]   _zz_570;
-  wire       [31:0]   _zz_571;
-  wire                _zz_572;
-  wire       [31:0]   _zz_573;
-  wire       [31:0]   _zz_574;
-  wire       [31:0]   _zz_575;
-  wire                _zz_576;
-  wire                _zz_577;
-  wire       [0:0]    _zz_578;
-  wire       [0:0]    _zz_579;
-  wire       [0:0]    _zz_580;
-  wire       [0:0]    _zz_581;
-  wire                _zz_582;
-  wire                _zz_583;
-  wire                _zz_584;
-  wire                _zz_585;
-  wire       [31:0]   _zz_586;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_FORMAL_PC_NEXT;
+  wire       [2:0]    _zz_decode_FORMAL_PC_NEXT_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [15:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [9:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [3:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePc_pcPlus;
+  wire       [2:0]    _zz_IBusCachedPlugin_decodePc_pcPlus_1;
+  wire       [31:0]   _zz_IBusCachedPlugin_decompressor_decompressed_27;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_28;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_29;
+  wire       [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_30;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_31;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_32;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_33;
+  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_34;
+  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_35;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire       [7:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_7;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_8;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspRf;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [25:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_168;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_169;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_170;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_171;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_172;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_173;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_174;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_175;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_176;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_177;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_178;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_179;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_180;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_181;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_182;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_183;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_184;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_185;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_186;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -505,8 +446,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
@@ -517,46 +458,47 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_LRSC;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -577,11 +519,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -589,10 +531,10 @@ module VexRiscv (
   wire                execute_BRANCH_COND_RESULT;
   wire                execute_PREDICTION_HAD_BRANCHED2;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -602,46 +544,47 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire                execute_IS_RVC;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
+  wire                writeBack_MEMORY_LRSC;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -655,7 +598,7 @@ module VexRiscv (
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_LRSC;
-  reg                 _zz_51;
+  reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
   reg                 IBusCachedPlugin_rsp_issueDetected_4;
@@ -663,9 +606,9 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
-  reg        [31:0]   _zz_53;
-  reg        [31:0]   _zz_54;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire                decode_IS_RVC;
@@ -754,7 +697,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -785,6 +728,11 @@ module VexRiscv (
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
   wire                BranchPlugin_jumpInterface_valid;
   wire       [31:0]   BranchPlugin_jumpInterface_payload;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -802,32 +750,40 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   reg        [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_decodePc_flushed;
   reg        [31:0]   IBusCachedPlugin_decodePc_pcReg /* verilator public */ ;
   wire       [31:0]   IBusCachedPlugin_decodePc_pcPlus;
   wire                IBusCachedPlugin_decodePc_injectedDecode;
+  wire                when_Fetcher_l180;
+  wire                when_Fetcher_l192;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -843,12 +799,12 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_1_halt;
-  wire                _zz_60;
-  wire                _zz_61;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_62;
-  wire                _zz_63;
-  reg                 _zz_64;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -877,59 +833,74 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decompressor_throw2BytesReg;
   wire                IBusCachedPlugin_decompressor_throw2Bytes;
   wire                IBusCachedPlugin_decompressor_unaligned;
+  reg                 IBusCachedPlugin_decompressor_bufferValidLatch;
+  reg                 IBusCachedPlugin_decompressor_throw2BytesLatch;
+  wire                IBusCachedPlugin_decompressor_bufferValidPatched;
+  wire                IBusCachedPlugin_decompressor_throw2BytesPatched;
   wire       [31:0]   IBusCachedPlugin_decompressor_raw;
   wire                IBusCachedPlugin_decompressor_isRvc;
-  wire       [15:0]   _zz_65;
+  wire       [15:0]   _zz_IBusCachedPlugin_decompressor_decompressed;
   reg        [31:0]   IBusCachedPlugin_decompressor_decompressed;
-  wire       [4:0]    _zz_66;
-  wire       [4:0]    _zz_67;
-  wire       [11:0]   _zz_68;
-  wire                _zz_69;
-  reg        [11:0]   _zz_70;
-  wire                _zz_71;
-  reg        [9:0]    _zz_72;
-  wire       [20:0]   _zz_73;
-  wire                _zz_74;
-  reg        [14:0]   _zz_75;
-  wire                _zz_76;
-  reg        [2:0]    _zz_77;
-  wire                _zz_78;
-  reg        [9:0]    _zz_79;
-  wire       [20:0]   _zz_80;
-  wire                _zz_81;
-  reg        [4:0]    _zz_82;
-  wire       [12:0]   _zz_83;
-  wire       [4:0]    _zz_84;
-  wire       [4:0]    _zz_85;
-  wire       [4:0]    _zz_86;
-  wire                _zz_87;
-  reg        [2:0]    _zz_88;
-  reg        [2:0]    _zz_89;
-  wire                _zz_90;
-  reg        [6:0]    _zz_91;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_1;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_2;
+  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_3;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_4;
+  reg        [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_5;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_6;
+  reg        [9:0]    _zz_IBusCachedPlugin_decompressor_decompressed_7;
+  wire       [20:0]   _zz_IBusCachedPlugin_decompressor_decompressed_8;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_9;
+  reg        [14:0]   _zz_IBusCachedPlugin_decompressor_decompressed_10;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_11;
+  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_12;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_13;
+  reg        [9:0]    _zz_IBusCachedPlugin_decompressor_decompressed_14;
+  wire       [20:0]   _zz_IBusCachedPlugin_decompressor_decompressed_15;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_16;
+  reg        [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_17;
+  wire       [12:0]   _zz_IBusCachedPlugin_decompressor_decompressed_18;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_19;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_20;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_21;
+  wire       [4:0]    switch_Misc_l44;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_22;
+  wire       [1:0]    switch_Misc_l199;
+  wire       [1:0]    switch_Misc_l199_1;
+  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_23;
+  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_24;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_25;
+  reg        [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_26;
+  wire                when_Fetcher_l279;
   wire                IBusCachedPlugin_decompressor_bufferFill;
+  wire                when_Fetcher_l283;
+  wire                when_Fetcher_l286;
+  wire                when_Fetcher_l291;
   wire                IBusCachedPlugin_injector_decodeInput_valid;
   wire                IBusCachedPlugin_injector_decodeInput_ready;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_pc;
   wire                IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_92;
-  reg        [31:0]   _zz_93;
-  reg                 _zz_94;
-  reg        [31:0]   _zz_95;
-  reg                 _zz_96;
+  reg                 _zz_IBusCachedPlugin_injector_decodeInput_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
+  reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
+  reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
+  reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
-  wire                _zz_97;
-  reg        [18:0]   _zz_98;
-  wire                _zz_99;
-  reg        [10:0]   _zz_100;
-  wire                _zz_101;
-  reg        [18:0]   _zz_102;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -937,13 +908,18 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_103;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -951,7 +927,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -959,8 +935,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -968,40 +945,56 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_104;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l311;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_105;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_106;
-  reg        [31:0]   _zz_107;
-  wire                _zz_108;
-  reg        [31:0]   _zz_109;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire                when_DBusCachedPlugin_l474;
+  wire       [1:0]    switch_Misc_l199_2;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_110;
-  wire                _zz_111;
-  wire                _zz_112;
-  wire                _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_117;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_118;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_119;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_120;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_121;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_122;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_123;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz_decode_IS_RS2_SIGNED_6;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1009,45 +1002,63 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_124;
+  reg                 _zz_2;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_125;
-  reg        [31:0]   _zz_126;
-  wire                _zz_127;
-  reg        [19:0]   _zz_128;
-  wire                _zz_129;
-  reg        [19:0]   _zz_130;
-  reg        [31:0]   _zz_131;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_132;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_133;
-  reg                 _zz_134;
-  reg                 _zz_135;
-  reg                 _zz_136;
-  reg        [4:0]    _zz_137;
-  reg        [31:0]   _zz_138;
-  wire                _zz_139;
-  wire                _zz_140;
-  wire                _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_145;
-  reg                 _zz_146;
-  reg                 _zz_147;
+  wire       [2:0]    switch_Misc_l199_3;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_148;
-  reg        [19:0]   _zz_149;
-  wire                _zz_150;
-  reg        [10:0]   _zz_151;
-  wire                _zz_152;
-  reg        [18:0]   _zz_153;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1069,9 +1080,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_154;
-  wire                _zz_155;
-  wire                _zz_156;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1084,40 +1095,67 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_157;
-  wire                _zz_158;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1125,6 +1163,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1137,216 +1177,325 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_159;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_160;
-  wire                _zz_161;
-  wire                _zz_162;
-  reg        [32:0]   _zz_163;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_164;
-  wire       [31:0]   _zz_165;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg                 decode_to_execute_IS_RVC;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_11;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_13;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_16;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_17;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_18;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_24;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_MEMORY_LRSC;
+  wire                when_Pipeline_l124_28;
+  reg                 execute_to_memory_MEMORY_LRSC;
+  wire                when_Pipeline_l124_29;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
+  wire                when_Pipeline_l124_30;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_31;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_32;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_33;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_37;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_38;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_39;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_40;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_41;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_42;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_43;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_44;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_47;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_48;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_50;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_51;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_52;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_53;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_54;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_55;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_58;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_59;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_60;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_61;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_62;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_63;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_64;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_65;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  reg        [31:0]   _zz_172;
-  reg        [31:0]   _zz_173;
-  reg        [31:0]   _zz_174;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [31:0]   _zz_183;
-  reg        [31:0]   _zz_184;
-  reg        [31:0]   _zz_185;
-  reg        [31:0]   _zz_186;
-  reg        [31:0]   _zz_187;
-  reg        [31:0]   _zz_188;
-  reg        [2:0]    _zz_189;
-  reg                 _zz_190;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_191;
-  wire                _zz_192;
-  wire                _zz_193;
-  wire                _zz_194;
-  wire                _zz_195;
-  wire                _zz_196;
-  reg                 _zz_197;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52_string;
-  reg [95:0] _zz_117_string;
-  reg [63:0] _zz_118_string;
-  reg [23:0] _zz_119_string;
-  reg [39:0] _zz_120_string;
-  reg [71:0] _zz_121_string;
-  reg [31:0] _zz_122_string;
-  reg [39:0] _zz_123_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1355,536 +1504,500 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_231 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_232 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_233 = 1'b1;
-  assign _zz_234 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_235 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_236 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_237 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_238 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_239 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_240 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_241 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_242 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_243 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_244 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_245 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_246 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
-  assign _zz_247 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_248 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_249 = (1'b0 || (! 1'b1));
-  assign _zz_250 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_251 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_252 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_253 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_254 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_255 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_256 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_257 = execute_INSTRUCTION[13 : 12];
-  assign _zz_258 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_259 = (! memory_arbitration_isStuck);
-  assign _zz_260 = (iBus_cmd_valid || (_zz_189 != 3'b000));
-  assign _zz_261 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign _zz_262 = (_zz_227 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_263 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_264 = ((_zz_154 && 1'b1) && (! 1'b0));
-  assign _zz_265 = ((_zz_155 && 1'b1) && (! 1'b0));
-  assign _zz_266 = ((_zz_156 && 1'b1) && (! 1'b0));
-  assign _zz_267 = {_zz_65[1 : 0],_zz_65[15 : 13]};
-  assign _zz_268 = _zz_65[6 : 5];
-  assign _zz_269 = _zz_65[11 : 10];
-  assign _zz_270 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_271 = execute_INSTRUCTION[13];
-  assign _zz_272 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_273 = ($signed(_zz_274) + $signed(_zz_279));
-  assign _zz_274 = ($signed(_zz_275) + $signed(_zz_277));
-  assign _zz_275 = 52'h0;
-  assign _zz_276 = {1'b0,memory_MUL_LL};
-  assign _zz_277 = {{19{_zz_276[32]}}, _zz_276};
-  assign _zz_278 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_279 = {{2{_zz_278[49]}}, _zz_278};
-  assign _zz_280 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_281 = {{2{_zz_280[49]}}, _zz_280};
-  assign _zz_282 = ($signed(_zz_284) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_283 = _zz_282[31 : 0];
-  assign _zz_284 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_285 = _zz_110[32 : 32];
-  assign _zz_286 = _zz_110[31 : 31];
-  assign _zz_287 = _zz_110[30 : 30];
-  assign _zz_288 = _zz_110[29 : 29];
-  assign _zz_289 = _zz_110[26 : 26];
-  assign _zz_290 = _zz_110[19 : 19];
-  assign _zz_291 = _zz_110[18 : 18];
-  assign _zz_292 = _zz_110[13 : 13];
-  assign _zz_293 = _zz_110[12 : 12];
-  assign _zz_294 = _zz_110[11 : 11];
-  assign _zz_295 = (decode_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_296 = {29'd0, _zz_295};
-  assign _zz_297 = _zz_110[16 : 16];
-  assign _zz_298 = _zz_110[5 : 5];
-  assign _zz_299 = _zz_110[3 : 3];
-  assign _zz_300 = _zz_110[17 : 17];
-  assign _zz_301 = _zz_110[10 : 10];
-  assign _zz_302 = _zz_110[15 : 15];
-  assign _zz_303 = _zz_110[4 : 4];
-  assign _zz_304 = _zz_110[0 : 0];
-  assign _zz_305 = (_zz_55 - 4'b0001);
-  assign _zz_306 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_307 = {29'd0, _zz_306};
-  assign _zz_308 = (decode_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_309 = {29'd0, _zz_308};
-  assign _zz_310 = {{_zz_75,_zz_65[6 : 2]},12'h0};
-  assign _zz_311 = {{{4'b0000,_zz_65[8 : 7]},_zz_65[12 : 9]},2'b00};
-  assign _zz_312 = {{{4'b0000,_zz_65[8 : 7]},_zz_65[12 : 9]},2'b00};
-  assign _zz_313 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_314 = {{_zz_98,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_315 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_316 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_317 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_318 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_319 = execute_SRC_LESS;
-  assign _zz_320 = (execute_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_321 = execute_INSTRUCTION[19 : 15];
-  assign _zz_322 = execute_INSTRUCTION[31 : 20];
-  assign _zz_323 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_324 = ($signed(_zz_325) + $signed(_zz_328));
-  assign _zz_325 = ($signed(_zz_326) + $signed(_zz_327));
-  assign _zz_326 = execute_SRC1;
-  assign _zz_327 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_328 = (execute_SRC_USE_SUB_LESS ? _zz_329 : _zz_330);
-  assign _zz_329 = 32'h00000001;
-  assign _zz_330 = 32'h0;
-  assign _zz_331 = execute_INSTRUCTION[31 : 20];
-  assign _zz_332 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_333 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_334 = (execute_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_335 = (_zz_157 & (~ _zz_336));
-  assign _zz_336 = (_zz_157 - 2'b01);
-  assign _zz_337 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_338 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_339 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_340 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_341 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_342 = {5'd0, _zz_341};
-  assign _zz_343 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_344 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_345 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_346 = {_zz_159,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_347 = _zz_348;
-  assign _zz_348 = _zz_349;
-  assign _zz_349 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_160) : _zz_160)} + _zz_351);
-  assign _zz_350 = memory_DivPlugin_div_needRevert;
-  assign _zz_351 = {32'd0, _zz_350};
-  assign _zz_352 = _zz_162;
-  assign _zz_353 = {32'd0, _zz_352};
-  assign _zz_354 = _zz_161;
-  assign _zz_355 = {31'd0, _zz_354};
-  assign _zz_356 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_357 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_358 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_359 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_360 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_361 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_362 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_363 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_364 = 1'b1;
-  assign _zz_365 = 1'b1;
-  assign _zz_366 = {_zz_59,_zz_58};
-  assign _zz_367 = 32'h0000107f;
-  assign _zz_368 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_369 = 32'h00002073;
-  assign _zz_370 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_371 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_372 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_373) == 32'h00000003),{(_zz_374 == _zz_375),{_zz_376,{_zz_377,_zz_378}}}}}};
-  assign _zz_373 = 32'h0000505f;
-  assign _zz_374 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_375 = 32'h00000063;
-  assign _zz_376 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_377 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_378 = {((decode_INSTRUCTION & 32'hf800707f) == 32'h1800202f),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_379) == 32'h00005013),{(_zz_380 == _zz_381),{_zz_382,{_zz_383,_zz_384}}}}}};
-  assign _zz_379 = 32'hbc00707f;
-  assign _zz_380 = (decode_INSTRUCTION & 32'hfc00307f);
-  assign _zz_381 = 32'h00001013;
-  assign _zz_382 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_383 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_384 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}}};
-  assign _zz_385 = (_zz_65[11 : 10] == 2'b01);
-  assign _zz_386 = ((_zz_65[11 : 10] == 2'b11) && (_zz_65[6 : 5] == 2'b00));
-  assign _zz_387 = 7'h0;
-  assign _zz_388 = _zz_65[6 : 2];
-  assign _zz_389 = _zz_65[12];
-  assign _zz_390 = _zz_65[11 : 7];
-  assign _zz_391 = decode_INSTRUCTION[31];
-  assign _zz_392 = decode_INSTRUCTION[19 : 12];
-  assign _zz_393 = decode_INSTRUCTION[20];
-  assign _zz_394 = decode_INSTRUCTION[31];
-  assign _zz_395 = decode_INSTRUCTION[7];
-  assign _zz_396 = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_397 = 32'h02004020;
-  assign _zz_398 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_399 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
-  assign _zz_400 = 1'b0;
-  assign _zz_401 = (((decode_INSTRUCTION & _zz_404) == 32'h00000050) != 1'b0);
-  assign _zz_402 = ({_zz_405,_zz_406} != 2'b00);
-  assign _zz_403 = {({_zz_407,_zz_408} != 2'b00),{(_zz_409 != _zz_410),{_zz_411,{_zz_412,_zz_413}}}};
-  assign _zz_404 = 32'h00403050;
-  assign _zz_405 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_406 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_407 = _zz_112;
-  assign _zz_408 = ((decode_INSTRUCTION & _zz_414) == 32'h00000004);
-  assign _zz_409 = ((decode_INSTRUCTION & _zz_415) == 32'h00000040);
-  assign _zz_410 = 1'b0;
-  assign _zz_411 = ({_zz_416,_zz_417} != 2'b00);
-  assign _zz_412 = ({_zz_418,_zz_419} != 3'b000);
-  assign _zz_413 = {(_zz_420 != _zz_421),{_zz_422,{_zz_423,_zz_424}}};
-  assign _zz_414 = 32'h0000001c;
-  assign _zz_415 = 32'h00000058;
-  assign _zz_416 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz_417 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h40001010);
-  assign _zz_419 = {(_zz_426 == _zz_427),(_zz_428 == _zz_429)};
-  assign _zz_420 = ((decode_INSTRUCTION & _zz_430) == 32'h00001000);
-  assign _zz_421 = 1'b0;
-  assign _zz_422 = ((_zz_431 == _zz_432) != 1'b0);
-  assign _zz_423 = ({_zz_433,_zz_434} != 2'b00);
-  assign _zz_424 = {(_zz_435 != _zz_436),{_zz_437,{_zz_438,_zz_439}}};
-  assign _zz_425 = 32'h40003054;
-  assign _zz_426 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_427 = 32'h00001010;
-  assign _zz_428 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_429 = 32'h00001010;
-  assign _zz_430 = 32'h00001000;
-  assign _zz_431 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_432 = 32'h00002000;
-  assign _zz_433 = ((decode_INSTRUCTION & _zz_440) == 32'h00002000);
-  assign _zz_434 = ((decode_INSTRUCTION & _zz_441) == 32'h00001000);
-  assign _zz_435 = ((decode_INSTRUCTION & _zz_442) == 32'h00004008);
-  assign _zz_436 = 1'b0;
-  assign _zz_437 = ((_zz_443 == _zz_444) != 1'b0);
-  assign _zz_438 = ({_zz_445,_zz_446} != 3'b000);
-  assign _zz_439 = {(_zz_447 != _zz_448),{_zz_449,{_zz_450,_zz_451}}};
-  assign _zz_440 = 32'h00002010;
-  assign _zz_441 = 32'h00005000;
-  assign _zz_442 = 32'h00004048;
-  assign _zz_443 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_444 = 32'h00000024;
-  assign _zz_445 = ((decode_INSTRUCTION & _zz_452) == 32'h00000020);
-  assign _zz_446 = {(_zz_453 == _zz_454),(_zz_455 == _zz_456)};
-  assign _zz_447 = ((decode_INSTRUCTION & _zz_457) == 32'h00000008);
-  assign _zz_448 = 1'b0;
-  assign _zz_449 = ({_zz_458,{_zz_459,_zz_460}} != 6'h0);
-  assign _zz_450 = ({_zz_461,_zz_462} != 2'b00);
-  assign _zz_451 = {(_zz_463 != _zz_464),{_zz_465,{_zz_466,_zz_467}}};
-  assign _zz_452 = 32'h00000034;
-  assign _zz_453 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_454 = 32'h00000020;
-  assign _zz_455 = (decode_INSTRUCTION & 32'h08000070);
-  assign _zz_456 = 32'h08000020;
-  assign _zz_457 = 32'h00000008;
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_468) == 32'h00002040);
-  assign _zz_459 = (_zz_469 == _zz_470);
-  assign _zz_460 = {_zz_471,{_zz_472,_zz_473}};
-  assign _zz_461 = (_zz_474 == _zz_475);
-  assign _zz_462 = (_zz_476 == _zz_477);
-  assign _zz_463 = {_zz_478,{_zz_479,_zz_480}};
-  assign _zz_464 = 5'h0;
-  assign _zz_465 = ({_zz_481,_zz_482} != 5'h0);
-  assign _zz_466 = (_zz_483 != _zz_484);
-  assign _zz_467 = {_zz_485,{_zz_486,_zz_487}};
-  assign _zz_468 = 32'h00002040;
-  assign _zz_469 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_470 = 32'h00001040;
-  assign _zz_471 = ((decode_INSTRUCTION & _zz_488) == 32'h00000040);
-  assign _zz_472 = (_zz_489 == _zz_490);
-  assign _zz_473 = {_zz_491,_zz_492};
-  assign _zz_474 = (decode_INSTRUCTION & 32'h08000020);
-  assign _zz_475 = 32'h08000020;
-  assign _zz_476 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_477 = 32'h00000020;
-  assign _zz_478 = ((decode_INSTRUCTION & _zz_493) == 32'h00000040);
-  assign _zz_479 = (_zz_494 == _zz_495);
-  assign _zz_480 = {_zz_496,{_zz_497,_zz_498}};
-  assign _zz_481 = _zz_115;
-  assign _zz_482 = {_zz_499,{_zz_500,_zz_501}};
-  assign _zz_483 = {_zz_112,{_zz_502,_zz_503}};
-  assign _zz_484 = 7'h0;
-  assign _zz_485 = ({_zz_504,_zz_505} != 2'b00);
-  assign _zz_486 = (_zz_506 != _zz_507);
-  assign _zz_487 = {_zz_508,{_zz_509,_zz_510}};
-  assign _zz_488 = 32'h00000050;
-  assign _zz_489 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz_490 = 32'h00000040;
-  assign _zz_491 = ((decode_INSTRUCTION & _zz_511) == 32'h00002008);
-  assign _zz_492 = ((decode_INSTRUCTION & _zz_512) == 32'h0);
-  assign _zz_493 = 32'h00000040;
-  assign _zz_494 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_495 = 32'h00004020;
-  assign _zz_496 = ((decode_INSTRUCTION & _zz_513) == 32'h00000010);
-  assign _zz_497 = _zz_115;
-  assign _zz_498 = (_zz_514 == _zz_515);
-  assign _zz_499 = ((decode_INSTRUCTION & _zz_516) == 32'h00002010);
-  assign _zz_500 = (_zz_517 == _zz_518);
-  assign _zz_501 = {_zz_519,_zz_520};
-  assign _zz_502 = (_zz_521 == _zz_522);
-  assign _zz_503 = {_zz_523,{_zz_524,_zz_525}};
-  assign _zz_504 = _zz_114;
-  assign _zz_505 = (_zz_526 == _zz_527);
-  assign _zz_506 = {_zz_114,_zz_528};
-  assign _zz_507 = 2'b00;
-  assign _zz_508 = (_zz_529 != 1'b0);
-  assign _zz_509 = (_zz_530 != _zz_531);
-  assign _zz_510 = {_zz_532,{_zz_533,_zz_534}};
-  assign _zz_511 = 32'h08002008;
-  assign _zz_512 = 32'h00000038;
-  assign _zz_513 = 32'h00000030;
-  assign _zz_514 = (decode_INSTRUCTION & 32'h12000020);
-  assign _zz_515 = 32'h00000020;
-  assign _zz_516 = 32'h00002030;
-  assign _zz_517 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_518 = 32'h00000010;
-  assign _zz_519 = ((decode_INSTRUCTION & _zz_535) == 32'h00000020);
-  assign _zz_520 = ((decode_INSTRUCTION & _zz_536) == 32'h00002020);
-  assign _zz_521 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_522 = 32'h00001010;
-  assign _zz_523 = ((decode_INSTRUCTION & _zz_537) == 32'h00002010);
-  assign _zz_524 = (_zz_538 == _zz_539);
-  assign _zz_525 = {_zz_540,{_zz_541,_zz_542}};
-  assign _zz_526 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_527 = 32'h00000020;
-  assign _zz_528 = ((decode_INSTRUCTION & _zz_543) == 32'h0);
-  assign _zz_529 = ((decode_INSTRUCTION & _zz_544) == 32'h00004010);
-  assign _zz_530 = (_zz_545 == _zz_546);
-  assign _zz_531 = 1'b0;
-  assign _zz_532 = ({_zz_547,_zz_548} != 5'h0);
-  assign _zz_533 = (_zz_549 != _zz_550);
-  assign _zz_534 = {_zz_551,{_zz_552,_zz_553}};
-  assign _zz_535 = 32'h02003020;
-  assign _zz_536 = 32'h12002060;
-  assign _zz_537 = 32'h00002010;
-  assign _zz_538 = (decode_INSTRUCTION & 32'h00002008);
-  assign _zz_539 = 32'h00002008;
-  assign _zz_540 = ((decode_INSTRUCTION & _zz_554) == 32'h00000010);
-  assign _zz_541 = _zz_115;
-  assign _zz_542 = (_zz_555 == _zz_556);
-  assign _zz_543 = 32'h00000020;
-  assign _zz_544 = 32'h00004014;
-  assign _zz_545 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_546 = 32'h00002010;
-  assign _zz_547 = (_zz_557 == _zz_558);
-  assign _zz_548 = {_zz_559,{_zz_560,_zz_561}};
-  assign _zz_549 = {_zz_113,_zz_562};
-  assign _zz_550 = 2'b00;
-  assign _zz_551 = ({_zz_563,_zz_564} != 3'b000);
-  assign _zz_552 = (_zz_565 != _zz_566);
-  assign _zz_553 = {_zz_567,_zz_568};
-  assign _zz_554 = 32'h00000050;
-  assign _zz_555 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_556 = 32'h0;
-  assign _zz_557 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_558 = 32'h0;
-  assign _zz_559 = ((decode_INSTRUCTION & _zz_569) == 32'h0);
-  assign _zz_560 = (_zz_570 == _zz_571);
-  assign _zz_561 = {_zz_572,_zz_113};
-  assign _zz_562 = ((decode_INSTRUCTION & _zz_573) == 32'h0);
-  assign _zz_563 = (_zz_574 == _zz_575);
-  assign _zz_564 = {_zz_576,_zz_577};
-  assign _zz_565 = {_zz_112,{_zz_578,_zz_579}};
-  assign _zz_566 = 3'b000;
-  assign _zz_567 = ({_zz_580,_zz_581} != 2'b00);
-  assign _zz_568 = (_zz_582 != 1'b0);
-  assign _zz_569 = 32'h00000018;
-  assign _zz_570 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_571 = 32'h00002000;
-  assign _zz_572 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_573 = 32'h00000058;
-  assign _zz_574 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_575 = 32'h00000040;
-  assign _zz_576 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_577 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz_578 = _zz_111;
-  assign _zz_579 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
-  assign _zz_580 = _zz_111;
-  assign _zz_581 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
-  assign _zz_582 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_583 = execute_INSTRUCTION[31];
-  assign _zz_584 = execute_INSTRUCTION[31];
-  assign _zz_585 = execute_INSTRUCTION[7];
-  assign _zz_586 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_364) begin
-      _zz_228 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_decode_FORMAL_PC_NEXT_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_decode_FORMAL_PC_NEXT = {29'd0, _zz_decode_FORMAL_PC_NEXT_1};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz_IBusCachedPlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_IBusCachedPlugin_decodePc_pcPlus = {29'd0, _zz_IBusCachedPlugin_decodePc_pcPlus_1};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_34 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_35 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hf800707f) == 32'h1800202f),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbc00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00001013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}}};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_28 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b01);
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_29 = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5] == 2'b00));
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = 7'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_31 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_32 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 7];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[19 : 12];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[20];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_7 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_8 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_6) == 32'h00000050) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ({_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {({_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_12} != 2'b00),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_16),{_zz__zz_decode_IS_RS2_SIGNED_17,{_zz__zz_decode_IS_RS2_SIGNED_20,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h00403050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_15) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ({_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_40}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25),(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = ({_zz__zz_decode_IS_RS2_SIGNED_36,_zz__zz_decode_IS_RS2_SIGNED_38} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = {(_zz__zz_decode_IS_RS2_SIGNED_41 != _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_55}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_42) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ({_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_50} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = {(_zz__zz_decode_IS_RS2_SIGNED_56 != _zz__zz_decode_IS_RS2_SIGNED_58),{_zz__zz_decode_IS_RS2_SIGNED_59,{_zz__zz_decode_IS_RS2_SIGNED_76,_zz__zz_decode_IS_RS2_SIGNED_83}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00000024;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = {(_zz__zz_decode_IS_RS2_SIGNED_51 == _zz__zz_decode_IS_RS2_SIGNED_52),(_zz__zz_decode_IS_RS2_SIGNED_53 == _zz__zz_decode_IS_RS2_SIGNED_54)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_57) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = ({_zz__zz_decode_IS_RS2_SIGNED_60,{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_65}} != 6'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ({_zz__zz_decode_IS_RS2_SIGNED_77,_zz__zz_decode_IS_RS2_SIGNED_80} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(_zz__zz_decode_IS_RS2_SIGNED_84 != _zz__zz_decode_IS_RS2_SIGNED_97),{_zz__zz_decode_IS_RS2_SIGNED_98,{_zz__zz_decode_IS_RS2_SIGNED_111,_zz__zz_decode_IS_RS2_SIGNED_130}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_61) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = {_zz__zz_decode_IS_RS2_SIGNED_66,{_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_71}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (_zz__zz_decode_IS_RS2_SIGNED_78 == _zz__zz_decode_IS_RS2_SIGNED_79);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (_zz__zz_decode_IS_RS2_SIGNED_81 == _zz__zz_decode_IS_RS2_SIGNED_82);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz__zz_decode_IS_RS2_SIGNED_85,{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_90}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ({_zz__zz_decode_IS_RS2_SIGNED_99,_zz__zz_decode_IS_RS2_SIGNED_100} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 != _zz__zz_decode_IS_RS2_SIGNED_129);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = {_zz__zz_decode_IS_RS2_SIGNED_131,{_zz__zz_decode_IS_RS2_SIGNED_136,_zz__zz_decode_IS_RS2_SIGNED_141}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_67) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = {_zz__zz_decode_IS_RS2_SIGNED_72,_zz__zz_decode_IS_RS2_SIGNED_74};
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_86) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (_zz__zz_decode_IS_RS2_SIGNED_88 == _zz__zz_decode_IS_RS2_SIGNED_89);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = {_zz__zz_decode_IS_RS2_SIGNED_91,{_zz__zz_decode_IS_RS2_SIGNED_93,_zz__zz_decode_IS_RS2_SIGNED_94}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {_zz__zz_decode_IS_RS2_SIGNED_101,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_113,_zz__zz_decode_IS_RS2_SIGNED_116}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 7'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = ({_zz__zz_decode_IS_RS2_SIGNED_132,_zz__zz_decode_IS_RS2_SIGNED_133} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = (_zz__zz_decode_IS_RS2_SIGNED_137 != _zz__zz_decode_IS_RS2_SIGNED_140);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = {_zz__zz_decode_IS_RS2_SIGNED_142,{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_150}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_75) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_92) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (_zz__zz_decode_IS_RS2_SIGNED_95 == _zz__zz_decode_IS_RS2_SIGNED_96);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,_zz__zz_decode_IS_RS2_SIGNED_109};
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (_zz__zz_decode_IS_RS2_SIGNED_114 == _zz__zz_decode_IS_RS2_SIGNED_115);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz__zz_decode_IS_RS2_SIGNED_117,{_zz__zz_decode_IS_RS2_SIGNED_119,_zz__zz_decode_IS_RS2_SIGNED_122}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (_zz__zz_decode_IS_RS2_SIGNED_134 == _zz__zz_decode_IS_RS2_SIGNED_135);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = {_zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_138};
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = (_zz__zz_decode_IS_RS2_SIGNED_143 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (_zz__zz_decode_IS_RS2_SIGNED_146 != _zz__zz_decode_IS_RS2_SIGNED_149);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_163,_zz__zz_decode_IS_RS2_SIGNED_168}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h08002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = 32'h00000038;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (decode_INSTRUCTION & 32'h12000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_110) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = {_zz__zz_decode_IS_RS2_SIGNED_123,{_zz__zz_decode_IS_RS2_SIGNED_125,_zz__zz_decode_IS_RS2_SIGNED_126}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_144) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = ({_zz__zz_decode_IS_RS2_SIGNED_152,_zz__zz_decode_IS_RS2_SIGNED_155} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (_zz__zz_decode_IS_RS2_SIGNED_164 != _zz__zz_decode_IS_RS2_SIGNED_167);
+  assign _zz__zz_decode_IS_RS2_SIGNED_168 = {_zz__zz_decode_IS_RS2_SIGNED_169,{_zz__zz_decode_IS_RS2_SIGNED_176,_zz__zz_decode_IS_RS2_SIGNED_181}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = 32'h12002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_124) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = _zz_decode_IS_RS2_SIGNED_5;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (_zz__zz_decode_IS_RS2_SIGNED_127 == _zz__zz_decode_IS_RS2_SIGNED_128);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = (_zz__zz_decode_IS_RS2_SIGNED_153 == _zz__zz_decode_IS_RS2_SIGNED_154);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = {_zz__zz_decode_IS_RS2_SIGNED_156,{_zz__zz_decode_IS_RS2_SIGNED_158,_zz__zz_decode_IS_RS2_SIGNED_161}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_165};
+  assign _zz__zz_decode_IS_RS2_SIGNED_167 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_169 = ({_zz__zz_decode_IS_RS2_SIGNED_170,_zz__zz_decode_IS_RS2_SIGNED_173} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_176 = (_zz__zz_decode_IS_RS2_SIGNED_177 != _zz__zz_decode_IS_RS2_SIGNED_180);
+  assign _zz__zz_decode_IS_RS2_SIGNED_181 = {_zz__zz_decode_IS_RS2_SIGNED_182,_zz__zz_decode_IS_RS2_SIGNED_185};
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_157) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = (_zz__zz_decode_IS_RS2_SIGNED_159 == _zz__zz_decode_IS_RS2_SIGNED_160);
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = {_zz__zz_decode_IS_RS2_SIGNED_162,_zz_decode_IS_RS2_SIGNED_3};
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_166) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_170 = (_zz__zz_decode_IS_RS2_SIGNED_171 == _zz__zz_decode_IS_RS2_SIGNED_172);
+  assign _zz__zz_decode_IS_RS2_SIGNED_173 = {_zz__zz_decode_IS_RS2_SIGNED_174,_zz__zz_decode_IS_RS2_SIGNED_175};
+  assign _zz__zz_decode_IS_RS2_SIGNED_177 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_178,_zz__zz_decode_IS_RS2_SIGNED_179}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_180 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_182 = ({_zz__zz_decode_IS_RS2_SIGNED_183,_zz__zz_decode_IS_RS2_SIGNED_184} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_185 = (_zz__zz_decode_IS_RS2_SIGNED_186 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = 32'h00000018;
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_171 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_172 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_174 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_175 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_178 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_179 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_183 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_184 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_186 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_365) begin
-      _zz_229 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_198                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_199                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_200                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_201                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_202                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_fetch_cacheMiss                   (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss               ), //o
-    .io_cpu_fetch_error                       (IBusCachedPlugin_cache_io_cpu_fetch_error                   ), //o
-    .io_cpu_fetch_mmuRefilling                (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling            ), //o
-    .io_cpu_fetch_mmuException                (IBusCachedPlugin_cache_io_cpu_fetch_mmuException            ), //o
-    .io_cpu_fetch_isUser                      (_zz_203                                                     ), //i
-    .io_cpu_decode_isValid                    (_zz_204                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_205                                                     ), //i
-    .io_cpu_decode_pc                         (_zz_206[31:0]                                               ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_fill_valid                        (_zz_207                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_fetch_cacheMiss                   (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss         ), //o
+    .io_cpu_fetch_error                       (IBusCachedPlugin_cache_io_cpu_fetch_error             ), //o
+    .io_cpu_fetch_mmuRefilling                (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling      ), //o
+    .io_cpu_fetch_mmuException                (IBusCachedPlugin_cache_io_cpu_fetch_mmuException      ), //o
+    .io_cpu_fetch_isUser                      (IBusCachedPlugin_cache_io_cpu_fetch_isUser            ), //i
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_cache_io_cpu_decode_pc               ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_208                                            ), //i
-    .io_cpu_execute_address                    (_zz_209[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_105[31:0]                                      ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_isLrsc                (_zz_210                                            ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_211                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_212[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_213                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_214                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_215                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_216[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_217                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_218                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_219                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_220                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_221                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_222                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_223                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_224                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_225[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_226                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_227                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_isLrsc                (dataCache_1_io_cpu_execute_args_isLrsc         ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_366)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_230 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_230 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_230 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_230 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1897,134 +2010,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2037,30 +2150,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2072,27 +2185,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2105,30 +2218,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2141,12 +2254,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2159,12 +2272,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2177,12 +2290,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2195,48 +2308,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2249,12 +2362,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2267,12 +2380,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2284,88 +2397,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2378,73 +2491,73 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
-      default : _zz_52_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_117)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_117_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_117_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_117_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_117_string = "URS1        ";
-      default : _zz_117_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_118)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_118_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_118_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_118_string = "BITWISE ";
-      default : _zz_118_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_119)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_119_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_119_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_119_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_119_string = "PC ";
-      default : _zz_119_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_120)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_120_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_120_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_120_string = "AND_1";
-      default : _zz_120_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_121)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_121_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_121_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_121_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_121_string = "SRA_1    ";
-      default : _zz_121_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_122)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_122_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_122_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_122_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_122_string = "JALR";
-      default : _zz_122_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_123)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_123_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_123_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_123_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_123_string = "ECALL";
-      default : _zz_123_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2475,28 +2588,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2537,7 +2650,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_273) + $signed(_zz_281));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2545,49 +2658,50 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_283;
-  assign execute_REGFILE_WRITE_DATA = _zz_125;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_209[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_285[0];
-  assign decode_IS_RS1_SIGNED = _zz_286[0];
-  assign decode_IS_DIV = _zz_287[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[32];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[30];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_288[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_289[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_290[0];
-  assign decode_MEMORY_MANAGMENT = _zz_291[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[29];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[26];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[19];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[18];
+  assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_292[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_293[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_294[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
-  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
-  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_296);
+  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_decode_FORMAL_PC_NEXT);
   assign memory_PC = execute_to_memory_PC;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
@@ -2602,22 +2716,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_147;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_297[0];
-  assign decode_RS1_USE = _zz_298[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_231)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2627,140 +2741,141 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_136)begin
-      if((_zz_137 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_138;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_140)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_234)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_142)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_235)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_144)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_136)begin
-      if((_zz_137 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_138;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_139)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_234)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_141)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_235)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_143)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_133;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_236)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_299[0];
-  assign decode_SRC_ADD_ZERO = _zz_300[0];
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[17];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_131;
-  assign execute_SRC1 = _zz_126;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_decompressor_output_payload_rsp_inst);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_301[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_367) == 32'h00001073),{(_zz_368 == _zz_369),{_zz_370,{_zz_371,_zz_372}}}}}}} != 23'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 23'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_272)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_339;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_340;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_LRSC = memory_to_writeBack_MEMORY_LRSC;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2773,49 +2888,49 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_LRSC = _zz_302[0];
-  assign decode_MEMORY_ENABLE = _zz_303[0];
-  assign decode_FLUSH_ALL = _zz_304[0];
-  always @ (*) begin
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_237)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_238)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_239)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_240)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52;
-  always @ (*) begin
-    _zz_53 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53 = BranchPlugin_jumpInterface_payload;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -2824,151 +2939,151 @@ module VexRiscv (
   assign decode_IS_RVC = IBusCachedPlugin_injector_decodeInput_payload_isRvc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_134 || _zz_135)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_241)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_241)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_226 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_242)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_231)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_236)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_244)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2977,54 +3092,56 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_244)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_valid)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_valid) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
-    if(IBusCachedPlugin_injector_decodeInput_valid)begin
+    if(IBusCachedPlugin_injector_decodeInput_valid) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_242)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_244)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_243)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_244)begin
-      case(_zz_245)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3037,70 +3154,78 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_305));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_230;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_307);
-    if(IBusCachedPlugin_fetchPc_inc)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_inc) begin
       IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
     end
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodePc_flushed = 1'b0;
-    if(_zz_246)begin
+    if(when_Fetcher_l192) begin
       IBusCachedPlugin_decodePc_flushed = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_309);
+  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_IBusCachedPlugin_decodePc_pcPlus);
   assign IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
-  always @ (*) begin
+  assign when_Fetcher_l180 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
+  assign when_Fetcher_l192 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3108,48 +3233,48 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-    if(IBusCachedPlugin_decompressor_throw2BytesReg)begin
+    if(IBusCachedPlugin_decompressor_throw2BytesReg) begin
       IBusCachedPlugin_fetchPc_redo_payload[1] = 1'b1;
     end
   end
 
   assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
-  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_63 = _zz_64;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(IBusCachedPlugin_injector_decodeInput_valid)begin
+    if(IBusCachedPlugin_injector_decodeInput_valid) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
@@ -3166,190 +3291,195 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
   assign IBusCachedPlugin_decompressor_throw2Bytes = (IBusCachedPlugin_decompressor_throw2BytesReg || IBusCachedPlugin_decompressor_input_payload_pc[1]);
   assign IBusCachedPlugin_decompressor_unaligned = (IBusCachedPlugin_decompressor_throw2Bytes || IBusCachedPlugin_decompressor_bufferValid);
-  assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValid ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2Bytes ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
+  assign IBusCachedPlugin_decompressor_bufferValidPatched = (IBusCachedPlugin_decompressor_input_valid ? IBusCachedPlugin_decompressor_bufferValid : IBusCachedPlugin_decompressor_bufferValidLatch);
+  assign IBusCachedPlugin_decompressor_throw2BytesPatched = (IBusCachedPlugin_decompressor_input_valid ? IBusCachedPlugin_decompressor_throw2Bytes : IBusCachedPlugin_decompressor_throw2BytesLatch);
+  assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValidPatched ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2BytesPatched ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
   assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
-  assign _zz_65 = IBusCachedPlugin_decompressor_raw[15 : 0];
-  always @ (*) begin
-    IBusCachedPlugin_decompressor_decompressed = 32'h0;
-    case(_zz_267)
+  assign _zz_IBusCachedPlugin_decompressor_decompressed = IBusCachedPlugin_decompressor_raw[15 : 0];
+  always @(*) begin
+    IBusCachedPlugin_decompressor_decompressed = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    case(switch_Misc_l44)
       5'h0 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_65[10 : 7]},_zz_65[12 : 11]},_zz_65[5]},_zz_65[6]},2'b00},5'h02},3'b000},_zz_67},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusCachedPlugin_decompressor_decompressed[10 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 11]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h13};
       end
       5'h02 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_68,_zz_66},3'b010},_zz_67},7'h03};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_3,_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h03};
       end
       5'h06 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_68[11 : 5],_zz_67},_zz_66},3'b010},_zz_68[4 : 0]},7'h23};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_3[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed_2},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_3[4 : 0]},7'h23};
       end
       5'h08 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_70,_zz_65[11 : 7]},3'b000},_zz_65[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h09 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_73[20],_zz_73[10 : 1]},_zz_73[11]},_zz_73[19 : 12]},_zz_85},7'h6f};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_8[20],_zz_IBusCachedPlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_8[11]},_zz_IBusCachedPlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_20},7'h6f};
       end
       5'h0a : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_70,5'h0},3'b000},_zz_65[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h0b : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_65[11 : 7] == 5'h02) ? {{{{{{{{{_zz_77,_zz_65[4 : 3]},_zz_65[5]},_zz_65[2]},_zz_65[6]},4'b0000},_zz_65[11 : 7]},3'b000},_zz_65[11 : 7]},7'h13} : {{_zz_310[31 : 12],_zz_65[11 : 7]},7'h37});
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_12,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusCachedPlugin_decompressor_decompressed_27[31 : 12],_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h37});
       end
       5'h0c : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_65[11 : 10] == 2'b10) ? _zz_91 : {{1'b0,(_zz_385 || _zz_386)},5'h0}),(((! _zz_65[11]) || _zz_87) ? _zz_65[6 : 2] : _zz_67)},_zz_66},_zz_89},_zz_66},(_zz_87 ? 7'h13 : 7'h33)};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_28 || _zz_IBusCachedPlugin_decompressor_decompressed_29)},5'h0}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
       end
       5'h0d : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_80[20],_zz_80[10 : 1]},_zz_80[11]},_zz_80[19 : 12]},_zz_84},7'h6f};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_15[20],_zz_IBusCachedPlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_15[11]},_zz_IBusCachedPlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_19},7'h6f};
       end
       5'h0e : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_83[12],_zz_83[10 : 5]},_zz_84},_zz_66},3'b000},_zz_83[4 : 1]},_zz_83[11]},7'h63};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h0f : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_83[12],_zz_83[10 : 5]},_zz_84},_zz_66},3'b001},_zz_83[4 : 1]},_zz_83[11]},7'h63};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h10 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_65[6 : 2]},_zz_65[11 : 7]},3'b001},_zz_65[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h12 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_65[3 : 2]},_zz_65[12]},_zz_65[6 : 4]},2'b00},_zz_86},3'b010},_zz_65[11 : 7]},7'h03};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[3 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[12]},_zz_IBusCachedPlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h03};
       end
       5'h14 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_65[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_65[6 : 2] == 5'h0) ? {{{{12'h0,_zz_65[11 : 7]},3'b000},(_zz_65[12] ? _zz_85 : _zz_84)},7'h67} : {{{{{_zz_387,_zz_388},(_zz_389 ? _zz_390 : _zz_84)},3'b000},_zz_65[11 : 7]},7'h33}));
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_30,_zz_IBusCachedPlugin_decompressor_decompressed_31},(_zz_IBusCachedPlugin_decompressor_decompressed_32 ? _zz_IBusCachedPlugin_decompressor_decompressed_33 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
       end
       5'h16 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_311[11 : 5],_zz_65[6 : 2]},_zz_86},3'b010},_zz_312[4 : 0]},7'h23};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_34[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_35[4 : 0]},7'h23};
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_66 = {2'b01,_zz_65[9 : 7]};
-  assign _zz_67 = {2'b01,_zz_65[4 : 2]};
-  assign _zz_68 = {{{{5'h0,_zz_65[5]},_zz_65[12 : 10]},_zz_65[6]},2'b00};
-  assign _zz_69 = _zz_65[12];
-  always @ (*) begin
-    _zz_70[11] = _zz_69;
-    _zz_70[10] = _zz_69;
-    _zz_70[9] = _zz_69;
-    _zz_70[8] = _zz_69;
-    _zz_70[7] = _zz_69;
-    _zz_70[6] = _zz_69;
-    _zz_70[5] = _zz_69;
-    _zz_70[4 : 0] = _zz_65[6 : 2];
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[9 : 7]};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 2]};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_4 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[11] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[10] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[9] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[8] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[7] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[6] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[5] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[4 : 0] = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
   end
 
-  assign _zz_71 = _zz_65[12];
-  always @ (*) begin
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_6 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[9] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[8] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[7] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[6] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[5] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[4] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[3] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[2] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[1] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[0] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
   end
 
-  assign _zz_73 = {{{{{{{{_zz_72,_zz_65[8]},_zz_65[10 : 9]},_zz_65[6]},_zz_65[7]},_zz_65[2]},_zz_65[11]},_zz_65[5 : 3]},1'b0};
-  assign _zz_74 = _zz_65[12];
-  always @ (*) begin
-    _zz_75[14] = _zz_74;
-    _zz_75[13] = _zz_74;
-    _zz_75[12] = _zz_74;
-    _zz_75[11] = _zz_74;
-    _zz_75[10] = _zz_74;
-    _zz_75[9] = _zz_74;
-    _zz_75[8] = _zz_74;
-    _zz_75[7] = _zz_74;
-    _zz_75[6] = _zz_74;
-    _zz_75[5] = _zz_74;
-    _zz_75[4] = _zz_74;
-    _zz_75[3] = _zz_74;
-    _zz_75[2] = _zz_74;
-    _zz_75[1] = _zz_74;
-    _zz_75[0] = _zz_74;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_8 = {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_7,_zz_IBusCachedPlugin_decompressor_decompressed[8]},_zz_IBusCachedPlugin_decompressor_decompressed[10 : 9]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},_zz_IBusCachedPlugin_decompressor_decompressed[7]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11]},_zz_IBusCachedPlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_9 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[14] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[13] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[12] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[11] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[10] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[9] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[8] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[7] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[6] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[5] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[4] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[3] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[2] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[1] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[0] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
   end
 
-  assign _zz_76 = _zz_65[12];
-  always @ (*) begin
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_11 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_12[2] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
+    _zz_IBusCachedPlugin_decompressor_decompressed_12[1] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
+    _zz_IBusCachedPlugin_decompressor_decompressed_12[0] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
   end
 
-  assign _zz_78 = _zz_65[12];
-  always @ (*) begin
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_13 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[9] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[8] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[7] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[6] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[5] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[4] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[3] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[2] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[1] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[0] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
   end
 
-  assign _zz_80 = {{{{{{{{_zz_79,_zz_65[8]},_zz_65[10 : 9]},_zz_65[6]},_zz_65[7]},_zz_65[2]},_zz_65[11]},_zz_65[5 : 3]},1'b0};
-  assign _zz_81 = _zz_65[12];
-  always @ (*) begin
-    _zz_82[4] = _zz_81;
-    _zz_82[3] = _zz_81;
-    _zz_82[2] = _zz_81;
-    _zz_82[1] = _zz_81;
-    _zz_82[0] = _zz_81;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_15 = {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_14,_zz_IBusCachedPlugin_decompressor_decompressed[8]},_zz_IBusCachedPlugin_decompressor_decompressed[10 : 9]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},_zz_IBusCachedPlugin_decompressor_decompressed[7]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11]},_zz_IBusCachedPlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_16 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[4] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[3] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[2] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[1] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[0] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
   end
 
-  assign _zz_83 = {{{{{_zz_82,_zz_65[6 : 5]},_zz_65[2]},_zz_65[11 : 10]},_zz_65[4 : 3]},1'b0};
-  assign _zz_84 = 5'h0;
-  assign _zz_85 = 5'h01;
-  assign _zz_86 = 5'h02;
-  assign _zz_87 = (_zz_65[11 : 10] != 2'b11);
-  always @ (*) begin
-    case(_zz_268)
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_18 = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_17,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},1'b0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_20 = 5'h01;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_21 = 5'h02;
+  assign switch_Misc_l44 = {_zz_IBusCachedPlugin_decompressor_decompressed[1 : 0],_zz_IBusCachedPlugin_decompressor_decompressed[15 : 13]};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_22 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] != 2'b11);
+  assign switch_Misc_l199 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
+  assign switch_Misc_l199_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
+  always @(*) begin
+    case(switch_Misc_l199_1)
       2'b00 : begin
-        _zz_88 = 3'b000;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b000;
       end
       2'b01 : begin
-        _zz_88 = 3'b100;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b100;
       end
       2'b10 : begin
-        _zz_88 = 3'b110;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b110;
       end
       default : begin
-        _zz_88 = 3'b111;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b111;
       end
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_269)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        _zz_89 = 3'b101;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
       end
       2'b01 : begin
-        _zz_89 = 3'b101;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
       end
       2'b10 : begin
-        _zz_89 = 3'b111;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b111;
       end
       default : begin
-        _zz_89 = _zz_88;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = _zz_IBusCachedPlugin_decompressor_decompressed_23;
       end
     endcase
   end
 
-  assign _zz_90 = _zz_65[12];
-  always @ (*) begin
-    _zz_91[6] = _zz_90;
-    _zz_91[5] = _zz_90;
-    _zz_91[4] = _zz_90;
-    _zz_91[3] = _zz_90;
-    _zz_91[2] = _zz_90;
-    _zz_91[1] = _zz_90;
-    _zz_91[0] = _zz_90;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_25 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[6] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[5] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[4] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[3] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[2] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[1] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[0] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
   end
 
   assign IBusCachedPlugin_decompressor_output_valid = (IBusCachedPlugin_decompressor_input_valid && (! ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_bufferValid)) && (! IBusCachedPlugin_decompressor_isInputHighRvc))));
@@ -3357,163 +3487,177 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_output_payload_isRvc = IBusCachedPlugin_decompressor_isRvc;
   assign IBusCachedPlugin_decompressor_output_payload_rsp_inst = (IBusCachedPlugin_decompressor_isRvc ? IBusCachedPlugin_decompressor_decompressed : IBusCachedPlugin_decompressor_raw);
   assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
+  assign when_Fetcher_l279 = (IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready);
   assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
+  assign when_Fetcher_l283 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l286 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l291 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
   assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
-  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_92;
-  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_93;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_94;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_95;
-  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_96;
+  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_IBusCachedPlugin_injector_decodeInput_valid;
+  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
+  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
+  assign when_Fetcher_l329 = (! 1'b0);
+  assign when_Fetcher_l329_1 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_2 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_injector_decodeInput_valid;
-  assign _zz_97 = _zz_313[11];
-  always @ (*) begin
-    _zz_98[18] = _zz_97;
-    _zz_98[17] = _zz_97;
-    _zz_98[16] = _zz_97;
-    _zz_98[15] = _zz_97;
-    _zz_98[14] = _zz_97;
-    _zz_98[13] = _zz_97;
-    _zz_98[12] = _zz_97;
-    _zz_98[11] = _zz_97;
-    _zz_98[10] = _zz_97;
-    _zz_98[9] = _zz_97;
-    _zz_98[8] = _zz_97;
-    _zz_98[7] = _zz_97;
-    _zz_98[6] = _zz_97;
-    _zz_98[5] = _zz_97;
-    _zz_98[4] = _zz_97;
-    _zz_98[3] = _zz_97;
-    _zz_98[2] = _zz_97;
-    _zz_98[1] = _zz_97;
-    _zz_98[0] = _zz_97;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_314[31]));
+  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_99 = _zz_315[19];
-  always @ (*) begin
-    _zz_100[10] = _zz_99;
-    _zz_100[9] = _zz_99;
-    _zz_100[8] = _zz_99;
-    _zz_100[7] = _zz_99;
-    _zz_100[6] = _zz_99;
-    _zz_100[5] = _zz_99;
-    _zz_100[4] = _zz_99;
-    _zz_100[3] = _zz_99;
-    _zz_100[2] = _zz_99;
-    _zz_100[1] = _zz_99;
-    _zz_100[0] = _zz_99;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_101 = _zz_316[11];
-  always @ (*) begin
-    _zz_102[18] = _zz_101;
-    _zz_102[17] = _zz_101;
-    _zz_102[16] = _zz_101;
-    _zz_102[15] = _zz_101;
-    _zz_102[14] = _zz_101;
-    _zz_102[13] = _zz_101;
-    _zz_102[12] = _zz_101;
-    _zz_102[11] = _zz_101;
-    _zz_102[10] = _zz_101;
-    _zz_102[9] = _zz_101;
-    _zz_102[8] = _zz_101;
-    _zz_102[7] = _zz_101;
-    _zz_102[6] = _zz_101;
-    _zz_102[5] = _zz_101;
-    _zz_102[4] = _zz_101;
-    _zz_102[3] = _zz_101;
-    _zz_102[2] = _zz_101;
-    _zz_102[1] = _zz_101;
-    _zz_102[0] = _zz_101;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_100,{{{_zz_391,_zz_392},_zz_393},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_102,{{{_zz_394,_zz_395},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,_zz_IBusCachedPlugin_predictionJumpInterface_payload_5},_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_7,_zz_IBusCachedPlugin_predictionJumpInterface_payload_8},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_199 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_200 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_201 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_200;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_203 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_240)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_238)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_207 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(_zz_238)begin
-      _zz_207 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_239)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_237)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_239)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_237)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  assign _zz_198 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_227 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3521,184 +3665,202 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  always @ (*) begin
-    _zz_51 = 1'b0;
-    if(decode_INSTRUCTION[25])begin
-      if(decode_MEMORY_LRSC)begin
-        _zz_51 = 1'b1;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  always @(*) begin
+    _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
+    if(when_DBusCachedPlugin_l311) begin
+      if(decode_MEMORY_LRSC) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l311 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_208 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_209 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_105 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_105 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_105 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_226 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  always @ (*) begin
-    _zz_210 = 1'b0;
-    if(execute_MEMORY_LRSC)begin
-      _zz_210 = 1'b1;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
+    if(execute_MEMORY_LRSC) begin
+      dataCache_1_io_cpu_execute_args_isLrsc = 1'b1;
     end
   end
 
-  assign _zz_211 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_212 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_211;
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_212;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_213 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_213 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_214 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_215 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_216 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_247)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_247)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_247)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_317};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_318};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_106 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_107[31] = _zz_106;
-    _zz_107[30] = _zz_106;
-    _zz_107[29] = _zz_106;
-    _zz_107[28] = _zz_106;
-    _zz_107[27] = _zz_106;
-    _zz_107[26] = _zz_106;
-    _zz_107[25] = _zz_106;
-    _zz_107[24] = _zz_106;
-    _zz_107[23] = _zz_106;
-    _zz_107[22] = _zz_106;
-    _zz_107[21] = _zz_106;
-    _zz_107[20] = _zz_106;
-    _zz_107[19] = _zz_106;
-    _zz_107[18] = _zz_106;
-    _zz_107[17] = _zz_106;
-    _zz_107[16] = _zz_106;
-    _zz_107[15] = _zz_106;
-    _zz_107[14] = _zz_106;
-    _zz_107[13] = _zz_106;
-    _zz_107[12] = _zz_106;
-    _zz_107[11] = _zz_106;
-    _zz_107[10] = _zz_106;
-    _zz_107[9] = _zz_106;
-    _zz_107[8] = _zz_106;
-    _zz_107[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+    if(when_DBusCachedPlugin_l474) begin
+      writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
+    end
   end
 
-  assign _zz_108 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_109[31] = _zz_108;
-    _zz_109[30] = _zz_108;
-    _zz_109[29] = _zz_108;
-    _zz_109[28] = _zz_108;
-    _zz_109[27] = _zz_108;
-    _zz_109[26] = _zz_108;
-    _zz_109[25] = _zz_108;
-    _zz_109[24] = _zz_108;
-    _zz_109[23] = _zz_108;
-    _zz_109[22] = _zz_108;
-    _zz_109[21] = _zz_108;
-    _zz_109[20] = _zz_108;
-    _zz_109[19] = _zz_108;
-    _zz_109[18] = _zz_108;
-    _zz_109[17] = _zz_108;
-    _zz_109[16] = _zz_108;
-    _zz_109[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign when_DBusCachedPlugin_l474 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l199_2 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_270)
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l199_2)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_107;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_109;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3717,61 +3879,62 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_111 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_112 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_113 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_114 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_115 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_116 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_110 = {(_zz_116 != 1'b0),{(_zz_116 != 1'b0),{((_zz_396 == _zz_397) != 1'b0),{(_zz_398 != 1'b0),{(_zz_399 != _zz_400),{_zz_401,{_zz_402,_zz_403}}}}}}};
-  assign _zz_117 = _zz_110[2 : 1];
-  assign _zz_49 = _zz_117;
-  assign _zz_118 = _zz_110[7 : 6];
-  assign _zz_48 = _zz_118;
-  assign _zz_119 = _zz_110[9 : 8];
-  assign _zz_47 = _zz_119;
-  assign _zz_120 = _zz_110[21 : 20];
-  assign _zz_46 = _zz_120;
-  assign _zz_121 = _zz_110[23 : 22];
-  assign _zz_45 = _zz_121;
-  assign _zz_122 = _zz_110[25 : 24];
-  assign _zz_44 = _zz_122;
-  assign _zz_123 = _zz_110[28 : 27];
-  assign _zz_43 = _zz_123;
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_6 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_6 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[21 : 20];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[23 : 22];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[25 : 24];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[28 : 27];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_228;
-  assign decode_RegFilePlugin_rs2Data = _zz_229;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_124)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_2) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_124)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_124)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3780,277 +3943,300 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_125 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_125 = {31'd0, _zz_319};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_125 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_126 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_126 = {29'd0, _zz_320};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_126 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_126 = {27'd0, _zz_321};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_127 = _zz_322[11];
-  always @ (*) begin
-    _zz_128[19] = _zz_127;
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_129 = _zz_323[11];
-  always @ (*) begin
-    _zz_130[19] = _zz_129;
-    _zz_130[18] = _zz_129;
-    _zz_130[17] = _zz_129;
-    _zz_130[16] = _zz_129;
-    _zz_130[15] = _zz_129;
-    _zz_130[14] = _zz_129;
-    _zz_130[13] = _zz_129;
-    _zz_130[12] = _zz_129;
-    _zz_130[11] = _zz_129;
-    _zz_130[10] = _zz_129;
-    _zz_130[9] = _zz_129;
-    _zz_130[8] = _zz_129;
-    _zz_130[7] = _zz_129;
-    _zz_130[6] = _zz_129;
-    _zz_130[5] = _zz_129;
-    _zz_130[4] = _zz_129;
-    _zz_130[3] = _zz_129;
-    _zz_130[2] = _zz_129;
-    _zz_130[1] = _zz_129;
-    _zz_130[0] = _zz_129;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_131 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_131 = {_zz_128,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_131 = {_zz_130,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_131 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_324;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_132[0] = execute_SRC1[31];
-    _zz_132[1] = execute_SRC1[30];
-    _zz_132[2] = execute_SRC1[29];
-    _zz_132[3] = execute_SRC1[28];
-    _zz_132[4] = execute_SRC1[27];
-    _zz_132[5] = execute_SRC1[26];
-    _zz_132[6] = execute_SRC1[25];
-    _zz_132[7] = execute_SRC1[24];
-    _zz_132[8] = execute_SRC1[23];
-    _zz_132[9] = execute_SRC1[22];
-    _zz_132[10] = execute_SRC1[21];
-    _zz_132[11] = execute_SRC1[20];
-    _zz_132[12] = execute_SRC1[19];
-    _zz_132[13] = execute_SRC1[18];
-    _zz_132[14] = execute_SRC1[17];
-    _zz_132[15] = execute_SRC1[16];
-    _zz_132[16] = execute_SRC1[15];
-    _zz_132[17] = execute_SRC1[14];
-    _zz_132[18] = execute_SRC1[13];
-    _zz_132[19] = execute_SRC1[12];
-    _zz_132[20] = execute_SRC1[11];
-    _zz_132[21] = execute_SRC1[10];
-    _zz_132[22] = execute_SRC1[9];
-    _zz_132[23] = execute_SRC1[8];
-    _zz_132[24] = execute_SRC1[7];
-    _zz_132[25] = execute_SRC1[6];
-    _zz_132[26] = execute_SRC1[5];
-    _zz_132[27] = execute_SRC1[4];
-    _zz_132[28] = execute_SRC1[3];
-    _zz_132[29] = execute_SRC1[2];
-    _zz_132[30] = execute_SRC1[1];
-    _zz_132[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_132 : execute_SRC1);
-  always @ (*) begin
-    _zz_133[0] = memory_SHIFT_RIGHT[31];
-    _zz_133[1] = memory_SHIFT_RIGHT[30];
-    _zz_133[2] = memory_SHIFT_RIGHT[29];
-    _zz_133[3] = memory_SHIFT_RIGHT[28];
-    _zz_133[4] = memory_SHIFT_RIGHT[27];
-    _zz_133[5] = memory_SHIFT_RIGHT[26];
-    _zz_133[6] = memory_SHIFT_RIGHT[25];
-    _zz_133[7] = memory_SHIFT_RIGHT[24];
-    _zz_133[8] = memory_SHIFT_RIGHT[23];
-    _zz_133[9] = memory_SHIFT_RIGHT[22];
-    _zz_133[10] = memory_SHIFT_RIGHT[21];
-    _zz_133[11] = memory_SHIFT_RIGHT[20];
-    _zz_133[12] = memory_SHIFT_RIGHT[19];
-    _zz_133[13] = memory_SHIFT_RIGHT[18];
-    _zz_133[14] = memory_SHIFT_RIGHT[17];
-    _zz_133[15] = memory_SHIFT_RIGHT[16];
-    _zz_133[16] = memory_SHIFT_RIGHT[15];
-    _zz_133[17] = memory_SHIFT_RIGHT[14];
-    _zz_133[18] = memory_SHIFT_RIGHT[13];
-    _zz_133[19] = memory_SHIFT_RIGHT[12];
-    _zz_133[20] = memory_SHIFT_RIGHT[11];
-    _zz_133[21] = memory_SHIFT_RIGHT[10];
-    _zz_133[22] = memory_SHIFT_RIGHT[9];
-    _zz_133[23] = memory_SHIFT_RIGHT[8];
-    _zz_133[24] = memory_SHIFT_RIGHT[7];
-    _zz_133[25] = memory_SHIFT_RIGHT[6];
-    _zz_133[26] = memory_SHIFT_RIGHT[5];
-    _zz_133[27] = memory_SHIFT_RIGHT[4];
-    _zz_133[28] = memory_SHIFT_RIGHT[3];
-    _zz_133[29] = memory_SHIFT_RIGHT[2];
-    _zz_133[30] = memory_SHIFT_RIGHT[1];
-    _zz_133[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_134 = 1'b0;
-    if(_zz_248)begin
-      if(_zz_249)begin
-        if(_zz_139)begin
-          _zz_134 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_250)begin
-      if(_zz_251)begin
-        if(_zz_141)begin
-          _zz_134 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_252)begin
-      if(_zz_253)begin
-        if(_zz_143)begin
-          _zz_134 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_134 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_135 = 1'b0;
-    if(_zz_248)begin
-      if(_zz_249)begin
-        if(_zz_140)begin
-          _zz_135 = 1'b1;
-        end
-      end
-    end
-    if(_zz_250)begin
-      if(_zz_251)begin
-        if(_zz_142)begin
-          _zz_135 = 1'b1;
-        end
-      end
-    end
-    if(_zz_252)begin
-      if(_zz_253)begin
-        if(_zz_144)begin
-          _zz_135 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_135 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_139 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_140 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_141 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_142 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_143 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_144 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_145 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_145 == 3'b000)) begin
-        _zz_146 = execute_BranchPlugin_eq;
-    end else if((_zz_145 == 3'b001)) begin
-        _zz_146 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_145 & 3'b101) == 3'b101))) begin
-        _zz_146 = (! execute_SRC_LESS);
-    end else begin
-        _zz_146 = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_147 = 1'b0;
+  assign switch_Misc_l199_3 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_3)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_147 = 1'b1;
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_147 = 1'b1;
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
-        _zz_147 = _zz_146;
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
   assign execute_BranchPlugin_missAlignedTarget = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -4061,169 +4247,183 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_148 = _zz_331[11];
-  always @ (*) begin
-    _zz_149[19] = _zz_148;
-    _zz_149[18] = _zz_148;
-    _zz_149[17] = _zz_148;
-    _zz_149[16] = _zz_148;
-    _zz_149[15] = _zz_148;
-    _zz_149[14] = _zz_148;
-    _zz_149[13] = _zz_148;
-    _zz_149[12] = _zz_148;
-    _zz_149[11] = _zz_148;
-    _zz_149[10] = _zz_148;
-    _zz_149[9] = _zz_148;
-    _zz_149[8] = _zz_148;
-    _zz_149[7] = _zz_148;
-    _zz_149[6] = _zz_148;
-    _zz_149[5] = _zz_148;
-    _zz_149[4] = _zz_148;
-    _zz_149[3] = _zz_148;
-    _zz_149[2] = _zz_148;
-    _zz_149[1] = _zz_148;
-    _zz_149[0] = _zz_148;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_149,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_151,{{{_zz_583,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_153,{{{_zz_584,_zz_585},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_334};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_150 = _zz_332[19];
-  always @ (*) begin
-    _zz_151[10] = _zz_150;
-    _zz_151[9] = _zz_150;
-    _zz_151[8] = _zz_150;
-    _zz_151[7] = _zz_150;
-    _zz_151[6] = _zz_150;
-    _zz_151[5] = _zz_150;
-    _zz_151[4] = _zz_150;
-    _zz_151[3] = _zz_150;
-    _zz_151[2] = _zz_150;
-    _zz_151[1] = _zz_150;
-    _zz_151[0] = _zz_150;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_152 = _zz_333[11];
-  always @ (*) begin
-    _zz_153[18] = _zz_152;
-    _zz_153[17] = _zz_152;
-    _zz_153[16] = _zz_152;
-    _zz_153[15] = _zz_152;
-    _zz_153[14] = _zz_152;
-    _zz_153[13] = _zz_152;
-    _zz_153[12] = _zz_152;
-    _zz_153[11] = _zz_152;
-    _zz_153[10] = _zz_152;
-    _zz_153[9] = _zz_152;
-    _zz_153[8] = _zz_152;
-    _zz_153[7] = _zz_152;
-    _zz_153[6] = _zz_152;
-    _zz_153[5] = _zz_152;
-    _zz_153[4] = _zz_152;
-    _zz_153[3] = _zz_152;
-    _zz_153[2] = _zz_152;
-    _zz_153[1] = _zz_152;
-    _zz_153[0] = _zz_152;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_154 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_155 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_156 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_157 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_158 = _zz_335[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_241)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4234,8 +4434,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4245,135 +4445,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_254)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_255)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_256)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_255)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_256)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4386,39 +4595,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_254)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_254)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_271)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_4 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_4)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_257)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4431,8 +4650,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_257)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4451,79 +4670,154 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_337) + $signed(_zz_338));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_236)begin
-      if(_zz_258)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_259)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_342);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_159 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_159[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_343);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_344 : _zz_345);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_346[31:0];
-  assign _zz_160 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_161 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_162 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_163[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_163[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_165 = (_zz_164 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_165 != 32'h0);
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_52 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_39 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4544,242 +4838,276 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_166[12 : 0] = 13'h1000;
-      _zz_166[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_167[3 : 0] = 4'b1011;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
     end
   end
 
-  always @ (*) begin
-    _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_168[4 : 0] = 5'h16;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
     end
   end
 
-  always @ (*) begin
-    _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_169[5 : 0] = 6'h21;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
     end
   end
 
-  always @ (*) begin
-    _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_170[31 : 30] = CsrPlugin_misa_base;
-      _zz_170[25 : 0] = CsrPlugin_misa_extensions;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_171[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_171[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_171[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_172[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_172[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_172[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_173[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_173[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_173[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_174 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_174[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_174[1 : 0] = CsrPlugin_mtvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_175[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_176[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_177[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_177[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_178[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_179[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_180[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_181[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_182[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_183 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_183[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_184 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_184[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_185 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_185[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_186 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_186[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_187 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_187[31 : 0] = _zz_164;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_188 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_188[31 : 0] = _zz_165;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_166 | _zz_167) | (_zz_168 | _zz_169)) | ((_zz_586 | _zz_170) | (_zz_171 | _zz_172))) | (((_zz_173 | _zz_174) | (_zz_175 | _zz_176)) | ((_zz_177 | _zz_178) | (_zz_179 | _zz_180)))) | (((_zz_181 | _zz_182) | (_zz_183 | _zz_184)) | ((_zz_185 | _zz_186) | (_zz_187 | _zz_188))));
-  assign iBusWishbone_ADR = {_zz_363,_zz_189};
-  assign iBusWishbone_CTI = ((_zz_189 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_260)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_260)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_190;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_196 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_192 = dBus_cmd_valid;
-  assign _zz_194 = dBus_cmd_payload_wr;
-  assign _zz_195 = (_zz_191 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_193 && (_zz_194 || _zz_195));
-  assign dBusWishbone_ADR = ((_zz_196 ? {{dBus_cmd_payload_address[31 : 5],_zz_191},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_196 ? (_zz_195 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_194 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_194;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_193 = (_zz_192 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_192;
-  assign dBusWishbone_STB = _zz_192;
-  assign dBus_rsp_valid = _zz_197;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
       IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_64 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
-      _zz_92 <= 1'b0;
+      _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_103;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_104;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_124 <= 1'b1;
-      _zz_136 <= 1'b0;
+      _zz_2 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4800,162 +5128,162 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_164 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_189 <= 3'b000;
-      _zz_190 <= 1'b0;
-      _zz_191 <= 3'b000;
-      _zz_197 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if((decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode)))begin
+      if(when_Fetcher_l180) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
       end
-      if(_zz_246)begin
+      if(when_Fetcher_l192) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_62)begin
-        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if((IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready))begin
+      if(when_Fetcher_l279) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
       end
-      if((IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid))begin
+      if(when_Fetcher_l283) begin
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(_zz_261)begin
-        if(IBusCachedPlugin_decompressor_bufferFill)begin
+      if(when_Fetcher_l286) begin
+        if(IBusCachedPlugin_decompressor_bufferFill) begin
           IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
         end
       end
-      if((IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent))begin
+      if(when_Fetcher_l291) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(decode_arbitration_removeIt)begin
-        _zz_92 <= 1'b0;
+      if(decode_arbitration_removeIt) begin
+        _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_decompressor_output_ready)begin
-        _zz_92 <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
+      if(IBusCachedPlugin_decompressor_output_ready) begin
+        _zz_IBusCachedPlugin_injector_decodeInput_valid <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
       end
-      if((! 1'b0))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_262)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_124 <= 1'b0;
-      _zz_136 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_2 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_263)begin
-        if(_zz_264)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_265)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_266)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_243)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4966,8 +5294,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_244)begin
-        case(_zz_245)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4977,143 +5305,149 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_156,{_zz_155,_zz_154}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_356[0];
-          CsrPlugin_mstatus_MIE <= _zz_357[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_359[0];
-          CsrPlugin_mie_MTIE <= _zz_360[0];
-          CsrPlugin_mie_MSIE <= _zz_361[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_164 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_260)begin
-        if(iBusWishbone_ACK)begin
-          _zz_189 <= (_zz_189 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_190 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_192 && _zz_193))begin
-        _zz_191 <= (_zz_191 + 3'b001);
-        if(_zz_195)begin
-          _zz_191 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_197 <= ((_zz_192 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_261)begin
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_decompressor_input_valid) begin
+      IBusCachedPlugin_decompressor_bufferValidLatch <= IBusCachedPlugin_decompressor_bufferValid;
+    end
+    if(IBusCachedPlugin_decompressor_input_valid) begin
+      IBusCachedPlugin_decompressor_throw2BytesLatch <= IBusCachedPlugin_decompressor_throw2Bytes;
+    end
+    if(when_Fetcher_l286) begin
       IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
-    if(IBusCachedPlugin_decompressor_output_ready)begin
-      _zz_93 <= IBusCachedPlugin_decompressor_output_payload_pc;
-      _zz_94 <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
-      _zz_95 <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
-      _zz_96 <= IBusCachedPlugin_decompressor_output_payload_isRvc;
+    if(IBusCachedPlugin_decompressor_output_ready) begin
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_pc <= IBusCachedPlugin_decompressor_output_payload_pc;
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc <= IBusCachedPlugin_decompressor_output_payload_isRvc;
     end
-    if(IBusCachedPlugin_injector_decodeInput_ready)begin
+    if(IBusCachedPlugin_injector_decodeInput_ready) begin
       IBusCachedPlugin_injector_formal_rawInDecode <= IBusCachedPlugin_decompressor_raw;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(_zz_262)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_137 <= _zz_40[11 : 7];
-    _zz_138 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_241)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_158 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_158 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_263)begin
-      if(_zz_264)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_265)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_266)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_243)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -5121,342 +5455,348 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_236)begin
-      if(_zz_258)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_347[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_259)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_162 ? (~ _zz_163) : _zz_163) + _zz_353);
-      memory_DivPlugin_rs2 <= ((_zz_161 ? (~ execute_RS2) : execute_RS2) + _zz_355);
-      memory_DivPlugin_div_needRevert <= ((_zz_162 ^ (_zz_161 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_6) begin
       decode_to_execute_IS_RVC <= decode_IS_RVC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54;
+    if(when_Pipeline_l124_7) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_8) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_9) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_10) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_11) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_15) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_17) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_28) begin
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_29) begin
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_30) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_31) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_32) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_35) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_38) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_39) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_53) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_54) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_55) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_56) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_63) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_64) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_65) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_358[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_362[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -5469,9 +5809,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_isLrsc,
   input               io_cpu_execute_args_totalyConsistent,
@@ -5494,6 +5833,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5509,9 +5849,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5519,7 +5860,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5528,27 +5869,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire                _zz_19;
-  wire                _zz_20;
-  wire       [0:0]    _zz_21;
-  wire       [0:0]    _zz_22;
-  wire       [9:0]    _zz_23;
-  wire       [9:0]    _zz_24;
-  wire       [0:0]    _zz_25;
-  wire       [0:0]    _zz_26;
-  wire       [0:0]    _zz_27;
-  wire       [2:0]    _zz_28;
-  wire       [1:0]    _zz_29;
-  wire       [21:0]   _zz_30;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5573,42 +5902,50 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5618,35 +5955,56 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   reg                 stageB_lrSc_reserved;
+  wire                when_DataCache_l866;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l984;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1010;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5658,62 +6016,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_31;
-  reg [7:0] _zz_32;
-  reg [7:0] _zz_33;
-  reg [7:0] _zz_34;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_16 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_17 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_18 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_19 = (! stageB_flusher_hold);
-  assign _zz_20 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_21 = _zz_4[0 : 0];
-  assign _zz_22 = _zz_4[1 : 1];
-  assign _zz_23 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_24 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_25 = 1'b1;
-  assign _zz_26 = (! stageB_lrSc_reserved);
-  assign _zz_27 = loader_counter_willIncrement;
-  assign _zz_28 = {2'd0, _zz_27};
-  assign _zz_29 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_30 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_30;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_34, _zz_33, _zz_32, _zz_31};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_31 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_32 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_33 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_34 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -5728,291 +6078,311 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_21[0];
-  assign ways_0_tagsReadRsp_error = _zz_22[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1010) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_25[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_23)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_24)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(_zz_18)begin
+          if(when_DataCache_l984) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
-            if(_zz_16)begin
+            if(when_DataCache_l1010) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l866 = ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6020,95 +6390,79 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(_zz_18)begin
+          if(when_DataCache_l984) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
-            if(_zz_16)begin
+            if(when_DataCache_l1010) begin
               io_mem_cmd_valid = 1'b0;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -6116,12 +6470,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6132,23 +6486,43 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l984 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1010 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_26};
-    end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6156,47 +6530,49 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_28);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6207,46 +6583,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_19)begin
-        if(_zz_20)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -6255,27 +6622,29 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_19)begin
-          if(! _zz_20) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
-      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+      if(when_DataCache_l866) begin
         stageB_lrSc_reserved <= (! stageB_request_wr);
       end
-      if(_zz_13)begin
+      if(when_DataCache_l1051) begin
         stageB_lrSc_reserved <= stageB_lrSc_reserved;
       end
       `ifndef SYNTHESIS
@@ -6283,28 +6652,27 @@ module DataCache (
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_17)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_29[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6354,13 +6722,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6369,8 +6733,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6384,16 +6753,17 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
@@ -6402,77 +6772,78 @@ module InstructionCache (
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6488,16 +6859,17 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
@@ -6509,7 +6881,7 @@ module InstructionCache (
   assign io_cpu_fetch_error = (fetchStage_hit_error || ((! io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute))));
   assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuRsp_refilling;
   assign io_cpu_fetch_mmuException = (((! io_cpu_fetch_mmuRsp_refilling) && io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute)));
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6517,45 +6889,45 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_IMACDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_IMACDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -82,39 +82,39 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  wire                _zz_207;
-  wire                _zz_208;
-  wire                _zz_209;
-  wire       [31:0]   _zz_210;
-  reg                 _zz_211;
-  wire                _zz_212;
-  wire       [31:0]   _zz_213;
-  reg                 _zz_214;
-  wire                _zz_215;
-  wire       [31:0]   _zz_216;
-  reg                 _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire       [31:0]   _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire                _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
-  wire                _zz_227;
-  wire                _zz_228;
-  wire       [3:0]    _zz_229;
-  wire                _zz_230;
-  wire                _zz_231;
-  reg        [31:0]   _zz_232;
-  reg        [31:0]   _zz_233;
-  reg        [31:0]   _zz_234;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isUser;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_pc;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  reg                 dataCache_1_io_cpu_execute_args_isLrsc;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_error;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling;
@@ -137,6 +137,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -145,369 +146,304 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  wire                _zz_240;
-  wire                _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire                _zz_244;
-  wire                _zz_245;
-  wire                _zz_246;
-  wire                _zz_247;
-  wire                _zz_248;
-  wire                _zz_249;
-  wire                _zz_250;
-  wire                _zz_251;
-  wire       [1:0]    _zz_252;
-  wire                _zz_253;
-  wire                _zz_254;
-  wire                _zz_255;
-  wire                _zz_256;
-  wire                _zz_257;
-  wire                _zz_258;
-  wire                _zz_259;
-  wire                _zz_260;
-  wire                _zz_261;
-  wire                _zz_262;
-  wire                _zz_263;
-  wire       [1:0]    _zz_264;
-  wire                _zz_265;
-  wire                _zz_266;
-  wire       [5:0]    _zz_267;
-  wire                _zz_268;
-  wire                _zz_269;
-  wire                _zz_270;
-  wire                _zz_271;
-  wire                _zz_272;
-  wire                _zz_273;
-  wire                _zz_274;
-  wire       [4:0]    _zz_275;
-  wire       [1:0]    _zz_276;
-  wire       [1:0]    _zz_277;
-  wire       [1:0]    _zz_278;
-  wire                _zz_279;
-  wire       [1:0]    _zz_280;
-  wire       [51:0]   _zz_281;
-  wire       [51:0]   _zz_282;
-  wire       [51:0]   _zz_283;
-  wire       [32:0]   _zz_284;
-  wire       [51:0]   _zz_285;
-  wire       [49:0]   _zz_286;
-  wire       [51:0]   _zz_287;
-  wire       [49:0]   _zz_288;
-  wire       [51:0]   _zz_289;
-  wire       [32:0]   _zz_290;
-  wire       [31:0]   _zz_291;
-  wire       [32:0]   _zz_292;
-  wire       [0:0]    _zz_293;
-  wire       [0:0]    _zz_294;
-  wire       [0:0]    _zz_295;
-  wire       [0:0]    _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [0:0]    _zz_298;
-  wire       [0:0]    _zz_299;
-  wire       [0:0]    _zz_300;
-  wire       [0:0]    _zz_301;
-  wire       [0:0]    _zz_302;
-  wire       [2:0]    _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [0:0]    _zz_305;
-  wire       [0:0]    _zz_306;
-  wire       [0:0]    _zz_307;
-  wire       [0:0]    _zz_308;
-  wire       [0:0]    _zz_309;
-  wire       [0:0]    _zz_310;
-  wire       [0:0]    _zz_311;
-  wire       [0:0]    _zz_312;
-  wire       [0:0]    _zz_313;
-  wire       [3:0]    _zz_314;
-  wire       [2:0]    _zz_315;
-  wire       [31:0]   _zz_316;
-  wire       [2:0]    _zz_317;
-  wire       [31:0]   _zz_318;
-  wire       [31:0]   _zz_319;
-  wire       [11:0]   _zz_320;
-  wire       [11:0]   _zz_321;
-  wire       [11:0]   _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [19:0]   _zz_324;
-  wire       [11:0]   _zz_325;
-  wire       [2:0]    _zz_326;
-  wire       [2:0]    _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [2:0]    _zz_329;
-  wire       [4:0]    _zz_330;
-  wire       [11:0]   _zz_331;
-  wire       [11:0]   _zz_332;
-  wire       [31:0]   _zz_333;
-  wire       [31:0]   _zz_334;
-  wire       [31:0]   _zz_335;
-  wire       [31:0]   _zz_336;
-  wire       [31:0]   _zz_337;
-  wire       [31:0]   _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [11:0]   _zz_340;
-  wire       [19:0]   _zz_341;
-  wire       [11:0]   _zz_342;
-  wire       [2:0]    _zz_343;
-  wire       [1:0]    _zz_344;
-  wire       [1:0]    _zz_345;
-  wire       [65:0]   _zz_346;
-  wire       [65:0]   _zz_347;
-  wire       [31:0]   _zz_348;
-  wire       [31:0]   _zz_349;
-  wire       [0:0]    _zz_350;
-  wire       [5:0]    _zz_351;
-  wire       [32:0]   _zz_352;
-  wire       [31:0]   _zz_353;
-  wire       [31:0]   _zz_354;
-  wire       [32:0]   _zz_355;
-  wire       [32:0]   _zz_356;
-  wire       [32:0]   _zz_357;
-  wire       [32:0]   _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [32:0]   _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [32:0]   _zz_362;
-  wire       [0:0]    _zz_363;
-  wire       [31:0]   _zz_364;
-  wire       [0:0]    _zz_365;
-  wire       [0:0]    _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [0:0]    _zz_368;
-  wire       [0:0]    _zz_369;
-  wire       [0:0]    _zz_370;
-  wire       [0:0]    _zz_371;
-  wire       [26:0]   _zz_372;
-  wire                _zz_373;
-  wire                _zz_374;
-  wire       [1:0]    _zz_375;
-  wire       [31:0]   _zz_376;
-  wire       [31:0]   _zz_377;
-  wire       [31:0]   _zz_378;
-  wire                _zz_379;
-  wire       [0:0]    _zz_380;
-  wire       [15:0]   _zz_381;
-  wire       [31:0]   _zz_382;
-  wire       [31:0]   _zz_383;
-  wire       [31:0]   _zz_384;
-  wire                _zz_385;
-  wire       [0:0]    _zz_386;
-  wire       [9:0]    _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
-  wire       [31:0]   _zz_390;
-  wire                _zz_391;
-  wire       [0:0]    _zz_392;
-  wire       [3:0]    _zz_393;
-  wire                _zz_394;
-  wire                _zz_395;
-  wire       [6:0]    _zz_396;
-  wire       [4:0]    _zz_397;
-  wire                _zz_398;
-  wire       [4:0]    _zz_399;
-  wire       [0:0]    _zz_400;
-  wire       [7:0]    _zz_401;
-  wire                _zz_402;
-  wire       [0:0]    _zz_403;
-  wire       [0:0]    _zz_404;
-  wire       [31:0]   _zz_405;
-  wire       [0:0]    _zz_406;
-  wire       [0:0]    _zz_407;
-  wire                _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [27:0]   _zz_410;
-  wire       [31:0]   _zz_411;
-  wire                _zz_412;
-  wire                _zz_413;
-  wire                _zz_414;
-  wire       [1:0]    _zz_415;
-  wire       [1:0]    _zz_416;
-  wire                _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [23:0]   _zz_419;
-  wire       [31:0]   _zz_420;
-  wire       [31:0]   _zz_421;
-  wire       [31:0]   _zz_422;
-  wire       [31:0]   _zz_423;
-  wire                _zz_424;
-  wire                _zz_425;
-  wire       [1:0]    _zz_426;
-  wire       [1:0]    _zz_427;
-  wire                _zz_428;
-  wire       [0:0]    _zz_429;
-  wire       [20:0]   _zz_430;
-  wire       [31:0]   _zz_431;
-  wire       [31:0]   _zz_432;
-  wire       [31:0]   _zz_433;
-  wire       [31:0]   _zz_434;
-  wire                _zz_435;
-  wire       [0:0]    _zz_436;
-  wire       [0:0]    _zz_437;
-  wire                _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [0:0]    _zz_440;
-  wire                _zz_441;
-  wire       [0:0]    _zz_442;
-  wire       [17:0]   _zz_443;
-  wire       [31:0]   _zz_444;
-  wire       [31:0]   _zz_445;
-  wire       [31:0]   _zz_446;
-  wire                _zz_447;
-  wire                _zz_448;
-  wire                _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [0:0]    _zz_451;
-  wire                _zz_452;
-  wire       [0:0]    _zz_453;
-  wire       [14:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire                _zz_456;
-  wire       [0:0]    _zz_457;
-  wire       [0:0]    _zz_458;
-  wire                _zz_459;
-  wire       [5:0]    _zz_460;
-  wire       [5:0]    _zz_461;
-  wire                _zz_462;
-  wire       [0:0]    _zz_463;
-  wire       [11:0]   _zz_464;
-  wire       [31:0]   _zz_465;
-  wire       [31:0]   _zz_466;
-  wire       [31:0]   _zz_467;
-  wire       [31:0]   _zz_468;
-  wire                _zz_469;
-  wire       [0:0]    _zz_470;
-  wire       [2:0]    _zz_471;
-  wire                _zz_472;
-  wire                _zz_473;
-  wire       [0:0]    _zz_474;
-  wire       [3:0]    _zz_475;
-  wire       [4:0]    _zz_476;
-  wire       [4:0]    _zz_477;
-  wire                _zz_478;
-  wire       [0:0]    _zz_479;
-  wire       [8:0]    _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire       [31:0]   _zz_483;
-  wire                _zz_484;
-  wire       [0:0]    _zz_485;
-  wire       [0:0]    _zz_486;
-  wire       [31:0]   _zz_487;
-  wire       [31:0]   _zz_488;
-  wire       [31:0]   _zz_489;
-  wire       [31:0]   _zz_490;
-  wire                _zz_491;
-  wire       [0:0]    _zz_492;
-  wire       [1:0]    _zz_493;
-  wire       [0:0]    _zz_494;
-  wire       [2:0]    _zz_495;
-  wire       [0:0]    _zz_496;
-  wire       [5:0]    _zz_497;
-  wire       [1:0]    _zz_498;
-  wire       [1:0]    _zz_499;
-  wire                _zz_500;
-  wire       [0:0]    _zz_501;
-  wire       [6:0]    _zz_502;
-  wire       [31:0]   _zz_503;
-  wire       [31:0]   _zz_504;
-  wire       [31:0]   _zz_505;
-  wire       [31:0]   _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [31:0]   _zz_508;
-  wire       [31:0]   _zz_509;
-  wire       [31:0]   _zz_510;
-  wire                _zz_511;
-  wire       [31:0]   _zz_512;
-  wire       [31:0]   _zz_513;
-  wire                _zz_514;
-  wire       [0:0]    _zz_515;
-  wire       [0:0]    _zz_516;
-  wire                _zz_517;
-  wire       [0:0]    _zz_518;
-  wire       [3:0]    _zz_519;
-  wire                _zz_520;
-  wire       [0:0]    _zz_521;
-  wire       [0:0]    _zz_522;
-  wire       [0:0]    _zz_523;
-  wire       [0:0]    _zz_524;
-  wire                _zz_525;
-  wire       [0:0]    _zz_526;
-  wire       [4:0]    _zz_527;
-  wire       [31:0]   _zz_528;
-  wire       [31:0]   _zz_529;
-  wire       [31:0]   _zz_530;
-  wire       [31:0]   _zz_531;
-  wire       [31:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire       [31:0]   _zz_536;
-  wire                _zz_537;
-  wire       [0:0]    _zz_538;
-  wire       [1:0]    _zz_539;
-  wire       [31:0]   _zz_540;
-  wire       [31:0]   _zz_541;
-  wire       [31:0]   _zz_542;
-  wire       [31:0]   _zz_543;
-  wire       [31:0]   _zz_544;
-  wire                _zz_545;
-  wire       [4:0]    _zz_546;
-  wire       [4:0]    _zz_547;
-  wire                _zz_548;
-  wire       [0:0]    _zz_549;
-  wire       [2:0]    _zz_550;
-  wire       [31:0]   _zz_551;
-  wire       [31:0]   _zz_552;
-  wire       [31:0]   _zz_553;
-  wire                _zz_554;
-  wire       [31:0]   _zz_555;
-  wire                _zz_556;
-  wire       [0:0]    _zz_557;
-  wire       [2:0]    _zz_558;
-  wire       [0:0]    _zz_559;
-  wire       [0:0]    _zz_560;
-  wire       [2:0]    _zz_561;
-  wire       [2:0]    _zz_562;
-  wire                _zz_563;
-  wire       [0:0]    _zz_564;
-  wire       [0:0]    _zz_565;
-  wire       [31:0]   _zz_566;
-  wire       [31:0]   _zz_567;
-  wire       [31:0]   _zz_568;
-  wire       [31:0]   _zz_569;
-  wire                _zz_570;
-  wire       [0:0]    _zz_571;
-  wire       [0:0]    _zz_572;
-  wire       [31:0]   _zz_573;
-  wire       [31:0]   _zz_574;
-  wire                _zz_575;
-  wire       [0:0]    _zz_576;
-  wire       [0:0]    _zz_577;
-  wire       [0:0]    _zz_578;
-  wire       [1:0]    _zz_579;
-  wire       [1:0]    _zz_580;
-  wire       [1:0]    _zz_581;
-  wire       [0:0]    _zz_582;
-  wire       [0:0]    _zz_583;
-  wire       [31:0]   _zz_584;
-  wire       [31:0]   _zz_585;
-  wire       [31:0]   _zz_586;
-  wire       [31:0]   _zz_587;
-  wire       [31:0]   _zz_588;
-  wire       [31:0]   _zz_589;
-  wire       [31:0]   _zz_590;
-  wire       [31:0]   _zz_591;
-  wire                _zz_592;
-  wire                _zz_593;
-  wire                _zz_594;
-  wire       [31:0]   _zz_595;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_FORMAL_PC_NEXT;
+  wire       [2:0]    _zz_decode_FORMAL_PC_NEXT_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [15:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [9:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [3:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePc_pcPlus;
+  wire       [2:0]    _zz_IBusCachedPlugin_decodePc_pcPlus_1;
+  wire       [31:0]   _zz_IBusCachedPlugin_decompressor_decompressed_27;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_28;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_29;
+  wire       [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_30;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_31;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_32;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_33;
+  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_34;
+  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_35;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire       [7:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_7;
+  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_8;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspRf;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire       [27:0]   _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [23:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_168;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_169;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_170;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_171;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_172;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_173;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_174;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_175;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_176;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_177;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_178;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_179;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_180;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_181;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_182;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_183;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_184;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_185;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_186;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -518,8 +454,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
@@ -531,46 +467,47 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_LRSC;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -593,11 +530,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -605,10 +542,10 @@ module VexRiscv (
   wire                execute_BRANCH_COND_RESULT;
   wire                execute_PREDICTION_HAD_BRANCHED2;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -618,46 +555,47 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire                execute_IS_RVC;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
+  wire                writeBack_MEMORY_LRSC;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -671,7 +609,7 @@ module VexRiscv (
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_LRSC;
-  reg                 _zz_51;
+  reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
   reg                 IBusCachedPlugin_rsp_issueDetected_4;
@@ -679,9 +617,9 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
-  reg        [31:0]   _zz_53;
-  reg        [31:0]   _zz_54;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire                decode_IS_RVC;
@@ -770,7 +708,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -796,12 +734,17 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_55;
+  reg                 _zz_when_DBusCachedPlugin_l386;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
   wire                BranchPlugin_jumpInterface_valid;
   wire       [31:0]   BranchPlugin_jumpInterface_payload;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -819,35 +762,43 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_56;
-  wire       [3:0]    _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
-  wire                _zz_60;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   reg        [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_decodePc_flushed;
   reg        [31:0]   IBusCachedPlugin_decodePc_pcReg /* verilator public */ ;
   wire       [31:0]   IBusCachedPlugin_decodePc_pcPlus;
   reg                 IBusCachedPlugin_decodePc_injectedDecode;
+  wire                when_Fetcher_l180;
+  wire                when_Fetcher_l192;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -863,12 +814,12 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_1_halt;
-  wire                _zz_61;
-  wire                _zz_62;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63;
-  wire                _zz_64;
-  reg                 _zz_65;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -897,59 +848,74 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decompressor_throw2BytesReg;
   wire                IBusCachedPlugin_decompressor_throw2Bytes;
   wire                IBusCachedPlugin_decompressor_unaligned;
+  reg                 IBusCachedPlugin_decompressor_bufferValidLatch;
+  reg                 IBusCachedPlugin_decompressor_throw2BytesLatch;
+  wire                IBusCachedPlugin_decompressor_bufferValidPatched;
+  wire                IBusCachedPlugin_decompressor_throw2BytesPatched;
   wire       [31:0]   IBusCachedPlugin_decompressor_raw;
   wire                IBusCachedPlugin_decompressor_isRvc;
-  wire       [15:0]   _zz_66;
+  wire       [15:0]   _zz_IBusCachedPlugin_decompressor_decompressed;
   reg        [31:0]   IBusCachedPlugin_decompressor_decompressed;
-  wire       [4:0]    _zz_67;
-  wire       [4:0]    _zz_68;
-  wire       [11:0]   _zz_69;
-  wire                _zz_70;
-  reg        [11:0]   _zz_71;
-  wire                _zz_72;
-  reg        [9:0]    _zz_73;
-  wire       [20:0]   _zz_74;
-  wire                _zz_75;
-  reg        [14:0]   _zz_76;
-  wire                _zz_77;
-  reg        [2:0]    _zz_78;
-  wire                _zz_79;
-  reg        [9:0]    _zz_80;
-  wire       [20:0]   _zz_81;
-  wire                _zz_82;
-  reg        [4:0]    _zz_83;
-  wire       [12:0]   _zz_84;
-  wire       [4:0]    _zz_85;
-  wire       [4:0]    _zz_86;
-  wire       [4:0]    _zz_87;
-  wire                _zz_88;
-  reg        [2:0]    _zz_89;
-  reg        [2:0]    _zz_90;
-  wire                _zz_91;
-  reg        [6:0]    _zz_92;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_1;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_2;
+  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_3;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_4;
+  reg        [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_5;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_6;
+  reg        [9:0]    _zz_IBusCachedPlugin_decompressor_decompressed_7;
+  wire       [20:0]   _zz_IBusCachedPlugin_decompressor_decompressed_8;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_9;
+  reg        [14:0]   _zz_IBusCachedPlugin_decompressor_decompressed_10;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_11;
+  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_12;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_13;
+  reg        [9:0]    _zz_IBusCachedPlugin_decompressor_decompressed_14;
+  wire       [20:0]   _zz_IBusCachedPlugin_decompressor_decompressed_15;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_16;
+  reg        [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_17;
+  wire       [12:0]   _zz_IBusCachedPlugin_decompressor_decompressed_18;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_19;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_20;
+  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_21;
+  wire       [4:0]    switch_Misc_l44;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_22;
+  wire       [1:0]    switch_Misc_l199;
+  wire       [1:0]    switch_Misc_l199_1;
+  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_23;
+  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_24;
+  wire                _zz_IBusCachedPlugin_decompressor_decompressed_25;
+  reg        [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_26;
+  wire                when_Fetcher_l279;
   wire                IBusCachedPlugin_decompressor_bufferFill;
+  wire                when_Fetcher_l283;
+  wire                when_Fetcher_l286;
+  wire                when_Fetcher_l291;
   wire                IBusCachedPlugin_injector_decodeInput_valid;
   wire                IBusCachedPlugin_injector_decodeInput_ready;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_pc;
   wire                IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_93;
-  reg        [31:0]   _zz_94;
-  reg                 _zz_95;
-  reg        [31:0]   _zz_96;
-  reg                 _zz_97;
+  reg                 _zz_IBusCachedPlugin_injector_decodeInput_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
+  reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
+  reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
+  reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
-  wire                _zz_98;
-  reg        [18:0]   _zz_99;
-  wire                _zz_100;
-  reg        [10:0]   _zz_101;
-  wire                _zz_102;
-  reg        [18:0]   _zz_103;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -957,13 +923,18 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_104;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -971,7 +942,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -979,8 +950,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -988,40 +960,56 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_105;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l311;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_107;
-  reg        [31:0]   _zz_108;
-  wire                _zz_109;
-  reg        [31:0]   _zz_110;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire                when_DBusCachedPlugin_l474;
+  wire       [1:0]    switch_Misc_l199_2;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [33:0]   _zz_111;
-  wire                _zz_112;
-  wire                _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_118;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_119;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_120;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_121;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_122;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_123;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_124;
+  wire                when_DBusCachedPlugin_l484;
+  wire       [33:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz_decode_IS_RS2_SIGNED_6;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1029,45 +1017,63 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_125;
+  reg                 _zz_2;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_126;
-  reg        [31:0]   _zz_127;
-  wire                _zz_128;
-  reg        [19:0]   _zz_129;
-  wire                _zz_130;
-  reg        [19:0]   _zz_131;
-  reg        [31:0]   _zz_132;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_133;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_134;
-  reg                 _zz_135;
-  reg                 _zz_136;
-  reg                 _zz_137;
-  reg        [4:0]    _zz_138;
-  reg        [31:0]   _zz_139;
-  wire                _zz_140;
-  wire                _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
-  wire                _zz_145;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_146;
-  reg                 _zz_147;
-  reg                 _zz_148;
+  wire       [2:0]    switch_Misc_l199_3;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_149;
-  reg        [19:0]   _zz_150;
-  wire                _zz_151;
-  reg        [10:0]   _zz_152;
-  wire                _zz_153;
-  reg        [18:0]   _zz_154;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1089,9 +1095,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_155;
-  wire                _zz_156;
-  wire                _zz_157;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1104,40 +1110,67 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_158;
-  wire                _zz_159;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1145,6 +1178,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1157,19 +1192,26 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_160;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_161;
-  wire                _zz_162;
-  wire                _zz_163;
-  reg        [32:0]   _zz_164;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_165;
-  wire       [31:0]   _zz_166;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1177,211 +1219,334 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_167;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
-  reg                 _zz_168;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
+  reg                 _zz_3;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg                 decode_to_execute_IS_RVC;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_11;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_13;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_16;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_17;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_18;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_24;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_MEMORY_LRSC;
+  wire                when_Pipeline_l124_28;
+  reg                 execute_to_memory_MEMORY_LRSC;
+  wire                when_Pipeline_l124_29;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
+  wire                when_Pipeline_l124_30;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_31;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_32;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_33;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_37;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_38;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_39;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_40;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_41;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_42;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_43;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_44;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_47;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_48;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_50;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_51;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_52;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_53;
   reg                 decode_to_execute_DO_EBREAK;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_54;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_55;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_58;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_59;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_60;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_61;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_62;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_63;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_64;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_65;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_169;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l360;
+  wire                when_Fetcher_l378;
+  wire                when_Fetcher_l398;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  reg        [31:0]   _zz_172;
-  reg        [31:0]   _zz_173;
-  reg        [31:0]   _zz_174;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [31:0]   _zz_183;
-  reg        [31:0]   _zz_184;
-  reg        [31:0]   _zz_185;
-  reg        [31:0]   _zz_186;
-  reg        [31:0]   _zz_187;
-  reg        [31:0]   _zz_188;
-  reg        [31:0]   _zz_189;
-  reg        [31:0]   _zz_190;
-  reg        [31:0]   _zz_191;
-  reg        [31:0]   _zz_192;
-  reg        [2:0]    _zz_193;
-  reg                 _zz_194;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  reg                 _zz_201;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52_string;
-  reg [95:0] _zz_118_string;
-  reg [63:0] _zz_119_string;
-  reg [23:0] _zz_120_string;
-  reg [39:0] _zz_121_string;
-  reg [71:0] _zz_122_string;
-  reg [31:0] _zz_123_string;
-  reg [39:0] _zz_124_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1390,541 +1555,500 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_235 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_236 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_237 = 1'b1;
-  assign _zz_238 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_239 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_240 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_241 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_242 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_243 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_244 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_245 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_246 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_247 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_248 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_249 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_250 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_251 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_252 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_253 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
-  assign _zz_254 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_255 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_256 = (1'b0 || (! 1'b1));
-  assign _zz_257 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_258 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_259 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_260 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_261 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_262 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_263 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_264 = execute_INSTRUCTION[13 : 12];
-  assign _zz_265 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_266 = (! memory_arbitration_isStuck);
-  assign _zz_267 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_268 = (iBus_cmd_valid || (_zz_193 != 3'b000));
-  assign _zz_269 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign _zz_270 = (_zz_231 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_271 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_272 = ((_zz_155 && 1'b1) && (! 1'b0));
-  assign _zz_273 = ((_zz_156 && 1'b1) && (! 1'b0));
-  assign _zz_274 = ((_zz_157 && 1'b1) && (! 1'b0));
-  assign _zz_275 = {_zz_66[1 : 0],_zz_66[15 : 13]};
-  assign _zz_276 = _zz_66[6 : 5];
-  assign _zz_277 = _zz_66[11 : 10];
-  assign _zz_278 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_279 = execute_INSTRUCTION[13];
-  assign _zz_280 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_281 = ($signed(_zz_282) + $signed(_zz_287));
-  assign _zz_282 = ($signed(_zz_283) + $signed(_zz_285));
-  assign _zz_283 = 52'h0;
-  assign _zz_284 = {1'b0,memory_MUL_LL};
-  assign _zz_285 = {{19{_zz_284[32]}}, _zz_284};
-  assign _zz_286 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_287 = {{2{_zz_286[49]}}, _zz_286};
-  assign _zz_288 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_289 = {{2{_zz_288[49]}}, _zz_288};
-  assign _zz_290 = ($signed(_zz_292) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_291 = _zz_290[31 : 0];
-  assign _zz_292 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_293 = _zz_111[32 : 32];
-  assign _zz_294 = _zz_111[31 : 31];
-  assign _zz_295 = _zz_111[30 : 30];
-  assign _zz_296 = _zz_111[29 : 29];
-  assign _zz_297 = _zz_111[26 : 26];
-  assign _zz_298 = _zz_111[19 : 19];
-  assign _zz_299 = _zz_111[18 : 18];
-  assign _zz_300 = _zz_111[13 : 13];
-  assign _zz_301 = _zz_111[12 : 12];
-  assign _zz_302 = _zz_111[11 : 11];
-  assign _zz_303 = (decode_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_304 = {29'd0, _zz_303};
-  assign _zz_305 = _zz_111[33 : 33];
-  assign _zz_306 = _zz_111[16 : 16];
-  assign _zz_307 = _zz_111[5 : 5];
-  assign _zz_308 = _zz_111[3 : 3];
-  assign _zz_309 = _zz_111[17 : 17];
-  assign _zz_310 = _zz_111[10 : 10];
-  assign _zz_311 = _zz_111[15 : 15];
-  assign _zz_312 = _zz_111[4 : 4];
-  assign _zz_313 = _zz_111[0 : 0];
-  assign _zz_314 = (_zz_56 - 4'b0001);
-  assign _zz_315 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_316 = {29'd0, _zz_315};
-  assign _zz_317 = (decode_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_318 = {29'd0, _zz_317};
-  assign _zz_319 = {{_zz_76,_zz_66[6 : 2]},12'h0};
-  assign _zz_320 = {{{4'b0000,_zz_66[8 : 7]},_zz_66[12 : 9]},2'b00};
-  assign _zz_321 = {{{4'b0000,_zz_66[8 : 7]},_zz_66[12 : 9]},2'b00};
-  assign _zz_322 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_323 = {{_zz_99,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_324 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_325 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_326 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_327 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_328 = execute_SRC_LESS;
-  assign _zz_329 = (execute_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_330 = execute_INSTRUCTION[19 : 15];
-  assign _zz_331 = execute_INSTRUCTION[31 : 20];
-  assign _zz_332 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_333 = ($signed(_zz_334) + $signed(_zz_337));
-  assign _zz_334 = ($signed(_zz_335) + $signed(_zz_336));
-  assign _zz_335 = execute_SRC1;
-  assign _zz_336 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_337 = (execute_SRC_USE_SUB_LESS ? _zz_338 : _zz_339);
-  assign _zz_338 = 32'h00000001;
-  assign _zz_339 = 32'h0;
-  assign _zz_340 = execute_INSTRUCTION[31 : 20];
-  assign _zz_341 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_342 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_343 = (execute_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_344 = (_zz_158 & (~ _zz_345));
-  assign _zz_345 = (_zz_158 - 2'b01);
-  assign _zz_346 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_347 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_348 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_349 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_350 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_351 = {5'd0, _zz_350};
-  assign _zz_352 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_353 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_354 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_355 = {_zz_160,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_356 = _zz_357;
-  assign _zz_357 = _zz_358;
-  assign _zz_358 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_161) : _zz_161)} + _zz_360);
-  assign _zz_359 = memory_DivPlugin_div_needRevert;
-  assign _zz_360 = {32'd0, _zz_359};
-  assign _zz_361 = _zz_163;
-  assign _zz_362 = {32'd0, _zz_361};
-  assign _zz_363 = _zz_162;
-  assign _zz_364 = {31'd0, _zz_363};
-  assign _zz_365 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_366 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_367 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_368 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_369 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_370 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_371 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_372 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_373 = 1'b1;
-  assign _zz_374 = 1'b1;
-  assign _zz_375 = {_zz_60,_zz_59};
-  assign _zz_376 = 32'h0000107f;
-  assign _zz_377 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_378 = 32'h00002073;
-  assign _zz_379 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_380 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_381 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_382) == 32'h00000003),{(_zz_383 == _zz_384),{_zz_385,{_zz_386,_zz_387}}}}}};
-  assign _zz_382 = 32'h0000505f;
-  assign _zz_383 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_384 = 32'h00000063;
-  assign _zz_385 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_386 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_387 = {((decode_INSTRUCTION & 32'hf800707f) == 32'h1800202f),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_388) == 32'h00005013),{(_zz_389 == _zz_390),{_zz_391,{_zz_392,_zz_393}}}}}};
-  assign _zz_388 = 32'hbc00707f;
-  assign _zz_389 = (decode_INSTRUCTION & 32'hfc00307f);
-  assign _zz_390 = 32'h00001013;
-  assign _zz_391 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_392 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_393 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}}};
-  assign _zz_394 = (_zz_66[11 : 10] == 2'b01);
-  assign _zz_395 = ((_zz_66[11 : 10] == 2'b11) && (_zz_66[6 : 5] == 2'b00));
-  assign _zz_396 = 7'h0;
-  assign _zz_397 = _zz_66[6 : 2];
-  assign _zz_398 = _zz_66[12];
-  assign _zz_399 = _zz_66[11 : 7];
-  assign _zz_400 = decode_INSTRUCTION[31];
-  assign _zz_401 = decode_INSTRUCTION[19 : 12];
-  assign _zz_402 = decode_INSTRUCTION[20];
-  assign _zz_403 = decode_INSTRUCTION[31];
-  assign _zz_404 = decode_INSTRUCTION[7];
-  assign _zz_405 = 32'h10103050;
-  assign _zz_406 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_407 = 1'b0;
-  assign _zz_408 = (((decode_INSTRUCTION & _zz_411) == 32'h02000030) != 1'b0);
-  assign _zz_409 = ({_zz_412,_zz_413} != 2'b00);
-  assign _zz_410 = {(_zz_414 != 1'b0),{(_zz_415 != _zz_416),{_zz_417,{_zz_418,_zz_419}}}};
-  assign _zz_411 = 32'h02004074;
-  assign _zz_412 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz_413 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_414 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz_415 = {(_zz_420 == _zz_421),(_zz_422 == _zz_423)};
-  assign _zz_416 = 2'b00;
-  assign _zz_417 = ({_zz_113,_zz_424} != 2'b00);
-  assign _zz_418 = (_zz_425 != 1'b0);
-  assign _zz_419 = {(_zz_426 != _zz_427),{_zz_428,{_zz_429,_zz_430}}};
-  assign _zz_420 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_421 = 32'h00001050;
-  assign _zz_422 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_423 = 32'h00002050;
-  assign _zz_424 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_425 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_426 = {(_zz_431 == _zz_432),(_zz_433 == _zz_434)};
-  assign _zz_427 = 2'b00;
-  assign _zz_428 = ({_zz_435,{_zz_436,_zz_437}} != 3'b000);
-  assign _zz_429 = (_zz_438 != 1'b0);
-  assign _zz_430 = {(_zz_439 != _zz_440),{_zz_441,{_zz_442,_zz_443}}};
-  assign _zz_431 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_432 = 32'h00005010;
-  assign _zz_433 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_434 = 32'h00005020;
-  assign _zz_435 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_436 = ((decode_INSTRUCTION & _zz_444) == 32'h00001010);
-  assign _zz_437 = ((decode_INSTRUCTION & _zz_445) == 32'h00001010);
-  assign _zz_438 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_439 = ((decode_INSTRUCTION & _zz_446) == 32'h00002000);
-  assign _zz_440 = 1'b0;
-  assign _zz_441 = ({_zz_447,_zz_448} != 2'b00);
-  assign _zz_442 = (_zz_449 != 1'b0);
-  assign _zz_443 = {(_zz_450 != _zz_451),{_zz_452,{_zz_453,_zz_454}}};
-  assign _zz_444 = 32'h00007034;
-  assign _zz_445 = 32'h02007054;
-  assign _zz_446 = 32'h00003000;
-  assign _zz_447 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_448 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_449 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz_450 = ((decode_INSTRUCTION & _zz_455) == 32'h00000024);
-  assign _zz_451 = 1'b0;
-  assign _zz_452 = ({_zz_456,{_zz_457,_zz_458}} != 3'b000);
-  assign _zz_453 = (_zz_459 != 1'b0);
-  assign _zz_454 = {(_zz_460 != _zz_461),{_zz_462,{_zz_463,_zz_464}}};
-  assign _zz_455 = 32'h00000064;
-  assign _zz_456 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_457 = ((decode_INSTRUCTION & _zz_465) == 32'h00000020);
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_466) == 32'h08000020);
-  assign _zz_459 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
-  assign _zz_460 = {(_zz_467 == _zz_468),{_zz_469,{_zz_470,_zz_471}}};
-  assign _zz_461 = 6'h0;
-  assign _zz_462 = ({_zz_472,_zz_473} != 2'b00);
-  assign _zz_463 = ({_zz_474,_zz_475} != 5'h0);
-  assign _zz_464 = {(_zz_476 != _zz_477),{_zz_478,{_zz_479,_zz_480}}};
-  assign _zz_465 = 32'h00000064;
-  assign _zz_466 = 32'h08000070;
-  assign _zz_467 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_468 = 32'h00002040;
-  assign _zz_469 = ((decode_INSTRUCTION & _zz_481) == 32'h00001040);
-  assign _zz_470 = (_zz_482 == _zz_483);
-  assign _zz_471 = {_zz_484,{_zz_485,_zz_486}};
-  assign _zz_472 = ((decode_INSTRUCTION & _zz_487) == 32'h08000020);
-  assign _zz_473 = ((decode_INSTRUCTION & _zz_488) == 32'h00000020);
-  assign _zz_474 = (_zz_489 == _zz_490);
-  assign _zz_475 = {_zz_491,{_zz_492,_zz_493}};
-  assign _zz_476 = {_zz_116,{_zz_494,_zz_495}};
-  assign _zz_477 = 5'h0;
-  assign _zz_478 = ({_zz_496,_zz_497} != 7'h0);
-  assign _zz_479 = (_zz_498 != _zz_499);
-  assign _zz_480 = {_zz_500,{_zz_501,_zz_502}};
-  assign _zz_481 = 32'h00001040;
-  assign _zz_482 = (decode_INSTRUCTION & 32'h00100040);
-  assign _zz_483 = 32'h00000040;
-  assign _zz_484 = ((decode_INSTRUCTION & _zz_503) == 32'h00000040);
-  assign _zz_485 = (_zz_504 == _zz_505);
-  assign _zz_486 = (_zz_506 == _zz_507);
-  assign _zz_487 = 32'h08000020;
-  assign _zz_488 = 32'h00000028;
-  assign _zz_489 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_490 = 32'h00000040;
-  assign _zz_491 = ((decode_INSTRUCTION & _zz_508) == 32'h00004020);
-  assign _zz_492 = (_zz_509 == _zz_510);
-  assign _zz_493 = {_zz_116,_zz_511};
-  assign _zz_494 = (_zz_512 == _zz_513);
-  assign _zz_495 = {_zz_514,{_zz_515,_zz_516}};
-  assign _zz_496 = _zz_113;
-  assign _zz_497 = {_zz_517,{_zz_518,_zz_519}};
-  assign _zz_498 = {_zz_115,_zz_520};
-  assign _zz_499 = 2'b00;
-  assign _zz_500 = ({_zz_521,_zz_522} != 2'b00);
-  assign _zz_501 = (_zz_523 != _zz_524);
-  assign _zz_502 = {_zz_525,{_zz_526,_zz_527}};
-  assign _zz_503 = 32'h00000050;
-  assign _zz_504 = (decode_INSTRUCTION & 32'h08002008);
-  assign _zz_505 = 32'h00002008;
-  assign _zz_506 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_507 = 32'h0;
-  assign _zz_508 = 32'h00004020;
-  assign _zz_509 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_510 = 32'h00000010;
-  assign _zz_511 = ((decode_INSTRUCTION & _zz_528) == 32'h00000020);
-  assign _zz_512 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_513 = 32'h00002010;
-  assign _zz_514 = ((decode_INSTRUCTION & _zz_529) == 32'h00000010);
-  assign _zz_515 = (_zz_530 == _zz_531);
-  assign _zz_516 = (_zz_532 == _zz_533);
-  assign _zz_517 = ((decode_INSTRUCTION & _zz_534) == 32'h00001010);
-  assign _zz_518 = (_zz_535 == _zz_536);
-  assign _zz_519 = {_zz_537,{_zz_538,_zz_539}};
-  assign _zz_520 = ((decode_INSTRUCTION & _zz_540) == 32'h00000020);
-  assign _zz_521 = _zz_115;
-  assign _zz_522 = (_zz_541 == _zz_542);
-  assign _zz_523 = (_zz_543 == _zz_544);
-  assign _zz_524 = 1'b0;
-  assign _zz_525 = (_zz_545 != 1'b0);
-  assign _zz_526 = (_zz_546 != _zz_547);
-  assign _zz_527 = {_zz_548,{_zz_549,_zz_550}};
-  assign _zz_528 = 32'h12000020;
-  assign _zz_529 = 32'h00001030;
-  assign _zz_530 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_531 = 32'h00000020;
-  assign _zz_532 = (decode_INSTRUCTION & 32'h12002060);
-  assign _zz_533 = 32'h00002020;
-  assign _zz_534 = 32'h00001010;
-  assign _zz_535 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_536 = 32'h00002010;
-  assign _zz_537 = ((decode_INSTRUCTION & _zz_551) == 32'h00002008);
-  assign _zz_538 = (_zz_552 == _zz_553);
-  assign _zz_539 = {_zz_116,_zz_554};
-  assign _zz_540 = 32'h00000070;
-  assign _zz_541 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_542 = 32'h0;
-  assign _zz_543 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_544 = 32'h00004010;
-  assign _zz_545 = ((decode_INSTRUCTION & _zz_555) == 32'h00002010);
-  assign _zz_546 = {_zz_556,{_zz_557,_zz_558}};
-  assign _zz_547 = 5'h0;
-  assign _zz_548 = ({_zz_559,_zz_560} != 2'b00);
-  assign _zz_549 = (_zz_561 != _zz_562);
-  assign _zz_550 = {_zz_563,{_zz_564,_zz_565}};
-  assign _zz_551 = 32'h00002008;
-  assign _zz_552 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_553 = 32'h00000010;
-  assign _zz_554 = ((decode_INSTRUCTION & _zz_566) == 32'h0);
-  assign _zz_555 = 32'h00006014;
-  assign _zz_556 = ((decode_INSTRUCTION & _zz_567) == 32'h0);
-  assign _zz_557 = (_zz_568 == _zz_569);
-  assign _zz_558 = {_zz_570,{_zz_571,_zz_572}};
-  assign _zz_559 = _zz_114;
-  assign _zz_560 = (_zz_573 == _zz_574);
-  assign _zz_561 = {_zz_575,{_zz_576,_zz_577}};
-  assign _zz_562 = 3'b000;
-  assign _zz_563 = ({_zz_578,_zz_579} != 3'b000);
-  assign _zz_564 = (_zz_580 != _zz_581);
-  assign _zz_565 = (_zz_582 != _zz_583);
-  assign _zz_566 = 32'h00000028;
-  assign _zz_567 = 32'h00000044;
-  assign _zz_568 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_569 = 32'h0;
-  assign _zz_570 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_571 = ((decode_INSTRUCTION & _zz_584) == 32'h00001000);
-  assign _zz_572 = _zz_114;
-  assign _zz_573 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_574 = 32'h0;
-  assign _zz_575 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_576 = ((decode_INSTRUCTION & _zz_585) == 32'h00002010);
-  assign _zz_577 = ((decode_INSTRUCTION & _zz_586) == 32'h40000030);
-  assign _zz_578 = _zz_113;
-  assign _zz_579 = {_zz_112,(_zz_587 == _zz_588)};
-  assign _zz_580 = {_zz_112,(_zz_589 == _zz_590)};
-  assign _zz_581 = 2'b00;
-  assign _zz_582 = ((decode_INSTRUCTION & _zz_591) == 32'h00001008);
-  assign _zz_583 = 1'b0;
-  assign _zz_584 = 32'h00005004;
-  assign _zz_585 = 32'h00002014;
-  assign _zz_586 = 32'h40000034;
-  assign _zz_587 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_588 = 32'h00000004;
-  assign _zz_589 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz_590 = 32'h00000004;
-  assign _zz_591 = 32'h00005048;
-  assign _zz_592 = execute_INSTRUCTION[31];
-  assign _zz_593 = execute_INSTRUCTION[31];
-  assign _zz_594 = execute_INSTRUCTION[7];
-  assign _zz_595 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_373) begin
-      _zz_232 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_decode_FORMAL_PC_NEXT_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_decode_FORMAL_PC_NEXT = {29'd0, _zz_decode_FORMAL_PC_NEXT_1};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz_IBusCachedPlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_IBusCachedPlugin_decodePc_pcPlus = {29'd0, _zz_IBusCachedPlugin_decodePc_pcPlus_1};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_34 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_35 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hf800707f) == 32'h1800202f),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbc00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00001013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}}};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_28 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b01);
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_29 = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5] == 2'b00));
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = 7'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_31 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_32 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 7];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[19 : 12];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[20];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_7 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_8 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_RS2_SIGNED = 32'h10103050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_4) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = ({_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_7} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = {(_zz__zz_decode_IS_RS2_SIGNED_9 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_10 != _zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_16,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_20}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h02004074;
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(_zz__zz_decode_IS_RS2_SIGNED_11 == _zz__zz_decode_IS_RS2_SIGNED_12),(_zz__zz_decode_IS_RS2_SIGNED_13 == _zz__zz_decode_IS_RS2_SIGNED_14)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ({_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_17} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (_zz__zz_decode_IS_RS2_SIGNED_19 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = {(_zz__zz_decode_IS_RS2_SIGNED_21 != _zz__zz_decode_IS_RS2_SIGNED_26),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ({_zz__zz_decode_IS_RS2_SIGNED_28,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_31}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (_zz__zz_decode_IS_RS2_SIGNED_34 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(_zz__zz_decode_IS_RS2_SIGNED_36 != _zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_39,{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_44}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00005020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_32) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ({_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_41} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = (_zz__zz_decode_IS_RS2_SIGNED_43 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = {(_zz__zz_decode_IS_RS2_SIGNED_45 != _zz__zz_decode_IS_RS2_SIGNED_47),{_zz__zz_decode_IS_RS2_SIGNED_48,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_56}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00007034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00003000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_46) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ({_zz__zz_decode_IS_RS2_SIGNED_49,{_zz__zz_decode_IS_RS2_SIGNED_50,_zz__zz_decode_IS_RS2_SIGNED_52}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (_zz__zz_decode_IS_RS2_SIGNED_55 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = {(_zz__zz_decode_IS_RS2_SIGNED_57 != _zz__zz_decode_IS_RS2_SIGNED_74),{_zz__zz_decode_IS_RS2_SIGNED_75,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_93}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_53) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {(_zz__zz_decode_IS_RS2_SIGNED_58 == _zz__zz_decode_IS_RS2_SIGNED_59),{_zz__zz_decode_IS_RS2_SIGNED_60,{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_65}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 6'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = ({_zz__zz_decode_IS_RS2_SIGNED_76,_zz__zz_decode_IS_RS2_SIGNED_78} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = ({_zz__zz_decode_IS_RS2_SIGNED_81,_zz__zz_decode_IS_RS2_SIGNED_84} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {(_zz__zz_decode_IS_RS2_SIGNED_94 != _zz__zz_decode_IS_RS2_SIGNED_107),{_zz__zz_decode_IS_RS2_SIGNED_108,{_zz__zz_decode_IS_RS2_SIGNED_125,_zz__zz_decode_IS_RS2_SIGNED_130}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h08000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_61) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = {_zz__zz_decode_IS_RS2_SIGNED_66,{_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_71}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_77) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (_zz__zz_decode_IS_RS2_SIGNED_82 == _zz__zz_decode_IS_RS2_SIGNED_83);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz__zz_decode_IS_RS2_SIGNED_85,{_zz__zz_decode_IS_RS2_SIGNED_87,_zz__zz_decode_IS_RS2_SIGNED_90}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_98}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = ({_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_110} != 7'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = (_zz__zz_decode_IS_RS2_SIGNED_126 != _zz__zz_decode_IS_RS2_SIGNED_129);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = {_zz__zz_decode_IS_RS2_SIGNED_131,{_zz__zz_decode_IS_RS2_SIGNED_136,_zz__zz_decode_IS_RS2_SIGNED_141}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h00100040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_67) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (_zz__zz_decode_IS_RS2_SIGNED_72 == _zz__zz_decode_IS_RS2_SIGNED_73);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_86) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (_zz__zz_decode_IS_RS2_SIGNED_88 == _zz__zz_decode_IS_RS2_SIGNED_89);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_91};
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (_zz__zz_decode_IS_RS2_SIGNED_96 == _zz__zz_decode_IS_RS2_SIGNED_97);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = {_zz__zz_decode_IS_RS2_SIGNED_99,{_zz__zz_decode_IS_RS2_SIGNED_101,_zz__zz_decode_IS_RS2_SIGNED_104}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = {_zz__zz_decode_IS_RS2_SIGNED_111,{_zz__zz_decode_IS_RS2_SIGNED_113,_zz__zz_decode_IS_RS2_SIGNED_116}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = {_zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_127};
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = ({_zz__zz_decode_IS_RS2_SIGNED_132,_zz__zz_decode_IS_RS2_SIGNED_133} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = (_zz__zz_decode_IS_RS2_SIGNED_137 != _zz__zz_decode_IS_RS2_SIGNED_140);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = {_zz__zz_decode_IS_RS2_SIGNED_142,{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_158}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h08002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_92) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_100) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (_zz__zz_decode_IS_RS2_SIGNED_102 == _zz__zz_decode_IS_RS2_SIGNED_103);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_112) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (_zz__zz_decode_IS_RS2_SIGNED_114 == _zz__zz_decode_IS_RS2_SIGNED_115);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz__zz_decode_IS_RS2_SIGNED_117,{_zz__zz_decode_IS_RS2_SIGNED_119,_zz__zz_decode_IS_RS2_SIGNED_122}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_128) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = (_zz__zz_decode_IS_RS2_SIGNED_134 == _zz__zz_decode_IS_RS2_SIGNED_135);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (_zz__zz_decode_IS_RS2_SIGNED_138 == _zz__zz_decode_IS_RS2_SIGNED_139);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = (_zz__zz_decode_IS_RS2_SIGNED_143 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (_zz__zz_decode_IS_RS2_SIGNED_146 != _zz__zz_decode_IS_RS2_SIGNED_157);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = {_zz__zz_decode_IS_RS2_SIGNED_159,{_zz__zz_decode_IS_RS2_SIGNED_164,_zz__zz_decode_IS_RS2_SIGNED_172}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h12000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h12002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (_zz__zz_decode_IS_RS2_SIGNED_120 == _zz__zz_decode_IS_RS2_SIGNED_121);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_123};
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_144) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz__zz_decode_IS_RS2_SIGNED_147,{_zz__zz_decode_IS_RS2_SIGNED_149,_zz__zz_decode_IS_RS2_SIGNED_152}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = ({_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_161} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = (_zz__zz_decode_IS_RS2_SIGNED_165 != _zz__zz_decode_IS_RS2_SIGNED_171);
+  assign _zz__zz_decode_IS_RS2_SIGNED_172 = {_zz__zz_decode_IS_RS2_SIGNED_173,{_zz__zz_decode_IS_RS2_SIGNED_178,_zz__zz_decode_IS_RS2_SIGNED_183}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_124) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_148) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = (_zz__zz_decode_IS_RS2_SIGNED_150 == _zz__zz_decode_IS_RS2_SIGNED_151);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = {_zz__zz_decode_IS_RS2_SIGNED_153,{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_156}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = (_zz__zz_decode_IS_RS2_SIGNED_162 == _zz__zz_decode_IS_RS2_SIGNED_163);
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = {_zz__zz_decode_IS_RS2_SIGNED_166,{_zz__zz_decode_IS_RS2_SIGNED_167,_zz__zz_decode_IS_RS2_SIGNED_169}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_171 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_173 = ({_zz__zz_decode_IS_RS2_SIGNED_174,_zz__zz_decode_IS_RS2_SIGNED_175} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_178 = (_zz__zz_decode_IS_RS2_SIGNED_179 != _zz__zz_decode_IS_RS2_SIGNED_182);
+  assign _zz__zz_decode_IS_RS2_SIGNED_183 = (_zz__zz_decode_IS_RS2_SIGNED_184 != _zz__zz_decode_IS_RS2_SIGNED_186);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_155) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_167 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_168) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_169 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_170) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_174 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_175 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_176 == _zz__zz_decode_IS_RS2_SIGNED_177)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_179 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_180 == _zz__zz_decode_IS_RS2_SIGNED_181)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_182 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_184 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_185) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_186 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_168 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_170 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_176 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_177 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_180 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_181 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_185 = 32'h00005048;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_374) begin
-      _zz_233 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_202                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_203                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_204                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_205                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_206                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_fetch_cacheMiss                   (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss               ), //o
-    .io_cpu_fetch_error                       (IBusCachedPlugin_cache_io_cpu_fetch_error                   ), //o
-    .io_cpu_fetch_mmuRefilling                (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling            ), //o
-    .io_cpu_fetch_mmuException                (IBusCachedPlugin_cache_io_cpu_fetch_mmuException            ), //o
-    .io_cpu_fetch_isUser                      (_zz_207                                                     ), //i
-    .io_cpu_decode_isValid                    (_zz_208                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_209                                                     ), //i
-    .io_cpu_decode_pc                         (_zz_210[31:0]                                               ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_fill_valid                        (_zz_211                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_fetch_cacheMiss                   (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss         ), //o
+    .io_cpu_fetch_error                       (IBusCachedPlugin_cache_io_cpu_fetch_error             ), //o
+    .io_cpu_fetch_mmuRefilling                (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling      ), //o
+    .io_cpu_fetch_mmuException                (IBusCachedPlugin_cache_io_cpu_fetch_mmuException      ), //o
+    .io_cpu_fetch_isUser                      (IBusCachedPlugin_cache_io_cpu_fetch_isUser            ), //i
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_cache_io_cpu_decode_pc               ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_212                                            ), //i
-    .io_cpu_execute_address                    (_zz_213[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_106[31:0]                                      ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_isLrsc                (_zz_214                                            ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_215                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_216[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_217                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_218                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_219                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_220[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_221                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_222                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_223                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_224                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_225                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_226                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_227                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_228                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_229[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_230                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_231                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_isLrsc                (dataCache_1_io_cpu_execute_args_isLrsc         ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_375)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_234 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_234 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_234 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_234 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      end
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      end
+      default : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1937,134 +2061,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2077,30 +2201,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2112,27 +2236,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2145,30 +2269,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2181,12 +2305,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2199,12 +2323,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2217,12 +2341,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2235,48 +2359,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2289,12 +2413,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2307,12 +2431,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2324,88 +2448,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2418,73 +2542,73 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
-      default : _zz_52_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_118)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_118_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_118_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_118_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_118_string = "URS1        ";
-      default : _zz_118_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_119)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_119_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_119_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_119_string = "BITWISE ";
-      default : _zz_119_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_120)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_120_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_120_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_120_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_120_string = "PC ";
-      default : _zz_120_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_121)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_121_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_121_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_121_string = "AND_1";
-      default : _zz_121_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_122)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_122_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_122_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_122_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_122_string = "SRA_1    ";
-      default : _zz_122_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_123)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_123_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_123_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_123_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_123_string = "JALR";
-      default : _zz_123_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_124)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_124_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_124_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_124_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_124_string = "ECALL";
-      default : _zz_124_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2515,28 +2639,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2577,7 +2701,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_281) + $signed(_zz_289));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -2585,53 +2709,54 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_291;
-  assign execute_REGFILE_WRITE_DATA = _zz_126;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_213[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_293[0];
-  assign decode_IS_RS1_SIGNED = _zz_294[0];
-  assign decode_IS_DIV = _zz_295[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[32];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[30];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_296[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_297[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_298[0];
-  assign decode_MEMORY_MANAGMENT = _zz_299[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[29];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[26];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[19];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[18];
+  assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_300[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_301[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_302[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
-  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
-  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_304);
+  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_decode_FORMAL_PC_NEXT);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_305[0];
+  assign decode_IS_EBREAK = _zz_decode_IS_RS2_SIGNED[33];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2645,22 +2770,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_148;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_306[0];
-  assign decode_RS1_USE = _zz_307[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_235)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -2670,140 +2795,141 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_137)begin
-      if((_zz_138 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_139;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_141)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_238)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_143)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_239)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_145)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_137)begin
-      if((_zz_138 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_139;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_140)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_238)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_142)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_239)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_144)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_134;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_240)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_308[0];
-  assign decode_SRC_ADD_ZERO = _zz_309[0];
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[17];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_132;
-  assign execute_SRC1 = _zz_127;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_decompressor_output_payload_rsp_inst);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_310[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_376) == 32'h00001073),{(_zz_377 == _zz_378),{_zz_379,{_zz_380,_zz_381}}}}}}} != 23'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 23'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_280)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_348;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_349;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_LRSC = memory_to_writeBack_MEMORY_LRSC;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -2816,49 +2942,49 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_LRSC = _zz_311[0];
-  assign decode_MEMORY_ENABLE = _zz_312[0];
-  assign decode_FLUSH_ALL = _zz_313[0];
-  always @ (*) begin
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_241)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_242)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_243)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_244)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52;
-  always @ (*) begin
-    _zz_53 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53 = BranchPlugin_jumpInterface_payload;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -2867,12 +2993,12 @@ module VexRiscv (
   assign decode_IS_RVC = IBusCachedPlugin_injector_decodeInput_payload_isRvc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_169)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2881,163 +3007,163 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_135 || _zz_136)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_245)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_245)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_230 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_246)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_235)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_247)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_247)begin
-      if(_zz_248)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_247)begin
-      if(_zz_248)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
-    if(_zz_168)begin
+    if(_zz_3) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_240)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_249)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_250)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3046,78 +3172,80 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_249)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_250)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_247)begin
-      if(_zz_248)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_251)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_valid)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_valid) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
-    if(IBusCachedPlugin_injector_decodeInput_valid)begin
+    if(IBusCachedPlugin_injector_decodeInput_valid) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_55 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_55 = 1'b1;
+  always @(*) begin
+    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    if(DebugPlugin_godmode) begin
+      _zz_when_DBusCachedPlugin_l386 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_246)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_249)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_250)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_249)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_250)begin
-      case(_zz_252)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3127,97 +3255,111 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_56 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_57 = (_zz_56 & (~ _zz_314));
-  assign _zz_58 = _zz_57[3];
-  assign _zz_59 = (_zz_57[1] || _zz_58);
-  assign _zz_60 = (_zz_57[2] || _zz_58);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_234;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_316);
-    if(IBusCachedPlugin_fetchPc_inc)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_inc) begin
       IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
     end
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodePc_flushed = 1'b0;
-    if(_zz_253)begin
+    if(when_Fetcher_l192) begin
       IBusCachedPlugin_decodePc_flushed = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_318);
-  always @ (*) begin
+  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_IBusCachedPlugin_decodePc_pcPlus);
+  always @(*) begin
     IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
-    if((_zz_169 != 3'b000))begin
+    if(when_Fetcher_l360) begin
       IBusCachedPlugin_decodePc_injectedDecode = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign when_Fetcher_l180 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
+  assign when_Fetcher_l192 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3225,48 +3367,48 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_62);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-    if(IBusCachedPlugin_decompressor_throw2BytesReg)begin
+    if(IBusCachedPlugin_decompressor_throw2BytesReg) begin
       IBusCachedPlugin_fetchPc_redo_payload[1] = 1'b1;
     end
   end
 
   assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
-  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64 = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(IBusCachedPlugin_injector_decodeInput_valid)begin
+    if(IBusCachedPlugin_injector_decodeInput_valid) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
@@ -3283,190 +3425,195 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
   assign IBusCachedPlugin_decompressor_throw2Bytes = (IBusCachedPlugin_decompressor_throw2BytesReg || IBusCachedPlugin_decompressor_input_payload_pc[1]);
   assign IBusCachedPlugin_decompressor_unaligned = (IBusCachedPlugin_decompressor_throw2Bytes || IBusCachedPlugin_decompressor_bufferValid);
-  assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValid ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2Bytes ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
+  assign IBusCachedPlugin_decompressor_bufferValidPatched = (IBusCachedPlugin_decompressor_input_valid ? IBusCachedPlugin_decompressor_bufferValid : IBusCachedPlugin_decompressor_bufferValidLatch);
+  assign IBusCachedPlugin_decompressor_throw2BytesPatched = (IBusCachedPlugin_decompressor_input_valid ? IBusCachedPlugin_decompressor_throw2Bytes : IBusCachedPlugin_decompressor_throw2BytesLatch);
+  assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValidPatched ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2BytesPatched ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
   assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
-  assign _zz_66 = IBusCachedPlugin_decompressor_raw[15 : 0];
-  always @ (*) begin
-    IBusCachedPlugin_decompressor_decompressed = 32'h0;
-    case(_zz_275)
+  assign _zz_IBusCachedPlugin_decompressor_decompressed = IBusCachedPlugin_decompressor_raw[15 : 0];
+  always @(*) begin
+    IBusCachedPlugin_decompressor_decompressed = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    case(switch_Misc_l44)
       5'h0 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_66[10 : 7]},_zz_66[12 : 11]},_zz_66[5]},_zz_66[6]},2'b00},5'h02},3'b000},_zz_68},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusCachedPlugin_decompressor_decompressed[10 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 11]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h13};
       end
       5'h02 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_69,_zz_67},3'b010},_zz_68},7'h03};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_3,_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h03};
       end
       5'h06 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_69[11 : 5],_zz_68},_zz_67},3'b010},_zz_69[4 : 0]},7'h23};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_3[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed_2},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_3[4 : 0]},7'h23};
       end
       5'h08 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_71,_zz_66[11 : 7]},3'b000},_zz_66[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h09 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_74[20],_zz_74[10 : 1]},_zz_74[11]},_zz_74[19 : 12]},_zz_86},7'h6f};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_8[20],_zz_IBusCachedPlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_8[11]},_zz_IBusCachedPlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_20},7'h6f};
       end
       5'h0a : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_71,5'h0},3'b000},_zz_66[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h0b : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_66[11 : 7] == 5'h02) ? {{{{{{{{{_zz_78,_zz_66[4 : 3]},_zz_66[5]},_zz_66[2]},_zz_66[6]},4'b0000},_zz_66[11 : 7]},3'b000},_zz_66[11 : 7]},7'h13} : {{_zz_319[31 : 12],_zz_66[11 : 7]},7'h37});
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_12,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusCachedPlugin_decompressor_decompressed_27[31 : 12],_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h37});
       end
       5'h0c : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_66[11 : 10] == 2'b10) ? _zz_92 : {{1'b0,(_zz_394 || _zz_395)},5'h0}),(((! _zz_66[11]) || _zz_88) ? _zz_66[6 : 2] : _zz_68)},_zz_67},_zz_90},_zz_67},(_zz_88 ? 7'h13 : 7'h33)};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_28 || _zz_IBusCachedPlugin_decompressor_decompressed_29)},5'h0}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
       end
       5'h0d : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_81[20],_zz_81[10 : 1]},_zz_81[11]},_zz_81[19 : 12]},_zz_85},7'h6f};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_15[20],_zz_IBusCachedPlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_15[11]},_zz_IBusCachedPlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_19},7'h6f};
       end
       5'h0e : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_84[12],_zz_84[10 : 5]},_zz_85},_zz_67},3'b000},_zz_84[4 : 1]},_zz_84[11]},7'h63};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h0f : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_84[12],_zz_84[10 : 5]},_zz_85},_zz_67},3'b001},_zz_84[4 : 1]},_zz_84[11]},7'h63};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h10 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_66[6 : 2]},_zz_66[11 : 7]},3'b001},_zz_66[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h12 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_66[3 : 2]},_zz_66[12]},_zz_66[6 : 4]},2'b00},_zz_87},3'b010},_zz_66[11 : 7]},7'h03};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[3 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[12]},_zz_IBusCachedPlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h03};
       end
       5'h14 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_66[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_66[6 : 2] == 5'h0) ? {{{{12'h0,_zz_66[11 : 7]},3'b000},(_zz_66[12] ? _zz_86 : _zz_85)},7'h67} : {{{{{_zz_396,_zz_397},(_zz_398 ? _zz_399 : _zz_85)},3'b000},_zz_66[11 : 7]},7'h33}));
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_30,_zz_IBusCachedPlugin_decompressor_decompressed_31},(_zz_IBusCachedPlugin_decompressor_decompressed_32 ? _zz_IBusCachedPlugin_decompressor_decompressed_33 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
       end
       5'h16 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_320[11 : 5],_zz_66[6 : 2]},_zz_87},3'b010},_zz_321[4 : 0]},7'h23};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_34[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_35[4 : 0]},7'h23};
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_67 = {2'b01,_zz_66[9 : 7]};
-  assign _zz_68 = {2'b01,_zz_66[4 : 2]};
-  assign _zz_69 = {{{{5'h0,_zz_66[5]},_zz_66[12 : 10]},_zz_66[6]},2'b00};
-  assign _zz_70 = _zz_66[12];
-  always @ (*) begin
-    _zz_71[11] = _zz_70;
-    _zz_71[10] = _zz_70;
-    _zz_71[9] = _zz_70;
-    _zz_71[8] = _zz_70;
-    _zz_71[7] = _zz_70;
-    _zz_71[6] = _zz_70;
-    _zz_71[5] = _zz_70;
-    _zz_71[4 : 0] = _zz_66[6 : 2];
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[9 : 7]};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 2]};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_4 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[11] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[10] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[9] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[8] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[7] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[6] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[5] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
+    _zz_IBusCachedPlugin_decompressor_decompressed_5[4 : 0] = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
   end
 
-  assign _zz_72 = _zz_66[12];
-  always @ (*) begin
-    _zz_73[9] = _zz_72;
-    _zz_73[8] = _zz_72;
-    _zz_73[7] = _zz_72;
-    _zz_73[6] = _zz_72;
-    _zz_73[5] = _zz_72;
-    _zz_73[4] = _zz_72;
-    _zz_73[3] = _zz_72;
-    _zz_73[2] = _zz_72;
-    _zz_73[1] = _zz_72;
-    _zz_73[0] = _zz_72;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_6 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[9] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[8] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[7] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[6] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[5] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[4] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[3] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[2] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[1] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusCachedPlugin_decompressor_decompressed_7[0] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
   end
 
-  assign _zz_74 = {{{{{{{{_zz_73,_zz_66[8]},_zz_66[10 : 9]},_zz_66[6]},_zz_66[7]},_zz_66[2]},_zz_66[11]},_zz_66[5 : 3]},1'b0};
-  assign _zz_75 = _zz_66[12];
-  always @ (*) begin
-    _zz_76[14] = _zz_75;
-    _zz_76[13] = _zz_75;
-    _zz_76[12] = _zz_75;
-    _zz_76[11] = _zz_75;
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7] = _zz_75;
-    _zz_76[6] = _zz_75;
-    _zz_76[5] = _zz_75;
-    _zz_76[4] = _zz_75;
-    _zz_76[3] = _zz_75;
-    _zz_76[2] = _zz_75;
-    _zz_76[1] = _zz_75;
-    _zz_76[0] = _zz_75;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_8 = {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_7,_zz_IBusCachedPlugin_decompressor_decompressed[8]},_zz_IBusCachedPlugin_decompressor_decompressed[10 : 9]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},_zz_IBusCachedPlugin_decompressor_decompressed[7]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11]},_zz_IBusCachedPlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_9 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[14] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[13] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[12] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[11] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[10] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[9] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[8] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[7] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[6] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[5] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[4] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[3] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[2] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[1] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusCachedPlugin_decompressor_decompressed_10[0] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
   end
 
-  assign _zz_77 = _zz_66[12];
-  always @ (*) begin
-    _zz_78[2] = _zz_77;
-    _zz_78[1] = _zz_77;
-    _zz_78[0] = _zz_77;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_11 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_12[2] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
+    _zz_IBusCachedPlugin_decompressor_decompressed_12[1] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
+    _zz_IBusCachedPlugin_decompressor_decompressed_12[0] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
   end
 
-  assign _zz_79 = _zz_66[12];
-  always @ (*) begin
-    _zz_80[9] = _zz_79;
-    _zz_80[8] = _zz_79;
-    _zz_80[7] = _zz_79;
-    _zz_80[6] = _zz_79;
-    _zz_80[5] = _zz_79;
-    _zz_80[4] = _zz_79;
-    _zz_80[3] = _zz_79;
-    _zz_80[2] = _zz_79;
-    _zz_80[1] = _zz_79;
-    _zz_80[0] = _zz_79;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_13 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[9] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[8] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[7] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[6] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[5] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[4] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[3] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[2] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[1] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusCachedPlugin_decompressor_decompressed_14[0] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
   end
 
-  assign _zz_81 = {{{{{{{{_zz_80,_zz_66[8]},_zz_66[10 : 9]},_zz_66[6]},_zz_66[7]},_zz_66[2]},_zz_66[11]},_zz_66[5 : 3]},1'b0};
-  assign _zz_82 = _zz_66[12];
-  always @ (*) begin
-    _zz_83[4] = _zz_82;
-    _zz_83[3] = _zz_82;
-    _zz_83[2] = _zz_82;
-    _zz_83[1] = _zz_82;
-    _zz_83[0] = _zz_82;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_15 = {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_14,_zz_IBusCachedPlugin_decompressor_decompressed[8]},_zz_IBusCachedPlugin_decompressor_decompressed[10 : 9]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},_zz_IBusCachedPlugin_decompressor_decompressed[7]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11]},_zz_IBusCachedPlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_16 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[4] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[3] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[2] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[1] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusCachedPlugin_decompressor_decompressed_17[0] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
   end
 
-  assign _zz_84 = {{{{{_zz_83,_zz_66[6 : 5]},_zz_66[2]},_zz_66[11 : 10]},_zz_66[4 : 3]},1'b0};
-  assign _zz_85 = 5'h0;
-  assign _zz_86 = 5'h01;
-  assign _zz_87 = 5'h02;
-  assign _zz_88 = (_zz_66[11 : 10] != 2'b11);
-  always @ (*) begin
-    case(_zz_276)
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_18 = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_17,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},1'b0};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h0;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_20 = 5'h01;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_21 = 5'h02;
+  assign switch_Misc_l44 = {_zz_IBusCachedPlugin_decompressor_decompressed[1 : 0],_zz_IBusCachedPlugin_decompressor_decompressed[15 : 13]};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_22 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] != 2'b11);
+  assign switch_Misc_l199 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
+  assign switch_Misc_l199_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
+  always @(*) begin
+    case(switch_Misc_l199_1)
       2'b00 : begin
-        _zz_89 = 3'b000;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b000;
       end
       2'b01 : begin
-        _zz_89 = 3'b100;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b100;
       end
       2'b10 : begin
-        _zz_89 = 3'b110;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b110;
       end
       default : begin
-        _zz_89 = 3'b111;
+        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b111;
       end
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_277)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        _zz_90 = 3'b101;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
       end
       2'b01 : begin
-        _zz_90 = 3'b101;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
       end
       2'b10 : begin
-        _zz_90 = 3'b111;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b111;
       end
       default : begin
-        _zz_90 = _zz_89;
+        _zz_IBusCachedPlugin_decompressor_decompressed_24 = _zz_IBusCachedPlugin_decompressor_decompressed_23;
       end
     endcase
   end
 
-  assign _zz_91 = _zz_66[12];
-  always @ (*) begin
-    _zz_92[6] = _zz_91;
-    _zz_92[5] = _zz_91;
-    _zz_92[4] = _zz_91;
-    _zz_92[3] = _zz_91;
-    _zz_92[2] = _zz_91;
-    _zz_92[1] = _zz_91;
-    _zz_92[0] = _zz_91;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_25 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[6] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[5] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[4] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[3] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[2] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[1] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusCachedPlugin_decompressor_decompressed_26[0] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
   end
 
   assign IBusCachedPlugin_decompressor_output_valid = (IBusCachedPlugin_decompressor_input_valid && (! ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_bufferValid)) && (! IBusCachedPlugin_decompressor_isInputHighRvc))));
@@ -3474,21 +3621,29 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_output_payload_isRvc = IBusCachedPlugin_decompressor_isRvc;
   assign IBusCachedPlugin_decompressor_output_payload_rsp_inst = (IBusCachedPlugin_decompressor_isRvc ? IBusCachedPlugin_decompressor_decompressed : IBusCachedPlugin_decompressor_raw);
   assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
+  assign when_Fetcher_l279 = (IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready);
   assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
+  assign when_Fetcher_l283 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l286 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign when_Fetcher_l291 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
   assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
-  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_93;
-  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_94;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_95;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_96;
-  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_97;
+  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_IBusCachedPlugin_injector_decodeInput_valid;
+  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
+  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
+  assign when_Fetcher_l329 = (! 1'b0);
+  assign when_Fetcher_l329_1 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_2 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_injector_decodeInput_valid;
-    case(_zz_169)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3500,150 +3655,156 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_98 = _zz_322[11];
-  always @ (*) begin
-    _zz_99[18] = _zz_98;
-    _zz_99[17] = _zz_98;
-    _zz_99[16] = _zz_98;
-    _zz_99[15] = _zz_98;
-    _zz_99[14] = _zz_98;
-    _zz_99[13] = _zz_98;
-    _zz_99[12] = _zz_98;
-    _zz_99[11] = _zz_98;
-    _zz_99[10] = _zz_98;
-    _zz_99[9] = _zz_98;
-    _zz_99[8] = _zz_98;
-    _zz_99[7] = _zz_98;
-    _zz_99[6] = _zz_98;
-    _zz_99[5] = _zz_98;
-    _zz_99[4] = _zz_98;
-    _zz_99[3] = _zz_98;
-    _zz_99[2] = _zz_98;
-    _zz_99[1] = _zz_98;
-    _zz_99[0] = _zz_98;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_323[31]));
+  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_100 = _zz_324[19];
-  always @ (*) begin
-    _zz_101[10] = _zz_100;
-    _zz_101[9] = _zz_100;
-    _zz_101[8] = _zz_100;
-    _zz_101[7] = _zz_100;
-    _zz_101[6] = _zz_100;
-    _zz_101[5] = _zz_100;
-    _zz_101[4] = _zz_100;
-    _zz_101[3] = _zz_100;
-    _zz_101[2] = _zz_100;
-    _zz_101[1] = _zz_100;
-    _zz_101[0] = _zz_100;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_102 = _zz_325[11];
-  always @ (*) begin
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_101,{{{_zz_400,_zz_401},_zz_402},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_103,{{{_zz_403,_zz_404},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,_zz_IBusCachedPlugin_predictionJumpInterface_payload_5},_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_7,_zz_IBusCachedPlugin_predictionJumpInterface_payload_8},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_203 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_204 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_205 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_204;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_207 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_244)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_242)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_211 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(_zz_242)begin
-      _zz_211 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_243)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_241)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_243)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_241)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  assign _zz_202 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_231 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3651,184 +3812,202 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  always @ (*) begin
-    _zz_51 = 1'b0;
-    if(decode_INSTRUCTION[25])begin
-      if(decode_MEMORY_LRSC)begin
-        _zz_51 = 1'b1;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  always @(*) begin
+    _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
+    if(when_DBusCachedPlugin_l311) begin
+      if(decode_MEMORY_LRSC) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l311 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_212 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_213 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_106 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_106 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_106 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_230 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  always @ (*) begin
-    _zz_214 = 1'b0;
-    if(execute_MEMORY_LRSC)begin
-      _zz_214 = 1'b1;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
+    if(execute_MEMORY_LRSC) begin
+      dataCache_1_io_cpu_execute_args_isLrsc = 1'b1;
     end
   end
 
-  assign _zz_215 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_216 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_215;
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_216;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_217 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_55 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_217 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_218 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_219 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_220 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_254)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_254)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_254)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_326};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_327};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_107 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_108[31] = _zz_107;
-    _zz_108[30] = _zz_107;
-    _zz_108[29] = _zz_107;
-    _zz_108[28] = _zz_107;
-    _zz_108[27] = _zz_107;
-    _zz_108[26] = _zz_107;
-    _zz_108[25] = _zz_107;
-    _zz_108[24] = _zz_107;
-    _zz_108[23] = _zz_107;
-    _zz_108[22] = _zz_107;
-    _zz_108[21] = _zz_107;
-    _zz_108[20] = _zz_107;
-    _zz_108[19] = _zz_107;
-    _zz_108[18] = _zz_107;
-    _zz_108[17] = _zz_107;
-    _zz_108[16] = _zz_107;
-    _zz_108[15] = _zz_107;
-    _zz_108[14] = _zz_107;
-    _zz_108[13] = _zz_107;
-    _zz_108[12] = _zz_107;
-    _zz_108[11] = _zz_107;
-    _zz_108[10] = _zz_107;
-    _zz_108[9] = _zz_107;
-    _zz_108[8] = _zz_107;
-    _zz_108[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+    if(when_DBusCachedPlugin_l474) begin
+      writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
+    end
   end
 
-  assign _zz_109 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_110[31] = _zz_109;
-    _zz_110[30] = _zz_109;
-    _zz_110[29] = _zz_109;
-    _zz_110[28] = _zz_109;
-    _zz_110[27] = _zz_109;
-    _zz_110[26] = _zz_109;
-    _zz_110[25] = _zz_109;
-    _zz_110[24] = _zz_109;
-    _zz_110[23] = _zz_109;
-    _zz_110[22] = _zz_109;
-    _zz_110[21] = _zz_109;
-    _zz_110[20] = _zz_109;
-    _zz_110[19] = _zz_109;
-    _zz_110[18] = _zz_109;
-    _zz_110[17] = _zz_109;
-    _zz_110[16] = _zz_109;
-    _zz_110[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign when_DBusCachedPlugin_l474 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l199_2 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_278)
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l199_2)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_108;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_110;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3847,61 +4026,62 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_112 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_113 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_114 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_115 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_116 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_117 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_111 = {(((decode_INSTRUCTION & _zz_405) == 32'h00100050) != 1'b0),{(_zz_117 != 1'b0),{(_zz_117 != 1'b0),{(_zz_406 != _zz_407),{_zz_408,{_zz_409,_zz_410}}}}}};
-  assign _zz_118 = _zz_111[2 : 1];
-  assign _zz_49 = _zz_118;
-  assign _zz_119 = _zz_111[7 : 6];
-  assign _zz_48 = _zz_119;
-  assign _zz_120 = _zz_111[9 : 8];
-  assign _zz_47 = _zz_120;
-  assign _zz_121 = _zz_111[21 : 20];
-  assign _zz_46 = _zz_121;
-  assign _zz_122 = _zz_111[23 : 22];
-  assign _zz_45 = _zz_122;
-  assign _zz_123 = _zz_111[25 : 24];
-  assign _zz_44 = _zz_123;
-  assign _zz_124 = _zz_111[28 : 27];
-  assign _zz_43 = _zz_124;
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED) == 32'h00100050) != 1'b0),{(_zz_decode_IS_RS2_SIGNED_6 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_6 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_1 != _zz__zz_decode_IS_RS2_SIGNED_2),{_zz__zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_8}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[21 : 20];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[23 : 22];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[25 : 24];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[28 : 27];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_232;
-  assign decode_RegFilePlugin_rs2Data = _zz_233;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_125)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_2) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_125)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_125)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3910,277 +4090,300 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_126 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_126 = {31'd0, _zz_328};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_126 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_127 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_127 = {29'd0, _zz_329};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_127 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_127 = {27'd0, _zz_330};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_128 = _zz_331[11];
-  always @ (*) begin
-    _zz_129[19] = _zz_128;
-    _zz_129[18] = _zz_128;
-    _zz_129[17] = _zz_128;
-    _zz_129[16] = _zz_128;
-    _zz_129[15] = _zz_128;
-    _zz_129[14] = _zz_128;
-    _zz_129[13] = _zz_128;
-    _zz_129[12] = _zz_128;
-    _zz_129[11] = _zz_128;
-    _zz_129[10] = _zz_128;
-    _zz_129[9] = _zz_128;
-    _zz_129[8] = _zz_128;
-    _zz_129[7] = _zz_128;
-    _zz_129[6] = _zz_128;
-    _zz_129[5] = _zz_128;
-    _zz_129[4] = _zz_128;
-    _zz_129[3] = _zz_128;
-    _zz_129[2] = _zz_128;
-    _zz_129[1] = _zz_128;
-    _zz_129[0] = _zz_128;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_130 = _zz_332[11];
-  always @ (*) begin
-    _zz_131[19] = _zz_130;
-    _zz_131[18] = _zz_130;
-    _zz_131[17] = _zz_130;
-    _zz_131[16] = _zz_130;
-    _zz_131[15] = _zz_130;
-    _zz_131[14] = _zz_130;
-    _zz_131[13] = _zz_130;
-    _zz_131[12] = _zz_130;
-    _zz_131[11] = _zz_130;
-    _zz_131[10] = _zz_130;
-    _zz_131[9] = _zz_130;
-    _zz_131[8] = _zz_130;
-    _zz_131[7] = _zz_130;
-    _zz_131[6] = _zz_130;
-    _zz_131[5] = _zz_130;
-    _zz_131[4] = _zz_130;
-    _zz_131[3] = _zz_130;
-    _zz_131[2] = _zz_130;
-    _zz_131[1] = _zz_130;
-    _zz_131[0] = _zz_130;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_132 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_132 = {_zz_129,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_132 = {_zz_131,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_132 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_333;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_133[0] = execute_SRC1[31];
-    _zz_133[1] = execute_SRC1[30];
-    _zz_133[2] = execute_SRC1[29];
-    _zz_133[3] = execute_SRC1[28];
-    _zz_133[4] = execute_SRC1[27];
-    _zz_133[5] = execute_SRC1[26];
-    _zz_133[6] = execute_SRC1[25];
-    _zz_133[7] = execute_SRC1[24];
-    _zz_133[8] = execute_SRC1[23];
-    _zz_133[9] = execute_SRC1[22];
-    _zz_133[10] = execute_SRC1[21];
-    _zz_133[11] = execute_SRC1[20];
-    _zz_133[12] = execute_SRC1[19];
-    _zz_133[13] = execute_SRC1[18];
-    _zz_133[14] = execute_SRC1[17];
-    _zz_133[15] = execute_SRC1[16];
-    _zz_133[16] = execute_SRC1[15];
-    _zz_133[17] = execute_SRC1[14];
-    _zz_133[18] = execute_SRC1[13];
-    _zz_133[19] = execute_SRC1[12];
-    _zz_133[20] = execute_SRC1[11];
-    _zz_133[21] = execute_SRC1[10];
-    _zz_133[22] = execute_SRC1[9];
-    _zz_133[23] = execute_SRC1[8];
-    _zz_133[24] = execute_SRC1[7];
-    _zz_133[25] = execute_SRC1[6];
-    _zz_133[26] = execute_SRC1[5];
-    _zz_133[27] = execute_SRC1[4];
-    _zz_133[28] = execute_SRC1[3];
-    _zz_133[29] = execute_SRC1[2];
-    _zz_133[30] = execute_SRC1[1];
-    _zz_133[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_133 : execute_SRC1);
-  always @ (*) begin
-    _zz_134[0] = memory_SHIFT_RIGHT[31];
-    _zz_134[1] = memory_SHIFT_RIGHT[30];
-    _zz_134[2] = memory_SHIFT_RIGHT[29];
-    _zz_134[3] = memory_SHIFT_RIGHT[28];
-    _zz_134[4] = memory_SHIFT_RIGHT[27];
-    _zz_134[5] = memory_SHIFT_RIGHT[26];
-    _zz_134[6] = memory_SHIFT_RIGHT[25];
-    _zz_134[7] = memory_SHIFT_RIGHT[24];
-    _zz_134[8] = memory_SHIFT_RIGHT[23];
-    _zz_134[9] = memory_SHIFT_RIGHT[22];
-    _zz_134[10] = memory_SHIFT_RIGHT[21];
-    _zz_134[11] = memory_SHIFT_RIGHT[20];
-    _zz_134[12] = memory_SHIFT_RIGHT[19];
-    _zz_134[13] = memory_SHIFT_RIGHT[18];
-    _zz_134[14] = memory_SHIFT_RIGHT[17];
-    _zz_134[15] = memory_SHIFT_RIGHT[16];
-    _zz_134[16] = memory_SHIFT_RIGHT[15];
-    _zz_134[17] = memory_SHIFT_RIGHT[14];
-    _zz_134[18] = memory_SHIFT_RIGHT[13];
-    _zz_134[19] = memory_SHIFT_RIGHT[12];
-    _zz_134[20] = memory_SHIFT_RIGHT[11];
-    _zz_134[21] = memory_SHIFT_RIGHT[10];
-    _zz_134[22] = memory_SHIFT_RIGHT[9];
-    _zz_134[23] = memory_SHIFT_RIGHT[8];
-    _zz_134[24] = memory_SHIFT_RIGHT[7];
-    _zz_134[25] = memory_SHIFT_RIGHT[6];
-    _zz_134[26] = memory_SHIFT_RIGHT[5];
-    _zz_134[27] = memory_SHIFT_RIGHT[4];
-    _zz_134[28] = memory_SHIFT_RIGHT[3];
-    _zz_134[29] = memory_SHIFT_RIGHT[2];
-    _zz_134[30] = memory_SHIFT_RIGHT[1];
-    _zz_134[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_135 = 1'b0;
-    if(_zz_255)begin
-      if(_zz_256)begin
-        if(_zz_140)begin
-          _zz_135 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_257)begin
-      if(_zz_258)begin
-        if(_zz_142)begin
-          _zz_135 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_259)begin
-      if(_zz_260)begin
-        if(_zz_144)begin
-          _zz_135 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_135 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_136 = 1'b0;
-    if(_zz_255)begin
-      if(_zz_256)begin
-        if(_zz_141)begin
-          _zz_136 = 1'b1;
-        end
-      end
-    end
-    if(_zz_257)begin
-      if(_zz_258)begin
-        if(_zz_143)begin
-          _zz_136 = 1'b1;
-        end
-      end
-    end
-    if(_zz_259)begin
-      if(_zz_260)begin
-        if(_zz_145)begin
-          _zz_136 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_136 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_140 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_141 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_142 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_143 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_144 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_145 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_146 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_146 == 3'b000)) begin
-        _zz_147 = execute_BranchPlugin_eq;
-    end else if((_zz_146 == 3'b001)) begin
-        _zz_147 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_146 & 3'b101) == 3'b101))) begin
-        _zz_147 = (! execute_SRC_LESS);
-    end else begin
-        _zz_147 = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_148 = 1'b0;
+  assign switch_Misc_l199_3 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_3)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_148 = 1'b1;
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_148 = 1'b1;
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
       end
       default : begin
-        _zz_148 = _zz_147;
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
   assign execute_BranchPlugin_missAlignedTarget = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -4191,169 +4394,183 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_149 = _zz_340[11];
-  always @ (*) begin
-    _zz_150[19] = _zz_149;
-    _zz_150[18] = _zz_149;
-    _zz_150[17] = _zz_149;
-    _zz_150[16] = _zz_149;
-    _zz_150[15] = _zz_149;
-    _zz_150[14] = _zz_149;
-    _zz_150[13] = _zz_149;
-    _zz_150[12] = _zz_149;
-    _zz_150[11] = _zz_149;
-    _zz_150[10] = _zz_149;
-    _zz_150[9] = _zz_149;
-    _zz_150[8] = _zz_149;
-    _zz_150[7] = _zz_149;
-    _zz_150[6] = _zz_149;
-    _zz_150[5] = _zz_149;
-    _zz_150[4] = _zz_149;
-    _zz_150[3] = _zz_149;
-    _zz_150[2] = _zz_149;
-    _zz_150[1] = _zz_149;
-    _zz_150[0] = _zz_149;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_150,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_152,{{{_zz_592,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_154,{{{_zz_593,_zz_594},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_343};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_151 = _zz_341[19];
-  always @ (*) begin
-    _zz_152[10] = _zz_151;
-    _zz_152[9] = _zz_151;
-    _zz_152[8] = _zz_151;
-    _zz_152[7] = _zz_151;
-    _zz_152[6] = _zz_151;
-    _zz_152[5] = _zz_151;
-    _zz_152[4] = _zz_151;
-    _zz_152[3] = _zz_151;
-    _zz_152[2] = _zz_151;
-    _zz_152[1] = _zz_151;
-    _zz_152[0] = _zz_151;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_153 = _zz_342[11];
-  always @ (*) begin
-    _zz_154[18] = _zz_153;
-    _zz_154[17] = _zz_153;
-    _zz_154[16] = _zz_153;
-    _zz_154[15] = _zz_153;
-    _zz_154[14] = _zz_153;
-    _zz_154[13] = _zz_153;
-    _zz_154[12] = _zz_153;
-    _zz_154[11] = _zz_153;
-    _zz_154[10] = _zz_153;
-    _zz_154[9] = _zz_153;
-    _zz_154[8] = _zz_153;
-    _zz_154[7] = _zz_153;
-    _zz_154[6] = _zz_153;
-    _zz_154[5] = _zz_153;
-    _zz_154[4] = _zz_153;
-    _zz_154[3] = _zz_153;
-    _zz_154[2] = _zz_153;
-    _zz_154[1] = _zz_153;
-    _zz_154[0] = _zz_153;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_155 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_156 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_157 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_158 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_159 = _zz_344[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_245)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -4364,8 +4581,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -4375,135 +4592,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_261)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_262)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_263)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_262)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_263)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4516,39 +4742,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_261)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_261)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_279)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_4 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_4)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_264)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4561,8 +4797,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_264)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4581,58 +4817,69 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_346) + $signed(_zz_347));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_240)begin
-      if(_zz_265)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_266)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_351);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_160 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_160[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_352);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_353 : _zz_354);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_355[31:0];
-  assign _zz_161 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_162 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_163 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_164[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_164[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_166 = (_zz_165 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_166 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_267)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -4642,9 +4889,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_167))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4653,12 +4900,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_267)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -4669,35 +4917,114 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_52 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_15 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_18 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_39 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4718,9 +5045,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_169)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -4729,242 +5062,273 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_170[12 : 0] = 13'h1000;
-      _zz_170[25 : 20] = 6'h20;
+  assign when_Fetcher_l360 = (switch_Fetcher_l362 != 3'b000);
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_Fetcher_l398 = (switch_Fetcher_l362 != 3'b000);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_171[3 : 0] = 4'b1011;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 0] = 4'b1011;
     end
   end
 
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_172[4 : 0] = 5'h16;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[4 : 0] = 5'h16;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_173[5 : 0] = 6'h21;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 0] = 6'h21;
     end
   end
 
-  always @ (*) begin
-    _zz_174 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_174[31 : 30] = CsrPlugin_misa_base;
-      _zz_174[25 : 0] = CsrPlugin_misa_extensions;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_175[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_175[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_175[3 : 3] = CsrPlugin_mstatus_MIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_176[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_176[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_176[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_177[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_177[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_177[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_178[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_178[1 : 0] = CsrPlugin_mtvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_179[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_180[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_181[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_181[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_182[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_183 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_183[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_184 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_184[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_185 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_185[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_186 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_186[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_187 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_187[31 : 0] = CsrPlugin_mcycle[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_188 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_188[31 : 0] = CsrPlugin_mcycle[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_189 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_189[31 : 0] = CsrPlugin_minstret[31 : 0];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_190 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_190[31 : 0] = CsrPlugin_minstret[63 : 32];
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_191 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_191[31 : 0] = _zz_165;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_192 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_192[31 : 0] = _zz_166;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_170 | _zz_171) | (_zz_172 | _zz_173)) | ((_zz_595 | _zz_174) | (_zz_175 | _zz_176))) | (((_zz_177 | _zz_178) | (_zz_179 | _zz_180)) | ((_zz_181 | _zz_182) | (_zz_183 | _zz_184)))) | (((_zz_185 | _zz_186) | (_zz_187 | _zz_188)) | ((_zz_189 | _zz_190) | (_zz_191 | _zz_192))));
-  assign iBusWishbone_ADR = {_zz_372,_zz_193};
-  assign iBusWishbone_CTI = ((_zz_193 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_268)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_268)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_194;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_200 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_196 = dBus_cmd_valid;
-  assign _zz_198 = dBus_cmd_payload_wr;
-  assign _zz_199 = (_zz_195 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_197 && (_zz_198 || _zz_199));
-  assign dBusWishbone_ADR = ((_zz_200 ? {{dBus_cmd_payload_address[31 : 5],_zz_195},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_200 ? (_zz_199 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_198 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_198;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_197 = (_zz_196 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_196;
-  assign dBusWishbone_STB = _zz_196;
-  assign dBus_rsp_valid = _zz_201;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
       IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_65 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
-      _zz_93 <= 1'b0;
+      _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_104;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_105;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_125 <= 1'b1;
-      _zz_137 <= 1'b0;
+      _zz_2 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4985,163 +5349,163 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_165 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_169 <= 3'b000;
-      _zz_193 <= 3'b000;
-      _zz_194 <= 1'b0;
-      _zz_195 <= 3'b000;
-      _zz_201 <= 1'b0;
+      switch_Fetcher_l362 <= 3'b000;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if((decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode)))begin
+      if(when_Fetcher_l180) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
       end
-      if(_zz_253)begin
+      if(when_Fetcher_l192) begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_63)begin
-        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if((IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready))begin
+      if(when_Fetcher_l279) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
       end
-      if((IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid))begin
+      if(when_Fetcher_l283) begin
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(_zz_269)begin
-        if(IBusCachedPlugin_decompressor_bufferFill)begin
+      if(when_Fetcher_l286) begin
+        if(IBusCachedPlugin_decompressor_bufferFill) begin
           IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
         end
       end
-      if((IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent))begin
+      if(when_Fetcher_l291) begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(decode_arbitration_removeIt)begin
-        _zz_93 <= 1'b0;
+      if(decode_arbitration_removeIt) begin
+        _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_decompressor_output_ready)begin
-        _zz_93 <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
+      if(IBusCachedPlugin_decompressor_output_ready) begin
+        _zz_IBusCachedPlugin_injector_decodeInput_valid <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
       end
-      if((! 1'b0))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_decodePc_flushed)begin
+      if(IBusCachedPlugin_decodePc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_270)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_125 <= 1'b0;
-      _zz_137 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_2 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_271)begin
-        if(_zz_272)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_273)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_274)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_249)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5152,8 +5516,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_250)begin
-        case(_zz_252)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5163,166 +5527,172 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_157,{_zz_156,_zz_155}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_169)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_169 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_169 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_169 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_169 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_169 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_365[0];
-          CsrPlugin_mstatus_MIE <= _zz_366[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_368[0];
-          CsrPlugin_mie_MTIE <= _zz_369[0];
-          CsrPlugin_mie_MSIE <= _zz_370[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_165 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_268)begin
-        if(iBusWishbone_ACK)begin
-          _zz_193 <= (_zz_193 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_194 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_196 && _zz_197))begin
-        _zz_195 <= (_zz_195 + 3'b001);
-        if(_zz_199)begin
-          _zz_195 <= 3'b000;
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_201 <= ((_zz_196 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_269)begin
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_decompressor_input_valid) begin
+      IBusCachedPlugin_decompressor_bufferValidLatch <= IBusCachedPlugin_decompressor_bufferValid;
+    end
+    if(IBusCachedPlugin_decompressor_input_valid) begin
+      IBusCachedPlugin_decompressor_throw2BytesLatch <= IBusCachedPlugin_decompressor_throw2Bytes;
+    end
+    if(when_Fetcher_l286) begin
       IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
-    if(IBusCachedPlugin_decompressor_output_ready)begin
-      _zz_94 <= IBusCachedPlugin_decompressor_output_payload_pc;
-      _zz_95 <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
-      _zz_96 <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
-      _zz_97 <= IBusCachedPlugin_decompressor_output_payload_isRvc;
+    if(IBusCachedPlugin_decompressor_output_ready) begin
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_pc <= IBusCachedPlugin_decompressor_output_payload_pc;
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc <= IBusCachedPlugin_decompressor_output_payload_isRvc;
     end
-    if(IBusCachedPlugin_injector_decodeInput_ready)begin
+    if(IBusCachedPlugin_injector_decodeInput_ready) begin
       IBusCachedPlugin_injector_formal_rawInDecode <= IBusCachedPlugin_decompressor_raw;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(_zz_270)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_138 <= _zz_40[11 : 7];
-    _zz_139 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_245)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_159 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_159 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_271)begin
-      if(_zz_272)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_273)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_274)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_249)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -5330,405 +5700,422 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_240)begin
-      if(_zz_265)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_356[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_266)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_163 ? (~ _zz_164) : _zz_164) + _zz_362);
-      memory_DivPlugin_rs2 <= ((_zz_162 ? (~ execute_RS2) : execute_RS2) + _zz_364);
-      memory_DivPlugin_div_needRevert <= ((_zz_163 ^ (_zz_162 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_6) begin
       decode_to_execute_IS_RVC <= decode_IS_RVC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54;
+    if(when_Pipeline_l124_7) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_8) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_9) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_10) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_11) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_15) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_17) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_28) begin
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_29) begin
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_30) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_31) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_32) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_35) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_38) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_39) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_54) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_55) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_56) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_57) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_63) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_64) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_65) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((_zz_169 != 3'b000))begin
-      _zz_96 <= IBusCachedPlugin_injectionPort_payload;
+    if(when_Fetcher_l398) begin
+      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst <= IBusCachedPlugin_injectionPort_payload;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_367[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_371[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_167 <= debug_bus_cmd_payload_address[2];
-    if(_zz_247)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
-      _zz_168 <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
+      _zz_3 <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_267)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -5736,18 +6123,18 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_247)begin
-        if(_zz_248)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_251)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
-      _zz_168 <= (DebugPlugin_stepIt && decode_arbitration_isFiring);
+      _zz_3 <= (DebugPlugin_stepIt && decode_arbitration_isFiring);
     end
   end
 
@@ -5757,9 +6144,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_isLrsc,
   input               io_cpu_execute_args_totalyConsistent,
@@ -5782,6 +6168,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -5797,9 +6184,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5807,7 +6195,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -5816,27 +6204,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire                _zz_19;
-  wire                _zz_20;
-  wire       [0:0]    _zz_21;
-  wire       [0:0]    _zz_22;
-  wire       [9:0]    _zz_23;
-  wire       [9:0]    _zz_24;
-  wire       [0:0]    _zz_25;
-  wire       [0:0]    _zz_26;
-  wire       [0:0]    _zz_27;
-  wire       [2:0]    _zz_28;
-  wire       [1:0]    _zz_29;
-  wire       [21:0]   _zz_30;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -5861,42 +6237,50 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5906,35 +6290,56 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   reg                 stageB_lrSc_reserved;
+  wire                when_DataCache_l866;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l984;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1010;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5946,62 +6351,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_31;
-  reg [7:0] _zz_32;
-  reg [7:0] _zz_33;
-  reg [7:0] _zz_34;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_16 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_17 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_18 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_19 = (! stageB_flusher_hold);
-  assign _zz_20 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_21 = _zz_4[0 : 0];
-  assign _zz_22 = _zz_4[1 : 1];
-  assign _zz_23 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_24 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_25 = 1'b1;
-  assign _zz_26 = (! stageB_lrSc_reserved);
-  assign _zz_27 = loader_counter_willIncrement;
-  assign _zz_28 = {2'd0, _zz_27};
-  assign _zz_29 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_30 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_30;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_34, _zz_33, _zz_32, _zz_31};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_31 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_32 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_33 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_34 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -6016,291 +6413,311 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_21[0];
-  assign ways_0_tagsReadRsp_error = _zz_22[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1010) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_25[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_23)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_24)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(_zz_18)begin
+          if(when_DataCache_l984) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
-            if(_zz_16)begin
+            if(when_DataCache_l1010) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l866 = ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6308,95 +6725,79 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(_zz_18)begin
+          if(when_DataCache_l984) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
-            if(_zz_16)begin
+            if(when_DataCache_l1010) begin
               io_mem_cmd_valid = 1'b0;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -6404,12 +6805,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6420,23 +6821,43 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l984 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1010 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_26};
-    end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_17)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6444,47 +6865,49 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_28);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6495,46 +6918,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_19)begin
-        if(_zz_20)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -6543,27 +6957,29 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_19)begin
-          if(! _zz_20) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
-      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+      if(when_DataCache_l866) begin
         stageB_lrSc_reserved <= (! stageB_request_wr);
       end
-      if(_zz_13)begin
+      if(when_DataCache_l1051) begin
         stageB_lrSc_reserved <= stageB_lrSc_reserved;
       end
       `ifndef SYNTHESIS
@@ -6571,28 +6987,27 @@ module DataCache (
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_17)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_29[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -6642,13 +7057,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6657,8 +7068,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6672,16 +7088,17 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
@@ -6690,77 +7107,78 @@ module InstructionCache (
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6776,16 +7194,17 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
@@ -6797,7 +7216,7 @@ module InstructionCache (
   assign io_cpu_fetch_error = (fetchStage_hit_error || ((! io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute))));
   assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuRsp_refilling;
   assign io_cpu_fetch_mmuException = (((! io_cpu_fetch_mmuRsp_refilling) && io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute)));
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -6805,45 +7224,45 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -81,66 +81,42 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_205;
-  wire                _zz_206;
-  wire                _zz_207;
-  wire                _zz_208;
-  wire                _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire                _zz_212;
-  reg                 _zz_213;
-  reg                 _zz_214;
-  reg        [31:0]   _zz_215;
-  reg                 _zz_216;
-  reg        [31:0]   _zz_217;
-  reg        [1:0]    _zz_218;
-  reg                 _zz_219;
-  reg                 _zz_220;
-  wire                _zz_221;
-  wire       [2:0]    _zz_222;
-  reg                 _zz_223;
-  wire       [31:0]   _zz_224;
-  reg                 _zz_225;
-  reg                 _zz_226;
-  wire                _zz_227;
-  wire       [31:0]   _zz_228;
-  wire                _zz_229;
-  wire                _zz_230;
-  wire                _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire       [3:0]    _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  reg        [31:0]   _zz_240;
-  reg        [31:0]   _zz_241;
-  reg        [31:0]   _zz_242;
-  reg                 _zz_243;
-  reg                 _zz_244;
-  reg                 _zz_245;
-  reg        [9:0]    _zz_246;
-  reg        [9:0]    _zz_247;
-  reg        [9:0]    _zz_248;
-  reg        [9:0]    _zz_249;
-  reg                 _zz_250;
-  reg                 _zz_251;
-  reg                 _zz_252;
-  reg                 _zz_253;
-  reg                 _zz_254;
-  reg                 _zz_255;
-  reg                 _zz_256;
-  reg        [9:0]    _zz_257;
-  reg        [9:0]    _zz_258;
-  reg        [9:0]    _zz_259;
-  reg        [9:0]    _zz_260;
-  reg                 _zz_261;
-  reg                 _zz_262;
-  reg                 _zz_263;
-  reg                 _zz_264;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  reg                 dataCache_1_io_cpu_execute_isValid;
+  reg        [31:0]   dataCache_1_io_cpu_execute_address;
+  reg                 dataCache_1_io_cpu_execute_args_wr;
+  reg        [1:0]    dataCache_1_io_cpu_execute_args_size;
+  reg                 dataCache_1_io_cpu_execute_args_isLrsc;
+  wire                dataCache_1_io_cpu_execute_args_amoCtrl_swap;
+  wire       [2:0]    dataCache_1_io_cpu_execute_args_amoCtrl_alu;
+  reg                 dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -163,6 +139,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -171,445 +148,351 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_265;
-  wire                _zz_266;
-  wire                _zz_267;
-  wire                _zz_268;
-  wire                _zz_269;
-  wire                _zz_270;
-  wire                _zz_271;
-  wire                _zz_272;
-  wire                _zz_273;
-  wire                _zz_274;
-  wire                _zz_275;
-  wire                _zz_276;
-  wire                _zz_277;
-  wire                _zz_278;
-  wire       [1:0]    _zz_279;
-  wire                _zz_280;
-  wire                _zz_281;
-  wire                _zz_282;
-  wire                _zz_283;
-  wire                _zz_284;
-  wire                _zz_285;
-  wire                _zz_286;
-  wire                _zz_287;
-  wire                _zz_288;
-  wire                _zz_289;
-  wire                _zz_290;
-  wire                _zz_291;
-  wire                _zz_292;
-  wire                _zz_293;
-  wire                _zz_294;
-  wire       [1:0]    _zz_295;
-  wire                _zz_296;
-  wire                _zz_297;
-  wire                _zz_298;
-  wire                _zz_299;
-  wire                _zz_300;
-  wire                _zz_301;
-  wire                _zz_302;
-  wire                _zz_303;
-  wire                _zz_304;
-  wire                _zz_305;
-  wire                _zz_306;
-  wire                _zz_307;
-  wire                _zz_308;
-  wire                _zz_309;
-  wire                _zz_310;
-  wire                _zz_311;
-  wire                _zz_312;
-  wire                _zz_313;
-  wire                _zz_314;
-  wire                _zz_315;
-  wire                _zz_316;
-  wire                _zz_317;
-  wire                _zz_318;
-  wire                _zz_319;
-  wire       [1:0]    _zz_320;
-  wire                _zz_321;
-  wire       [1:0]    _zz_322;
-  wire       [51:0]   _zz_323;
-  wire       [51:0]   _zz_324;
-  wire       [51:0]   _zz_325;
-  wire       [32:0]   _zz_326;
-  wire       [51:0]   _zz_327;
-  wire       [49:0]   _zz_328;
-  wire       [51:0]   _zz_329;
-  wire       [49:0]   _zz_330;
-  wire       [51:0]   _zz_331;
-  wire       [32:0]   _zz_332;
-  wire       [31:0]   _zz_333;
-  wire       [32:0]   _zz_334;
-  wire       [0:0]    _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [0:0]    _zz_337;
-  wire       [0:0]    _zz_338;
-  wire       [0:0]    _zz_339;
-  wire       [0:0]    _zz_340;
-  wire       [0:0]    _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [0:0]    _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [0:0]    _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [0:0]    _zz_348;
-  wire       [0:0]    _zz_349;
-  wire       [0:0]    _zz_350;
-  wire       [0:0]    _zz_351;
-  wire       [0:0]    _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [0:0]    _zz_354;
-  wire       [4:0]    _zz_355;
-  wire       [2:0]    _zz_356;
-  wire       [31:0]   _zz_357;
-  wire       [11:0]   _zz_358;
-  wire       [31:0]   _zz_359;
-  wire       [19:0]   _zz_360;
-  wire       [11:0]   _zz_361;
-  wire       [31:0]   _zz_362;
-  wire       [31:0]   _zz_363;
-  wire       [19:0]   _zz_364;
-  wire       [11:0]   _zz_365;
-  wire       [2:0]    _zz_366;
-  wire       [2:0]    _zz_367;
-  wire       [0:0]    _zz_368;
-  wire       [1:0]    _zz_369;
-  wire       [0:0]    _zz_370;
-  wire       [1:0]    _zz_371;
-  wire       [0:0]    _zz_372;
-  wire       [0:0]    _zz_373;
-  wire       [0:0]    _zz_374;
-  wire       [0:0]    _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [0:0]    _zz_377;
-  wire       [0:0]    _zz_378;
-  wire       [0:0]    _zz_379;
-  wire       [1:0]    _zz_380;
-  wire       [0:0]    _zz_381;
-  wire       [2:0]    _zz_382;
-  wire       [4:0]    _zz_383;
-  wire       [11:0]   _zz_384;
-  wire       [11:0]   _zz_385;
-  wire       [31:0]   _zz_386;
-  wire       [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
-  wire       [31:0]   _zz_390;
-  wire       [31:0]   _zz_391;
-  wire       [31:0]   _zz_392;
-  wire       [11:0]   _zz_393;
-  wire       [19:0]   _zz_394;
-  wire       [11:0]   _zz_395;
-  wire       [31:0]   _zz_396;
-  wire       [31:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [11:0]   _zz_399;
-  wire       [19:0]   _zz_400;
-  wire       [11:0]   _zz_401;
-  wire       [2:0]    _zz_402;
-  wire       [1:0]    _zz_403;
-  wire       [1:0]    _zz_404;
-  wire       [65:0]   _zz_405;
-  wire       [65:0]   _zz_406;
-  wire       [31:0]   _zz_407;
-  wire       [31:0]   _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [5:0]    _zz_410;
-  wire       [32:0]   _zz_411;
-  wire       [31:0]   _zz_412;
-  wire       [31:0]   _zz_413;
-  wire       [32:0]   _zz_414;
-  wire       [32:0]   _zz_415;
-  wire       [32:0]   _zz_416;
-  wire       [32:0]   _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [32:0]   _zz_419;
-  wire       [0:0]    _zz_420;
-  wire       [32:0]   _zz_421;
-  wire       [0:0]    _zz_422;
-  wire       [31:0]   _zz_423;
-  wire       [0:0]    _zz_424;
-  wire       [0:0]    _zz_425;
-  wire       [0:0]    _zz_426;
-  wire       [0:0]    _zz_427;
-  wire       [0:0]    _zz_428;
-  wire       [0:0]    _zz_429;
-  wire       [0:0]    _zz_430;
-  wire       [0:0]    _zz_431;
-  wire       [0:0]    _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [0:0]    _zz_434;
-  wire       [0:0]    _zz_435;
-  wire       [0:0]    _zz_436;
-  wire       [0:0]    _zz_437;
-  wire       [0:0]    _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [0:0]    _zz_441;
-  wire       [0:0]    _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [0:0]    _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [0:0]    _zz_446;
-  wire       [0:0]    _zz_447;
-  wire       [0:0]    _zz_448;
-  wire       [0:0]    _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [0:0]    _zz_451;
-  wire       [0:0]    _zz_452;
-  wire       [0:0]    _zz_453;
-  wire       [0:0]    _zz_454;
-  wire       [0:0]    _zz_455;
-  wire       [0:0]    _zz_456;
-  wire       [0:0]    _zz_457;
-  wire       [0:0]    _zz_458;
-  wire       [0:0]    _zz_459;
-  wire       [0:0]    _zz_460;
-  wire       [0:0]    _zz_461;
-  wire       [0:0]    _zz_462;
-  wire       [0:0]    _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [0:0]    _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [0:0]    _zz_467;
-  wire       [0:0]    _zz_468;
-  wire       [26:0]   _zz_469;
-  wire                _zz_470;
-  wire                _zz_471;
-  wire       [2:0]    _zz_472;
-  wire       [31:0]   _zz_473;
-  wire       [31:0]   _zz_474;
-  wire       [31:0]   _zz_475;
-  wire                _zz_476;
-  wire       [0:0]    _zz_477;
-  wire       [17:0]   _zz_478;
-  wire       [31:0]   _zz_479;
-  wire       [31:0]   _zz_480;
-  wire       [31:0]   _zz_481;
-  wire                _zz_482;
-  wire       [0:0]    _zz_483;
-  wire       [11:0]   _zz_484;
-  wire       [31:0]   _zz_485;
-  wire       [31:0]   _zz_486;
-  wire       [31:0]   _zz_487;
-  wire                _zz_488;
-  wire       [0:0]    _zz_489;
-  wire       [5:0]    _zz_490;
-  wire       [31:0]   _zz_491;
-  wire       [31:0]   _zz_492;
-  wire       [31:0]   _zz_493;
-  wire                _zz_494;
-  wire                _zz_495;
-  wire                _zz_496;
-  wire                _zz_497;
-  wire                _zz_498;
-  wire       [31:0]   _zz_499;
-  wire       [31:0]   _zz_500;
-  wire                _zz_501;
-  wire       [0:0]    _zz_502;
-  wire       [0:0]    _zz_503;
-  wire                _zz_504;
-  wire       [0:0]    _zz_505;
-  wire       [27:0]   _zz_506;
-  wire       [31:0]   _zz_507;
-  wire                _zz_508;
-  wire                _zz_509;
-  wire       [0:0]    _zz_510;
-  wire       [0:0]    _zz_511;
-  wire       [0:0]    _zz_512;
-  wire       [0:0]    _zz_513;
-  wire                _zz_514;
-  wire       [0:0]    _zz_515;
-  wire       [23:0]   _zz_516;
-  wire       [31:0]   _zz_517;
-  wire       [31:0]   _zz_518;
-  wire                _zz_519;
-  wire                _zz_520;
-  wire       [0:0]    _zz_521;
-  wire       [1:0]    _zz_522;
-  wire       [0:0]    _zz_523;
-  wire       [0:0]    _zz_524;
-  wire                _zz_525;
-  wire       [0:0]    _zz_526;
-  wire       [20:0]   _zz_527;
-  wire       [31:0]   _zz_528;
-  wire       [31:0]   _zz_529;
-  wire       [31:0]   _zz_530;
-  wire       [31:0]   _zz_531;
-  wire       [31:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire       [0:0]    _zz_536;
-  wire       [0:0]    _zz_537;
-  wire       [0:0]    _zz_538;
-  wire       [0:0]    _zz_539;
-  wire                _zz_540;
-  wire       [0:0]    _zz_541;
-  wire       [17:0]   _zz_542;
-  wire       [31:0]   _zz_543;
-  wire       [31:0]   _zz_544;
-  wire       [31:0]   _zz_545;
-  wire       [31:0]   _zz_546;
-  wire       [31:0]   _zz_547;
-  wire                _zz_548;
-  wire       [3:0]    _zz_549;
-  wire       [3:0]    _zz_550;
-  wire                _zz_551;
-  wire       [0:0]    _zz_552;
-  wire       [14:0]   _zz_553;
-  wire       [31:0]   _zz_554;
-  wire       [31:0]   _zz_555;
-  wire                _zz_556;
-  wire       [0:0]    _zz_557;
-  wire       [0:0]    _zz_558;
-  wire       [31:0]   _zz_559;
-  wire       [31:0]   _zz_560;
-  wire                _zz_561;
-  wire       [5:0]    _zz_562;
-  wire       [5:0]    _zz_563;
-  wire                _zz_564;
-  wire       [0:0]    _zz_565;
-  wire       [11:0]   _zz_566;
-  wire       [31:0]   _zz_567;
-  wire       [31:0]   _zz_568;
-  wire       [31:0]   _zz_569;
-  wire       [31:0]   _zz_570;
-  wire                _zz_571;
-  wire       [0:0]    _zz_572;
-  wire       [2:0]    _zz_573;
-  wire                _zz_574;
-  wire       [0:0]    _zz_575;
-  wire       [0:0]    _zz_576;
-  wire       [0:0]    _zz_577;
-  wire       [3:0]    _zz_578;
-  wire       [4:0]    _zz_579;
-  wire       [4:0]    _zz_580;
-  wire                _zz_581;
-  wire       [0:0]    _zz_582;
-  wire       [8:0]    _zz_583;
-  wire       [31:0]   _zz_584;
-  wire       [31:0]   _zz_585;
-  wire       [31:0]   _zz_586;
-  wire                _zz_587;
-  wire       [0:0]    _zz_588;
-  wire       [0:0]    _zz_589;
-  wire       [31:0]   _zz_590;
-  wire       [31:0]   _zz_591;
-  wire       [31:0]   _zz_592;
-  wire       [31:0]   _zz_593;
-  wire       [31:0]   _zz_594;
-  wire       [31:0]   _zz_595;
-  wire       [31:0]   _zz_596;
-  wire                _zz_597;
-  wire       [0:0]    _zz_598;
-  wire       [1:0]    _zz_599;
-  wire       [0:0]    _zz_600;
-  wire       [2:0]    _zz_601;
-  wire       [0:0]    _zz_602;
-  wire       [5:0]    _zz_603;
-  wire       [1:0]    _zz_604;
-  wire       [1:0]    _zz_605;
-  wire                _zz_606;
-  wire       [0:0]    _zz_607;
-  wire       [6:0]    _zz_608;
-  wire       [31:0]   _zz_609;
-  wire       [31:0]   _zz_610;
-  wire       [31:0]   _zz_611;
-  wire       [31:0]   _zz_612;
-  wire       [31:0]   _zz_613;
-  wire       [31:0]   _zz_614;
-  wire       [31:0]   _zz_615;
-  wire       [31:0]   _zz_616;
-  wire                _zz_617;
-  wire       [31:0]   _zz_618;
-  wire       [31:0]   _zz_619;
-  wire                _zz_620;
-  wire       [0:0]    _zz_621;
-  wire       [0:0]    _zz_622;
-  wire                _zz_623;
-  wire       [0:0]    _zz_624;
-  wire       [3:0]    _zz_625;
-  wire                _zz_626;
-  wire       [0:0]    _zz_627;
-  wire       [0:0]    _zz_628;
-  wire       [0:0]    _zz_629;
-  wire       [0:0]    _zz_630;
-  wire                _zz_631;
-  wire       [0:0]    _zz_632;
-  wire       [4:0]    _zz_633;
-  wire       [31:0]   _zz_634;
-  wire       [31:0]   _zz_635;
-  wire       [31:0]   _zz_636;
-  wire       [31:0]   _zz_637;
-  wire       [31:0]   _zz_638;
-  wire       [31:0]   _zz_639;
-  wire       [31:0]   _zz_640;
-  wire       [31:0]   _zz_641;
-  wire       [31:0]   _zz_642;
-  wire                _zz_643;
-  wire       [0:0]    _zz_644;
-  wire       [1:0]    _zz_645;
-  wire       [31:0]   _zz_646;
-  wire       [31:0]   _zz_647;
-  wire       [31:0]   _zz_648;
-  wire       [31:0]   _zz_649;
-  wire       [31:0]   _zz_650;
-  wire                _zz_651;
-  wire       [4:0]    _zz_652;
-  wire       [4:0]    _zz_653;
-  wire                _zz_654;
-  wire       [0:0]    _zz_655;
-  wire       [2:0]    _zz_656;
-  wire       [31:0]   _zz_657;
-  wire       [31:0]   _zz_658;
-  wire       [31:0]   _zz_659;
-  wire                _zz_660;
-  wire       [31:0]   _zz_661;
-  wire                _zz_662;
-  wire       [0:0]    _zz_663;
-  wire       [2:0]    _zz_664;
-  wire       [0:0]    _zz_665;
-  wire       [0:0]    _zz_666;
-  wire       [2:0]    _zz_667;
-  wire       [2:0]    _zz_668;
-  wire                _zz_669;
-  wire       [0:0]    _zz_670;
-  wire       [0:0]    _zz_671;
-  wire       [31:0]   _zz_672;
-  wire       [31:0]   _zz_673;
-  wire       [31:0]   _zz_674;
-  wire       [31:0]   _zz_675;
-  wire                _zz_676;
-  wire       [0:0]    _zz_677;
-  wire       [0:0]    _zz_678;
-  wire       [31:0]   _zz_679;
-  wire       [31:0]   _zz_680;
-  wire                _zz_681;
-  wire       [0:0]    _zz_682;
-  wire       [0:0]    _zz_683;
-  wire       [0:0]    _zz_684;
-  wire       [1:0]    _zz_685;
-  wire       [1:0]    _zz_686;
-  wire       [1:0]    _zz_687;
-  wire       [0:0]    _zz_688;
-  wire       [0:0]    _zz_689;
-  wire       [31:0]   _zz_690;
-  wire       [31:0]   _zz_691;
-  wire       [31:0]   _zz_692;
-  wire       [31:0]   _zz_693;
-  wire       [31:0]   _zz_694;
-  wire       [31:0]   _zz_695;
-  wire       [31:0]   _zz_696;
-  wire       [31:0]   _zz_697;
-  wire                _zz_698;
-  wire                _zz_699;
-  wire                _zz_700;
-  wire       [31:0]   _zz_701;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [17:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
+  wire                _zz_decode_LEGAL_INSTRUCTION_21;
+  wire                _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_7;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspRf;
+  wire       [9:0]    _zz_MmuPlugin_ports_0_cacheHitsCalc;
+  wire       [9:0]    _zz_MmuPlugin_ports_0_cacheHitsCalc_1;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_2;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_3;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_4;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_5;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_valid_4;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_exception;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_superPage;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowRead;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowWrite;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowExecute;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowUser;
+  wire       [1:0]    _zz_MmuPlugin_ports_0_entryToReplace_valueNext;
+  wire       [0:0]    _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1;
+  wire       [9:0]    _zz_MmuPlugin_ports_1_cacheHitsCalc;
+  wire       [9:0]    _zz_MmuPlugin_ports_1_cacheHitsCalc_1;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_2;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_3;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_4;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_5;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_valid_4;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_exception;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_superPage;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowRead;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowWrite;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowExecute;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowUser;
+  wire       [1:0]    _zz_MmuPlugin_ports_1_entryToReplace_valueNext;
+  wire       [0:0]    _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1;
+  wire       [1:0]    _zz__zz_MmuPlugin_shared_refills_2;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [28:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [21:0]   _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [18:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_168;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_169;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_170;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_171;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_172;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_173;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_174;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_175;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_176;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_177;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_178;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_179;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_180;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_181;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_182;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_183;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_184;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_185;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_186;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_187;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_188;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_189;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_190;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_191;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_192;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_193;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_194;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_195;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -621,8 +504,8 @@ module VexRiscv (
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire                execute_IS_DBUS_SHARING;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
@@ -633,49 +516,49 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire                memory_IS_SFENCE_VMA;
-  wire                execute_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA;
+  wire                decode_IS_SFENCE_VMA2;
   wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_LRSC;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -696,11 +579,12 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
+  wire                execute_IS_SFENCE_VMA;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -708,10 +592,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -721,54 +605,55 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  wire                writeBack_IS_SFENCE_VMA;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  wire                execute_IS_SFENCE_VMA2;
   wire                writeBack_IS_DBUS_SHARING;
   wire                memory_IS_DBUS_SHARING;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   _zz_decode_RS2_2;
+  wire                writeBack_MEMORY_LRSC;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MEMORY_AMO;
-  wire                execute_MEMORY_LRSC;
+  reg                 execute_MEMORY_AMO;
+  reg                 execute_MEMORY_LRSC;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
@@ -778,7 +663,7 @@ module VexRiscv (
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_AMO;
   wire                decode_MEMORY_LRSC;
-  reg                 _zz_51;
+  reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
   reg                 IBusCachedPlugin_rsp_issueDetected_4;
@@ -786,11 +671,11 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53;
-  reg        [31:0]   _zz_54;
-  reg        [31:0]   _zz_55;
+  reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -885,7 +770,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -938,6 +823,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -958,29 +848,35 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [4:0]    _zz_56;
-  wire       [4:0]    _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
+  wire       [4:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [4:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -1003,16 +899,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_62;
-  wire                _zz_63;
-  wire                _zz_64;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_65;
-  wire                _zz_66;
-  reg                 _zz_67;
-  wire                _zz_68;
-  reg                 _zz_69;
-  reg        [31:0]   _zz_70;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1020,22 +918,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_71;
-  reg        [18:0]   _zz_72;
-  wire                _zz_73;
-  reg        [10:0]   _zz_74;
-  wire                _zz_75;
-  reg        [18:0]   _zz_76;
-  reg                 _zz_77;
-  wire                _zz_78;
-  reg        [10:0]   _zz_79;
-  wire                _zz_80;
-  reg        [18:0]   _zz_81;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1043,7 +948,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_82;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1051,6 +956,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -1058,7 +968,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -1066,8 +976,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -1075,27 +986,44 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_83;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l311;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_84;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_85;
-  reg        [31:0]   _zz_86;
-  wire                _zz_87;
-  reg        [31:0]   _zz_88;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire                when_DBusCachedPlugin_l474;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
+  wire                when_DBusCachedPlugin_l484;
   reg                 DBusCachedPlugin_forceDatapath;
+  wire                when_DBusCachedPlugin_l498;
+  wire                when_DBusCachedPlugin_l499;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
@@ -1148,12 +1076,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
   wire                MmuPlugin_ports_0_dirty;
   reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
-  reg        [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
+  wire                when_MmuPlugin_l125;
+  wire                when_MmuPlugin_l126;
+  wire       [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
-  wire                _zz_89;
-  wire                _zz_90;
-  wire                _zz_91;
-  wire       [1:0]    _zz_92;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid_1;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid_2;
+  wire       [1:0]    _zz_MmuPlugin_ports_0_cacheLine_valid_3;
   wire                MmuPlugin_ports_0_cacheLine_valid;
   wire                MmuPlugin_ports_0_cacheLine_exception;
   wire                MmuPlugin_ports_0_cacheLine_superPage;
@@ -1217,12 +1147,15 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
   wire                MmuPlugin_ports_1_dirty;
   reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
-  reg        [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
+  wire                when_MmuPlugin_l125_1;
+  wire                when_MmuPlugin_l126_1;
+  wire                when_MmuPlugin_l128;
+  wire       [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
-  wire                _zz_93;
-  wire                _zz_94;
-  wire                _zz_95;
-  wire       [1:0]    _zz_96;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid_1;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid_2;
+  wire       [1:0]    _zz_MmuPlugin_ports_1_cacheLine_valid_3;
   wire                MmuPlugin_ports_1_cacheLine_valid;
   wire                MmuPlugin_ports_1_cacheLine_exception;
   wire                MmuPlugin_ports_1_cacheLine_superPage;
@@ -1261,6 +1194,7 @@ module VexRiscv (
   wire       [11:0]   MmuPlugin_shared_dBusRsp_pte_PPN1;
   wire                MmuPlugin_shared_dBusRsp_exception;
   wire                MmuPlugin_shared_dBusRsp_leaf;
+  wire                when_MmuPlugin_l205;
   reg                 MmuPlugin_shared_pteBuffer_V;
   reg                 MmuPlugin_shared_pteBuffer_R;
   reg                 MmuPlugin_shared_pteBuffer_W;
@@ -1272,27 +1206,42 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_shared_pteBuffer_RSW;
   reg        [9:0]    MmuPlugin_shared_pteBuffer_PPN0;
   reg        [11:0]   MmuPlugin_shared_pteBuffer_PPN1;
-  reg        [1:0]    _zz_97;
-  wire       [1:0]    _zz_98;
-  reg        [1:0]    _zz_99;
+  wire       [1:0]    _zz_MmuPlugin_shared_refills;
+  reg        [1:0]    _zz_MmuPlugin_shared_refills_1;
   wire       [1:0]    MmuPlugin_shared_refills;
-  wire       [1:0]    _zz_100;
-  reg        [1:0]    _zz_101;
-  wire       [31:0]   _zz_102;
-  wire       [34:0]   _zz_103;
-  wire                _zz_104;
-  wire                _zz_105;
-  wire                _zz_106;
-  wire                _zz_107;
-  wire                _zz_108;
-  wire                _zz_109;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_110;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_111;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_112;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_113;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_114;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_115;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_116;
+  wire       [1:0]    _zz_MmuPlugin_shared_refills_2;
+  reg        [1:0]    _zz_MmuPlugin_shared_refills_3;
+  wire                when_MmuPlugin_l217;
+  wire       [31:0]   _zz_MmuPlugin_shared_vpn_0;
+  wire                when_MmuPlugin_l243;
+  wire                when_MmuPlugin_l272;
+  wire                when_MmuPlugin_l274;
+  wire                when_MmuPlugin_l280;
+  wire                when_MmuPlugin_l280_1;
+  wire                when_MmuPlugin_l280_2;
+  wire                when_MmuPlugin_l280_3;
+  wire                when_MmuPlugin_l274_1;
+  wire                when_MmuPlugin_l280_4;
+  wire                when_MmuPlugin_l280_5;
+  wire                when_MmuPlugin_l280_6;
+  wire                when_MmuPlugin_l280_7;
+  wire                when_MmuPlugin_l304;
+  wire       [35:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz_decode_IS_RS2_SIGNED_7;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1300,54 +1249,72 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_117;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_118;
-  reg        [31:0]   _zz_119;
-  wire                _zz_120;
-  reg        [19:0]   _zz_121;
-  wire                _zz_122;
-  reg        [19:0]   _zz_123;
-  reg        [31:0]   _zz_124;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_125;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_126;
-  reg                 _zz_127;
-  reg                 _zz_128;
-  reg                 _zz_129;
-  reg        [4:0]    _zz_130;
-  reg        [31:0]   _zz_131;
-  wire                _zz_132;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_138;
-  reg                 _zz_139;
-  reg                 _zz_140;
-  wire                _zz_141;
-  reg        [19:0]   _zz_142;
-  wire                _zz_143;
-  reg        [10:0]   _zz_144;
-  wire                _zz_145;
-  reg        [18:0]   _zz_146;
-  reg                 _zz_147;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_148;
-  reg        [19:0]   _zz_149;
-  wire                _zz_150;
-  reg        [10:0]   _zz_151;
-  wire                _zz_152;
-  reg        [18:0]   _zz_153;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_154;
+  reg        [1:0]    _zz_CsrPlugin_privilege;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1404,12 +1371,14 @@ module VexRiscv (
   reg        [21:0]   CsrPlugin_satp_PPN;
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
-  wire                _zz_155;
-  wire                _zz_156;
-  wire                _zz_157;
-  wire                _zz_158;
-  wire                _zz_159;
-  wire                _zz_160;
+  reg                 CsrPlugin_rescheduleLogic_rescheduleNext;
+  wire                when_CsrPlugin_l803;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
+  wire                _zz_when_CsrPlugin_l952_3;
+  wire                _zz_when_CsrPlugin_l952_4;
+  wire                _zz_when_CsrPlugin_l952_5;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1421,41 +1390,87 @@ module VexRiscv (
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
+  wire                when_CsrPlugin_l866;
+  wire                when_CsrPlugin_l866_1;
+  wire                when_CsrPlugin_l866_2;
+  wire                when_CsrPlugin_l866_3;
+  wire                when_CsrPlugin_l866_4;
+  wire                when_CsrPlugin_l866_5;
+  wire                when_CsrPlugin_l866_6;
+  wire                when_CsrPlugin_l866_7;
+  wire                when_CsrPlugin_l866_8;
+  wire                when_CsrPlugin_l866_9;
+  wire                when_CsrPlugin_l866_10;
+  wire                when_CsrPlugin_l866_11;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_161;
-  wire                _zz_162;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l946_1;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l952_3;
+  wire                when_CsrPlugin_l952_4;
+  wire                when_CsrPlugin_l952_5;
+  wire                when_CsrPlugin_l952_6;
+  wire                when_CsrPlugin_l952_7;
+  wire                when_CsrPlugin_l952_8;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   reg        [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1463,6 +1478,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1475,229 +1492,345 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_163;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_164;
-  wire                _zz_165;
-  wire                _zz_166;
-  reg        [32:0]   _zz_167;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_168;
-  wire       [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  wire       [31:0]   _zz_171;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_LRSC;
+  wire                when_Pipeline_l124_27;
+  reg                 execute_to_memory_MEMORY_LRSC;
+  wire                when_Pipeline_l124_28;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_MEMORY_AMO;
+  wire                when_Pipeline_l124_30;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_31;
+  reg                 decode_to_execute_IS_SFENCE_VMA2;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_SFENCE_VMA;
-  reg                 execute_to_memory_IS_SFENCE_VMA;
-  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_34;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_36;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_37;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_38;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_39;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_40;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_41;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_43;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_44;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_46;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_49;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_50;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_51;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_52;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_53;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_54;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_55;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_56;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_57;
   reg                 execute_to_memory_IS_DBUS_SHARING;
+  wire                when_Pipeline_l124_58;
   reg                 memory_to_writeBack_IS_DBUS_SHARING;
+  wire                when_Pipeline_l124_59;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_60;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_61;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_62;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_63;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_64;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_65;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_66;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_67;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_68;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_69;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_256;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_384;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_770;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_771;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_324;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_260;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_261;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_321;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_320;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_322;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_323;
+  wire                when_CsrPlugin_l1264_24;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_25;
   reg                 execute_CsrPlugin_csr_4032;
+  wire                when_CsrPlugin_l1264_26;
   reg                 execute_CsrPlugin_csr_2496;
+  wire                when_CsrPlugin_l1264_27;
   reg                 execute_CsrPlugin_csr_3520;
-  reg        [31:0]   _zz_172;
-  reg        [31:0]   _zz_173;
-  reg        [31:0]   _zz_174;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [31:0]   _zz_183;
-  reg        [31:0]   _zz_184;
-  reg        [31:0]   _zz_185;
-  reg        [31:0]   _zz_186;
-  reg        [31:0]   _zz_187;
-  reg        [31:0]   _zz_188;
-  reg        [31:0]   _zz_189;
-  reg        [31:0]   _zz_190;
-  reg        [31:0]   _zz_191;
-  reg        [31:0]   _zz_192;
-  reg        [31:0]   _zz_193;
-  reg        [31:0]   _zz_194;
-  reg        [31:0]   _zz_195;
-  reg        [2:0]    _zz_196;
-  reg                 _zz_197;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  reg                 _zz_204;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
   reg [47:0] MmuPlugin_shared_state_1_string;
-  reg [95:0] _zz_110_string;
-  reg [63:0] _zz_111_string;
-  reg [23:0] _zz_112_string;
-  reg [39:0] _zz_113_string;
-  reg [71:0] _zz_114_string;
-  reg [31:0] _zz_115_string;
-  reg [39:0] _zz_116_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1706,753 +1839,661 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_265 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_266 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_267 = 1'b1;
-  assign _zz_268 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_269 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_270 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_271 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_272 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_273 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_274 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_275 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_276 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_277 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_278 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_279 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_280 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
-  assign _zz_281 = (! dataCache_1_io_cpu_execute_refilling);
-  assign _zz_282 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_283 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign _zz_284 = MmuPlugin_shared_portSortedOh[0];
-  assign _zz_285 = MmuPlugin_shared_portSortedOh[1];
-  assign _zz_286 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_287 = (1'b0 || (! 1'b1));
-  assign _zz_288 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_289 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_290 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_291 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_292 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_293 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_294 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_295 = execute_INSTRUCTION[13 : 12];
-  assign _zz_296 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_297 = (! memory_arbitration_isStuck);
-  assign _zz_298 = (iBus_cmd_valid || (_zz_196 != 3'b000));
-  assign _zz_299 = (_zz_239 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_300 = (MmuPlugin_shared_refills != 2'b00);
-  assign _zz_301 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
-  assign _zz_302 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
-  assign _zz_303 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
-  assign _zz_304 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
-  assign _zz_305 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
-  assign _zz_306 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
-  assign _zz_307 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
-  assign _zz_308 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
-  assign _zz_309 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
-  assign _zz_310 = ((_zz_155 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign _zz_311 = ((_zz_156 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign _zz_312 = ((_zz_157 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign _zz_313 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_314 = ((_zz_155 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
-  assign _zz_315 = ((_zz_156 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
-  assign _zz_316 = ((_zz_157 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
-  assign _zz_317 = ((_zz_158 && 1'b1) && (! 1'b0));
-  assign _zz_318 = ((_zz_159 && 1'b1) && (! 1'b0));
-  assign _zz_319 = ((_zz_160 && 1'b1) && (! 1'b0));
-  assign _zz_320 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_321 = execute_INSTRUCTION[13];
-  assign _zz_322 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_323 = ($signed(_zz_324) + $signed(_zz_329));
-  assign _zz_324 = ($signed(_zz_325) + $signed(_zz_327));
-  assign _zz_325 = 52'h0;
-  assign _zz_326 = {1'b0,memory_MUL_LL};
-  assign _zz_327 = {{19{_zz_326[32]}}, _zz_326};
-  assign _zz_328 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_329 = {{2{_zz_328[49]}}, _zz_328};
-  assign _zz_330 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_331 = {{2{_zz_330[49]}}, _zz_330};
-  assign _zz_332 = ($signed(_zz_334) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_333 = _zz_332[31 : 0];
-  assign _zz_334 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_335 = _zz_103[34 : 34];
-  assign _zz_336 = _zz_103[33 : 33];
-  assign _zz_337 = _zz_103[32 : 32];
-  assign _zz_338 = _zz_103[31 : 31];
-  assign _zz_339 = _zz_103[28 : 28];
-  assign _zz_340 = _zz_103[21 : 21];
-  assign _zz_341 = _zz_103[20 : 20];
-  assign _zz_342 = _zz_103[19 : 19];
-  assign _zz_343 = _zz_103[13 : 13];
-  assign _zz_344 = _zz_103[12 : 12];
-  assign _zz_345 = _zz_103[11 : 11];
-  assign _zz_346 = _zz_103[17 : 17];
-  assign _zz_347 = _zz_103[5 : 5];
-  assign _zz_348 = _zz_103[3 : 3];
-  assign _zz_349 = _zz_103[18 : 18];
-  assign _zz_350 = _zz_103[10 : 10];
-  assign _zz_351 = _zz_103[16 : 16];
-  assign _zz_352 = _zz_103[15 : 15];
-  assign _zz_353 = _zz_103[4 : 4];
-  assign _zz_354 = _zz_103[0 : 0];
-  assign _zz_355 = (_zz_56 - 5'h01);
-  assign _zz_356 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_357 = {29'd0, _zz_356};
-  assign _zz_358 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_359 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_360 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_361 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_362 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_363 = {{_zz_76,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_364 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_365 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_366 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_367 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_368 = MmuPlugin_ports_0_entryToReplace_willIncrement;
-  assign _zz_369 = {1'd0, _zz_368};
-  assign _zz_370 = MmuPlugin_ports_1_entryToReplace_willIncrement;
-  assign _zz_371 = {1'd0, _zz_370};
-  assign _zz_372 = MmuPlugin_shared_dBusRspStaged_payload_data[0 : 0];
-  assign _zz_373 = MmuPlugin_shared_dBusRspStaged_payload_data[1 : 1];
-  assign _zz_374 = MmuPlugin_shared_dBusRspStaged_payload_data[2 : 2];
-  assign _zz_375 = MmuPlugin_shared_dBusRspStaged_payload_data[3 : 3];
-  assign _zz_376 = MmuPlugin_shared_dBusRspStaged_payload_data[4 : 4];
-  assign _zz_377 = MmuPlugin_shared_dBusRspStaged_payload_data[5 : 5];
-  assign _zz_378 = MmuPlugin_shared_dBusRspStaged_payload_data[6 : 6];
-  assign _zz_379 = MmuPlugin_shared_dBusRspStaged_payload_data[7 : 7];
-  assign _zz_380 = (_zz_99 - 2'b01);
-  assign _zz_381 = execute_SRC_LESS;
-  assign _zz_382 = 3'b100;
-  assign _zz_383 = execute_INSTRUCTION[19 : 15];
-  assign _zz_384 = execute_INSTRUCTION[31 : 20];
-  assign _zz_385 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_386 = ($signed(_zz_387) + $signed(_zz_390));
-  assign _zz_387 = ($signed(_zz_388) + $signed(_zz_389));
-  assign _zz_388 = execute_SRC1;
-  assign _zz_389 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_390 = (execute_SRC_USE_SUB_LESS ? _zz_391 : _zz_392);
-  assign _zz_391 = 32'h00000001;
-  assign _zz_392 = 32'h0;
-  assign _zz_393 = execute_INSTRUCTION[31 : 20];
-  assign _zz_394 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_395 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_396 = {_zz_142,execute_INSTRUCTION[31 : 20]};
-  assign _zz_397 = {{_zz_144,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_398 = {{_zz_146,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_399 = execute_INSTRUCTION[31 : 20];
-  assign _zz_400 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_401 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_402 = 3'b100;
-  assign _zz_403 = (_zz_161 & (~ _zz_404));
-  assign _zz_404 = (_zz_161 - 2'b01);
-  assign _zz_405 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_406 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_407 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_408 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_409 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_410 = {5'd0, _zz_409};
-  assign _zz_411 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_412 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_413 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_414 = {_zz_163,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_415 = _zz_416;
-  assign _zz_416 = _zz_417;
-  assign _zz_417 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_164) : _zz_164)} + _zz_419);
-  assign _zz_418 = memory_DivPlugin_div_needRevert;
-  assign _zz_419 = {32'd0, _zz_418};
-  assign _zz_420 = _zz_166;
-  assign _zz_421 = {32'd0, _zz_420};
-  assign _zz_422 = _zz_165;
-  assign _zz_423 = {31'd0, _zz_422};
-  assign _zz_424 = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_425 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_426 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_427 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_428 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_429 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_430 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_431 = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_432 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_433 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_434 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_435 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_436 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_437 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_438 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_439 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_440 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_441 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_442 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_443 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_444 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_445 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_446 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_447 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_448 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_449 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_450 = execute_CsrPlugin_writeData[4 : 4];
-  assign _zz_451 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_452 = execute_CsrPlugin_writeData[6 : 6];
-  assign _zz_453 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_454 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_455 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_456 = execute_CsrPlugin_writeData[12 : 12];
-  assign _zz_457 = execute_CsrPlugin_writeData[13 : 13];
-  assign _zz_458 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_459 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_460 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_461 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_462 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_463 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_464 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_465 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_466 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_467 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_468 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_469 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_470 = 1'b1;
-  assign _zz_471 = 1'b1;
-  assign _zz_472 = {_zz_59,{_zz_61,_zz_60}};
-  assign _zz_473 = 32'h0000107f;
-  assign _zz_474 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_475 = 32'h00002073;
-  assign _zz_476 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_477 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_478 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_479) == 32'h00000003),{(_zz_480 == _zz_481),{_zz_482,{_zz_483,_zz_484}}}}}};
-  assign _zz_479 = 32'h0000505f;
-  assign _zz_480 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_481 = 32'h00000063;
-  assign _zz_482 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_483 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_484 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_485) == 32'h0000500f),{(_zz_486 == _zz_487),{_zz_488,{_zz_489,_zz_490}}}}}};
-  assign _zz_485 = 32'h01f0707f;
-  assign _zz_486 = (decode_INSTRUCTION & 32'hbc00707f);
-  assign _zz_487 = 32'h00005013;
-  assign _zz_488 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_489 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_490 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_491) == 32'h12000073),{(_zz_492 == _zz_493),{_zz_494,_zz_495}}}}};
-  assign _zz_491 = 32'hfe007fff;
-  assign _zz_492 = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_493 = 32'h10200073;
-  assign _zz_494 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_495 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_496 = decode_INSTRUCTION[31];
-  assign _zz_497 = decode_INSTRUCTION[31];
-  assign _zz_498 = decode_INSTRUCTION[7];
-  assign _zz_499 = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_500 = 32'h02004020;
-  assign _zz_501 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_502 = ((decode_INSTRUCTION & 32'h02203050) == 32'h00000050);
-  assign _zz_503 = 1'b0;
-  assign _zz_504 = (((decode_INSTRUCTION & _zz_507) == 32'h00000050) != 1'b0);
-  assign _zz_505 = ({_zz_508,_zz_509} != 2'b00);
-  assign _zz_506 = {({_zz_510,_zz_511} != 2'b00),{(_zz_512 != _zz_513),{_zz_514,{_zz_515,_zz_516}}}};
-  assign _zz_507 = 32'h02403050;
-  assign _zz_508 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_509 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_510 = _zz_105;
-  assign _zz_511 = ((decode_INSTRUCTION & _zz_517) == 32'h00000004);
-  assign _zz_512 = ((decode_INSTRUCTION & _zz_518) == 32'h00000040);
-  assign _zz_513 = 1'b0;
-  assign _zz_514 = ({_zz_519,_zz_520} != 2'b00);
-  assign _zz_515 = ({_zz_521,_zz_522} != 3'b000);
-  assign _zz_516 = {(_zz_523 != _zz_524),{_zz_525,{_zz_526,_zz_527}}};
-  assign _zz_517 = 32'h0000001c;
-  assign _zz_518 = 32'h00000058;
-  assign _zz_519 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz_520 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz_521 = ((decode_INSTRUCTION & _zz_528) == 32'h40001010);
-  assign _zz_522 = {(_zz_529 == _zz_530),(_zz_531 == _zz_532)};
-  assign _zz_523 = ((decode_INSTRUCTION & _zz_533) == 32'h00001000);
-  assign _zz_524 = 1'b0;
-  assign _zz_525 = ((_zz_534 == _zz_535) != 1'b0);
-  assign _zz_526 = ({_zz_536,_zz_537} != 2'b00);
-  assign _zz_527 = {(_zz_538 != _zz_539),{_zz_540,{_zz_541,_zz_542}}};
-  assign _zz_528 = 32'h40003054;
-  assign _zz_529 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_530 = 32'h00001010;
-  assign _zz_531 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_532 = 32'h00001010;
-  assign _zz_533 = 32'h00001000;
-  assign _zz_534 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_535 = 32'h00002000;
-  assign _zz_536 = ((decode_INSTRUCTION & _zz_543) == 32'h00002000);
-  assign _zz_537 = ((decode_INSTRUCTION & _zz_544) == 32'h00001000);
-  assign _zz_538 = ((decode_INSTRUCTION & _zz_545) == 32'h02000050);
-  assign _zz_539 = 1'b0;
-  assign _zz_540 = ((_zz_546 == _zz_547) != 1'b0);
-  assign _zz_541 = (_zz_548 != 1'b0);
-  assign _zz_542 = {(_zz_549 != _zz_550),{_zz_551,{_zz_552,_zz_553}}};
-  assign _zz_543 = 32'h00002010;
-  assign _zz_544 = 32'h00005000;
-  assign _zz_545 = 32'h02003050;
-  assign _zz_546 = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_547 = 32'h00004008;
-  assign _zz_548 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_549 = {(_zz_554 == _zz_555),{_zz_556,{_zz_557,_zz_558}}};
-  assign _zz_550 = 4'b0000;
-  assign _zz_551 = ((_zz_559 == _zz_560) != 1'b0);
-  assign _zz_552 = (_zz_561 != 1'b0);
-  assign _zz_553 = {(_zz_562 != _zz_563),{_zz_564,{_zz_565,_zz_566}}};
-  assign _zz_554 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_555 = 32'h00000020;
-  assign _zz_556 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_557 = ((decode_INSTRUCTION & _zz_567) == 32'h08000020);
-  assign _zz_558 = ((decode_INSTRUCTION & _zz_568) == 32'h00000020);
-  assign _zz_559 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_560 = 32'h00000008;
-  assign _zz_561 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
-  assign _zz_562 = {(_zz_569 == _zz_570),{_zz_571,{_zz_572,_zz_573}}};
-  assign _zz_563 = 6'h0;
-  assign _zz_564 = ({_zz_574,{_zz_575,_zz_576}} != 3'b000);
-  assign _zz_565 = ({_zz_577,_zz_578} != 5'h0);
-  assign _zz_566 = {(_zz_579 != _zz_580),{_zz_581,{_zz_582,_zz_583}}};
-  assign _zz_567 = 32'h08000070;
-  assign _zz_568 = 32'h10000070;
-  assign _zz_569 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_570 = 32'h00002040;
-  assign _zz_571 = ((decode_INSTRUCTION & _zz_584) == 32'h00001040);
-  assign _zz_572 = (_zz_585 == _zz_586);
-  assign _zz_573 = {_zz_587,{_zz_588,_zz_589}};
-  assign _zz_574 = ((decode_INSTRUCTION & _zz_590) == 32'h08000020);
-  assign _zz_575 = (_zz_591 == _zz_592);
-  assign _zz_576 = (_zz_593 == _zz_594);
-  assign _zz_577 = (_zz_595 == _zz_596);
-  assign _zz_578 = {_zz_597,{_zz_598,_zz_599}};
-  assign _zz_579 = {_zz_108,{_zz_600,_zz_601}};
-  assign _zz_580 = 5'h0;
-  assign _zz_581 = ({_zz_602,_zz_603} != 7'h0);
-  assign _zz_582 = (_zz_604 != _zz_605);
-  assign _zz_583 = {_zz_606,{_zz_607,_zz_608}};
-  assign _zz_584 = 32'h00001040;
-  assign _zz_585 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_586 = 32'h00000040;
-  assign _zz_587 = ((decode_INSTRUCTION & _zz_609) == 32'h00000040);
-  assign _zz_588 = (_zz_610 == _zz_611);
-  assign _zz_589 = (_zz_612 == _zz_613);
-  assign _zz_590 = 32'h08000020;
-  assign _zz_591 = (decode_INSTRUCTION & 32'h10000020);
-  assign _zz_592 = 32'h00000020;
-  assign _zz_593 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_594 = 32'h00000020;
-  assign _zz_595 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_596 = 32'h00000040;
-  assign _zz_597 = ((decode_INSTRUCTION & _zz_614) == 32'h00004020);
-  assign _zz_598 = (_zz_615 == _zz_616);
-  assign _zz_599 = {_zz_108,_zz_617};
-  assign _zz_600 = (_zz_618 == _zz_619);
-  assign _zz_601 = {_zz_620,{_zz_621,_zz_622}};
-  assign _zz_602 = _zz_105;
-  assign _zz_603 = {_zz_623,{_zz_624,_zz_625}};
-  assign _zz_604 = {_zz_107,_zz_626};
-  assign _zz_605 = 2'b00;
-  assign _zz_606 = ({_zz_627,_zz_628} != 2'b00);
-  assign _zz_607 = (_zz_629 != _zz_630);
-  assign _zz_608 = {_zz_631,{_zz_632,_zz_633}};
-  assign _zz_609 = 32'h02400040;
-  assign _zz_610 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_611 = 32'h0;
-  assign _zz_612 = (decode_INSTRUCTION & 32'h18002008);
-  assign _zz_613 = 32'h10002008;
-  assign _zz_614 = 32'h00004020;
-  assign _zz_615 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_616 = 32'h00000010;
-  assign _zz_617 = ((decode_INSTRUCTION & _zz_634) == 32'h00000020);
-  assign _zz_618 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_619 = 32'h00002010;
-  assign _zz_620 = ((decode_INSTRUCTION & _zz_635) == 32'h00000010);
-  assign _zz_621 = (_zz_636 == _zz_637);
-  assign _zz_622 = (_zz_638 == _zz_639);
-  assign _zz_623 = ((decode_INSTRUCTION & _zz_640) == 32'h00001010);
-  assign _zz_624 = (_zz_641 == _zz_642);
-  assign _zz_625 = {_zz_643,{_zz_644,_zz_645}};
-  assign _zz_626 = ((decode_INSTRUCTION & _zz_646) == 32'h00000020);
-  assign _zz_627 = _zz_107;
-  assign _zz_628 = (_zz_647 == _zz_648);
-  assign _zz_629 = (_zz_649 == _zz_650);
-  assign _zz_630 = 1'b0;
-  assign _zz_631 = (_zz_651 != 1'b0);
-  assign _zz_632 = (_zz_652 != _zz_653);
-  assign _zz_633 = {_zz_654,{_zz_655,_zz_656}};
-  assign _zz_634 = 32'h02000028;
-  assign _zz_635 = 32'h00001030;
-  assign _zz_636 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_637 = 32'h00000020;
-  assign _zz_638 = (decode_INSTRUCTION & 32'h02002068);
-  assign _zz_639 = 32'h00002020;
-  assign _zz_640 = 32'h00001010;
-  assign _zz_641 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_642 = 32'h00002010;
-  assign _zz_643 = ((decode_INSTRUCTION & _zz_657) == 32'h00002008);
-  assign _zz_644 = (_zz_658 == _zz_659);
-  assign _zz_645 = {_zz_108,_zz_660};
-  assign _zz_646 = 32'h00000070;
-  assign _zz_647 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_648 = 32'h0;
-  assign _zz_649 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_650 = 32'h00004010;
-  assign _zz_651 = ((decode_INSTRUCTION & _zz_661) == 32'h00002010);
-  assign _zz_652 = {_zz_662,{_zz_663,_zz_664}};
-  assign _zz_653 = 5'h0;
-  assign _zz_654 = ({_zz_665,_zz_666} != 2'b00);
-  assign _zz_655 = (_zz_667 != _zz_668);
-  assign _zz_656 = {_zz_669,{_zz_670,_zz_671}};
-  assign _zz_657 = 32'h00002008;
-  assign _zz_658 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_659 = 32'h00000010;
-  assign _zz_660 = ((decode_INSTRUCTION & _zz_672) == 32'h0);
-  assign _zz_661 = 32'h00006014;
-  assign _zz_662 = ((decode_INSTRUCTION & _zz_673) == 32'h0);
-  assign _zz_663 = (_zz_674 == _zz_675);
-  assign _zz_664 = {_zz_676,{_zz_677,_zz_678}};
-  assign _zz_665 = _zz_106;
-  assign _zz_666 = (_zz_679 == _zz_680);
-  assign _zz_667 = {_zz_681,{_zz_682,_zz_683}};
-  assign _zz_668 = 3'b000;
-  assign _zz_669 = ({_zz_684,_zz_685} != 3'b000);
-  assign _zz_670 = (_zz_686 != _zz_687);
-  assign _zz_671 = (_zz_688 != _zz_689);
-  assign _zz_672 = 32'h00000028;
-  assign _zz_673 = 32'h00000044;
-  assign _zz_674 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_675 = 32'h0;
-  assign _zz_676 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_677 = ((decode_INSTRUCTION & _zz_690) == 32'h00001000);
-  assign _zz_678 = _zz_106;
-  assign _zz_679 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_680 = 32'h0;
-  assign _zz_681 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_682 = ((decode_INSTRUCTION & _zz_691) == 32'h00002010);
-  assign _zz_683 = ((decode_INSTRUCTION & _zz_692) == 32'h40000030);
-  assign _zz_684 = _zz_105;
-  assign _zz_685 = {_zz_104,(_zz_693 == _zz_694)};
-  assign _zz_686 = {_zz_104,(_zz_695 == _zz_696)};
-  assign _zz_687 = 2'b00;
-  assign _zz_688 = ((decode_INSTRUCTION & _zz_697) == 32'h00001008);
-  assign _zz_689 = 1'b0;
-  assign _zz_690 = 32'h00005004;
-  assign _zz_691 = 32'h00002014;
-  assign _zz_692 = 32'h40000034;
-  assign _zz_693 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_694 = 32'h00000004;
-  assign _zz_695 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz_696 = 32'h00000004;
-  assign _zz_697 = 32'h00005048;
-  assign _zz_698 = execute_INSTRUCTION[31];
-  assign _zz_699 = execute_INSTRUCTION[31];
-  assign _zz_700 = execute_INSTRUCTION[7];
-  assign _zz_701 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_470) begin
-      _zz_240 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 5'h01);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
+  assign _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1 = MmuPlugin_ports_0_entryToReplace_willIncrement;
+  assign _zz_MmuPlugin_ports_0_entryToReplace_valueNext = {1'd0, _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1};
+  assign _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1 = MmuPlugin_ports_1_entryToReplace_willIncrement;
+  assign _zz_MmuPlugin_ports_1_entryToReplace_valueNext = {1'd0, _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1};
+  assign _zz__zz_MmuPlugin_shared_refills_2 = (_zz_MmuPlugin_shared_refills_1 - 2'b01);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_7 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,{_zz_IBusCachedPlugin_jump_pcLoad_payload_5,_zz_IBusCachedPlugin_jump_pcLoad_payload_4}};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h12000073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),{_zz_decode_LEGAL_INSTRUCTION_21,_zz_decode_LEGAL_INSTRUCTION_22}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hfe007fff;
+  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_21 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_22 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_1 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_2 = (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_3 = (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_4 = (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_5 = (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_1 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_2 = (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_3 = (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_4 = (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_5 = (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h02203050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_6) == 32'h00000050) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ({_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {({_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_12} != 2'b00),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_16),{_zz__zz_decode_IS_RS2_SIGNED_17,{_zz__zz_decode_IS_RS2_SIGNED_20,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h02403050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_15) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ({_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_38}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25),(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = ({_zz__zz_decode_IS_RS2_SIGNED_36,_zz__zz_decode_IS_RS2_SIGNED_37} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {(_zz__zz_decode_IS_RS2_SIGNED_39 != _zz__zz_decode_IS_RS2_SIGNED_40),{_zz__zz_decode_IS_RS2_SIGNED_41,{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_45}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = _zz_decode_IS_RS2_SIGNED_6;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (_zz_decode_IS_RS2_SIGNED_6 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((_zz__zz_decode_IS_RS2_SIGNED_43 == _zz__zz_decode_IS_RS2_SIGNED_44) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = {(_zz__zz_decode_IS_RS2_SIGNED_46 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_47 != _zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_59,_zz__zz_decode_IS_RS2_SIGNED_61}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00004008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = {(_zz__zz_decode_IS_RS2_SIGNED_48 == _zz__zz_decode_IS_RS2_SIGNED_49),{_zz__zz_decode_IS_RS2_SIGNED_50,{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_53}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 4'b0000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((_zz__zz_decode_IS_RS2_SIGNED_57 == _zz__zz_decode_IS_RS2_SIGNED_58) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (_zz__zz_decode_IS_RS2_SIGNED_60 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {(_zz__zz_decode_IS_RS2_SIGNED_62 != _zz__zz_decode_IS_RS2_SIGNED_79),{_zz__zz_decode_IS_RS2_SIGNED_80,{_zz__zz_decode_IS_RS2_SIGNED_89,_zz__zz_decode_IS_RS2_SIGNED_102}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_52) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_54) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h00000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = {(_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64),{_zz__zz_decode_IS_RS2_SIGNED_65,{_zz__zz_decode_IS_RS2_SIGNED_67,_zz__zz_decode_IS_RS2_SIGNED_70}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 6'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = ({_zz__zz_decode_IS_RS2_SIGNED_81,{_zz__zz_decode_IS_RS2_SIGNED_83,_zz__zz_decode_IS_RS2_SIGNED_86}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ({_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_93} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = {(_zz__zz_decode_IS_RS2_SIGNED_103 != _zz__zz_decode_IS_RS2_SIGNED_116),{_zz__zz_decode_IS_RS2_SIGNED_117,{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_139}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = 32'h08000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = 32'h10000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_66) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = {_zz__zz_decode_IS_RS2_SIGNED_71,{_zz__zz_decode_IS_RS2_SIGNED_73,_zz__zz_decode_IS_RS2_SIGNED_76}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = (_zz__zz_decode_IS_RS2_SIGNED_84 == _zz__zz_decode_IS_RS2_SIGNED_85);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (_zz__zz_decode_IS_RS2_SIGNED_87 == _zz__zz_decode_IS_RS2_SIGNED_88);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,{_zz__zz_decode_IS_RS2_SIGNED_96,_zz__zz_decode_IS_RS2_SIGNED_99}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_104,_zz__zz_decode_IS_RS2_SIGNED_107}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ({_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_119} != 7'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (_zz__zz_decode_IS_RS2_SIGNED_135 != _zz__zz_decode_IS_RS2_SIGNED_138);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = {_zz__zz_decode_IS_RS2_SIGNED_140,{_zz__zz_decode_IS_RS2_SIGNED_145,_zz__zz_decode_IS_RS2_SIGNED_150}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_72) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = (_zz__zz_decode_IS_RS2_SIGNED_74 == _zz__zz_decode_IS_RS2_SIGNED_75);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (_zz__zz_decode_IS_RS2_SIGNED_77 == _zz__zz_decode_IS_RS2_SIGNED_78);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = (decode_INSTRUCTION & 32'h10000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_95) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = (_zz__zz_decode_IS_RS2_SIGNED_97 == _zz__zz_decode_IS_RS2_SIGNED_98);
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_100};
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106);
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = {_zz__zz_decode_IS_RS2_SIGNED_108,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_113}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = {_zz__zz_decode_IS_RS2_SIGNED_120,{_zz__zz_decode_IS_RS2_SIGNED_122,_zz__zz_decode_IS_RS2_SIGNED_125}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = {_zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_136};
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ({_zz__zz_decode_IS_RS2_SIGNED_141,_zz__zz_decode_IS_RS2_SIGNED_142} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = (_zz__zz_decode_IS_RS2_SIGNED_146 != _zz__zz_decode_IS_RS2_SIGNED_149);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {_zz__zz_decode_IS_RS2_SIGNED_151,{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_167}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = 32'h02400040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = (decode_INSTRUCTION & 32'h18002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = 32'h10002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_101) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_109) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (_zz__zz_decode_IS_RS2_SIGNED_111 == _zz__zz_decode_IS_RS2_SIGNED_112);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (_zz__zz_decode_IS_RS2_SIGNED_114 == _zz__zz_decode_IS_RS2_SIGNED_115);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_121) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (_zz__zz_decode_IS_RS2_SIGNED_123 == _zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {_zz__zz_decode_IS_RS2_SIGNED_126,{_zz__zz_decode_IS_RS2_SIGNED_128,_zz__zz_decode_IS_RS2_SIGNED_131}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_137) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = (_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = (_zz__zz_decode_IS_RS2_SIGNED_147 == _zz__zz_decode_IS_RS2_SIGNED_148);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (_zz__zz_decode_IS_RS2_SIGNED_152 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = (_zz__zz_decode_IS_RS2_SIGNED_155 != _zz__zz_decode_IS_RS2_SIGNED_166);
+  assign _zz__zz_decode_IS_RS2_SIGNED_167 = {_zz__zz_decode_IS_RS2_SIGNED_168,{_zz__zz_decode_IS_RS2_SIGNED_173,_zz__zz_decode_IS_RS2_SIGNED_181}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h02000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = (decode_INSTRUCTION & 32'h02002068);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_127) == 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (_zz__zz_decode_IS_RS2_SIGNED_129 == _zz__zz_decode_IS_RS2_SIGNED_130);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_132};
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_153) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = {_zz__zz_decode_IS_RS2_SIGNED_156,{_zz__zz_decode_IS_RS2_SIGNED_158,_zz__zz_decode_IS_RS2_SIGNED_161}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_168 = ({_zz__zz_decode_IS_RS2_SIGNED_169,_zz__zz_decode_IS_RS2_SIGNED_170} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_173 = (_zz__zz_decode_IS_RS2_SIGNED_174 != _zz__zz_decode_IS_RS2_SIGNED_180);
+  assign _zz__zz_decode_IS_RS2_SIGNED_181 = {_zz__zz_decode_IS_RS2_SIGNED_182,{_zz__zz_decode_IS_RS2_SIGNED_187,_zz__zz_decode_IS_RS2_SIGNED_192}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_133) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_157) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = (_zz__zz_decode_IS_RS2_SIGNED_159 == _zz__zz_decode_IS_RS2_SIGNED_160);
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = {_zz__zz_decode_IS_RS2_SIGNED_162,{_zz__zz_decode_IS_RS2_SIGNED_163,_zz__zz_decode_IS_RS2_SIGNED_165}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_169 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_170 = (_zz__zz_decode_IS_RS2_SIGNED_171 == _zz__zz_decode_IS_RS2_SIGNED_172);
+  assign _zz__zz_decode_IS_RS2_SIGNED_174 = {_zz__zz_decode_IS_RS2_SIGNED_175,{_zz__zz_decode_IS_RS2_SIGNED_176,_zz__zz_decode_IS_RS2_SIGNED_178}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_180 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_182 = ({_zz__zz_decode_IS_RS2_SIGNED_183,_zz__zz_decode_IS_RS2_SIGNED_184} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_187 = (_zz__zz_decode_IS_RS2_SIGNED_188 != _zz__zz_decode_IS_RS2_SIGNED_191);
+  assign _zz__zz_decode_IS_RS2_SIGNED_192 = (_zz__zz_decode_IS_RS2_SIGNED_193 != _zz__zz_decode_IS_RS2_SIGNED_195);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_164) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_171 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_172 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_175 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_176 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_177) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_178 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_179) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_183 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_184 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_185 == _zz__zz_decode_IS_RS2_SIGNED_186)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_188 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_189 == _zz__zz_decode_IS_RS2_SIGNED_190)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_191 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_193 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_194) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_195 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_177 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_179 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_185 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_186 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_189 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_190 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_194 = 32'h00005048;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_28 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_471) begin
-      _zz_241 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_205                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_206                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_207                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_208                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_209                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]           ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_210                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_211                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_212                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_213                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical           ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_214                                            ), //i
-    .io_cpu_execute_address                    (_zz_215[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (_zz_216                                            ), //i
-    .io_cpu_execute_args_data                  (_zz_217[31:0]                                      ), //i
-    .io_cpu_execute_args_size                  (_zz_218[1:0]                                       ), //i
-    .io_cpu_execute_args_isLrsc                (_zz_219                                            ), //i
-    .io_cpu_execute_args_isAmo                 (_zz_220                                            ), //i
-    .io_cpu_execute_args_amoCtrl_swap          (_zz_221                                            ), //i
-    .io_cpu_execute_args_amoCtrl_alu           (_zz_222[2:0]                                       ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_223                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_224[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_225                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]  ), //i
-    .io_cpu_writeBack_isValid                  (_zz_226                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_227                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_228[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_229                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_230                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_231                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_232                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_233                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_234                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_235                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_236                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_237[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_238                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_239                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (dataCache_1_io_cpu_execute_args_wr             ), //i
+    .io_cpu_execute_args_size                  (dataCache_1_io_cpu_execute_args_size           ), //i
+    .io_cpu_execute_args_isLrsc                (dataCache_1_io_cpu_execute_args_isLrsc         ), //i
+    .io_cpu_execute_args_isAmo                 (execute_MEMORY_AMO                             ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (dataCache_1_io_cpu_execute_args_amoCtrl_swap   ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (dataCache_1_io_cpu_execute_args_amoCtrl_alu    ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical    ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_472)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_7)
       3'b000 : begin
-        _zz_242 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = DBusCachedPlugin_redoBranch_payload;
       end
       3'b001 : begin
-        _zz_242 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = CsrPlugin_jumpInterface_payload;
       end
       3'b010 : begin
-        _zz_242 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = BranchPlugin_jumpInterface_payload;
       end
       3'b011 : begin
-        _zz_242 = CsrPlugin_redoInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = CsrPlugin_redoInterface_payload;
       end
       default : begin
-        _zz_242 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_92)
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
       2'b00 : begin
-        _zz_243 = MmuPlugin_ports_0_cache_0_valid;
-        _zz_244 = MmuPlugin_ports_0_cache_0_exception;
-        _zz_245 = MmuPlugin_ports_0_cache_0_superPage;
-        _zz_246 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
-        _zz_247 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
-        _zz_248 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
-        _zz_249 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
-        _zz_250 = MmuPlugin_ports_0_cache_0_allowRead;
-        _zz_251 = MmuPlugin_ports_0_cache_0_allowWrite;
-        _zz_252 = MmuPlugin_ports_0_cache_0_allowExecute;
-        _zz_253 = MmuPlugin_ports_0_cache_0_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
       end
       2'b01 : begin
-        _zz_243 = MmuPlugin_ports_0_cache_1_valid;
-        _zz_244 = MmuPlugin_ports_0_cache_1_exception;
-        _zz_245 = MmuPlugin_ports_0_cache_1_superPage;
-        _zz_246 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
-        _zz_247 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
-        _zz_248 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
-        _zz_249 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
-        _zz_250 = MmuPlugin_ports_0_cache_1_allowRead;
-        _zz_251 = MmuPlugin_ports_0_cache_1_allowWrite;
-        _zz_252 = MmuPlugin_ports_0_cache_1_allowExecute;
-        _zz_253 = MmuPlugin_ports_0_cache_1_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       2'b10 : begin
-        _zz_243 = MmuPlugin_ports_0_cache_2_valid;
-        _zz_244 = MmuPlugin_ports_0_cache_2_exception;
-        _zz_245 = MmuPlugin_ports_0_cache_2_superPage;
-        _zz_246 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
-        _zz_247 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
-        _zz_248 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
-        _zz_249 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
-        _zz_250 = MmuPlugin_ports_0_cache_2_allowRead;
-        _zz_251 = MmuPlugin_ports_0_cache_2_allowWrite;
-        _zz_252 = MmuPlugin_ports_0_cache_2_allowExecute;
-        _zz_253 = MmuPlugin_ports_0_cache_2_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
       end
       default : begin
-        _zz_243 = MmuPlugin_ports_0_cache_3_valid;
-        _zz_244 = MmuPlugin_ports_0_cache_3_exception;
-        _zz_245 = MmuPlugin_ports_0_cache_3_superPage;
-        _zz_246 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
-        _zz_247 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
-        _zz_248 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
-        _zz_249 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
-        _zz_250 = MmuPlugin_ports_0_cache_3_allowRead;
-        _zz_251 = MmuPlugin_ports_0_cache_3_allowWrite;
-        _zz_252 = MmuPlugin_ports_0_cache_3_allowExecute;
-        _zz_253 = MmuPlugin_ports_0_cache_3_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_96)
-      2'b00 : begin
-        _zz_254 = MmuPlugin_ports_1_cache_0_valid;
-        _zz_255 = MmuPlugin_ports_1_cache_0_exception;
-        _zz_256 = MmuPlugin_ports_1_cache_0_superPage;
-        _zz_257 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
-        _zz_258 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
-        _zz_259 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
-        _zz_260 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
-        _zz_261 = MmuPlugin_ports_1_cache_0_allowRead;
-        _zz_262 = MmuPlugin_ports_1_cache_0_allowWrite;
-        _zz_263 = MmuPlugin_ports_1_cache_0_allowExecute;
-        _zz_264 = MmuPlugin_ports_1_cache_0_allowUser;
-      end
-      2'b01 : begin
-        _zz_254 = MmuPlugin_ports_1_cache_1_valid;
-        _zz_255 = MmuPlugin_ports_1_cache_1_exception;
-        _zz_256 = MmuPlugin_ports_1_cache_1_superPage;
-        _zz_257 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
-        _zz_258 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
-        _zz_259 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
-        _zz_260 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
-        _zz_261 = MmuPlugin_ports_1_cache_1_allowRead;
-        _zz_262 = MmuPlugin_ports_1_cache_1_allowWrite;
-        _zz_263 = MmuPlugin_ports_1_cache_1_allowExecute;
-        _zz_264 = MmuPlugin_ports_1_cache_1_allowUser;
-      end
-      2'b10 : begin
-        _zz_254 = MmuPlugin_ports_1_cache_2_valid;
-        _zz_255 = MmuPlugin_ports_1_cache_2_exception;
-        _zz_256 = MmuPlugin_ports_1_cache_2_superPage;
-        _zz_257 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
-        _zz_258 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
-        _zz_259 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
-        _zz_260 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
-        _zz_261 = MmuPlugin_ports_1_cache_2_allowRead;
-        _zz_262 = MmuPlugin_ports_1_cache_2_allowWrite;
-        _zz_263 = MmuPlugin_ports_1_cache_2_allowExecute;
-        _zz_264 = MmuPlugin_ports_1_cache_2_allowUser;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       default : begin
-        _zz_254 = MmuPlugin_ports_1_cache_3_valid;
-        _zz_255 = MmuPlugin_ports_1_cache_3_exception;
-        _zz_256 = MmuPlugin_ports_1_cache_3_superPage;
-        _zz_257 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
-        _zz_258 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
-        _zz_259 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
-        _zz_260 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
-        _zz_261 = MmuPlugin_ports_1_cache_3_allowRead;
-        _zz_262 = MmuPlugin_ports_1_cache_3_allowWrite;
-        _zz_263 = MmuPlugin_ports_1_cache_3_allowExecute;
-        _zz_264 = MmuPlugin_ports_1_cache_3_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_MmuPlugin_ports_0_cacheLine_valid_3)
+      2'b00 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_0_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_0_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_0_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_0_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_0_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_0_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_0_allowUser;
+      end
+      2'b01 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_1_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_1_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_1_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_1_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_1_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_1_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_1_allowUser;
+      end
+      2'b10 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_2_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_2_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_2_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_2_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_2_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_2_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_2_allowUser;
+      end
+      default : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_3_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_3_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_3_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_3_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_3_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_3_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_3_allowUser;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_MmuPlugin_ports_1_cacheLine_valid_3)
+      2'b00 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_0_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_0_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_0_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_0_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_0_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_0_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_0_allowUser;
+      end
+      2'b01 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_1_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_1_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_1_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_1_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_1_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_1_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_1_allowUser;
+      end
+      2'b10 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_2_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_2_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_2_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_2_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_2_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_2_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_2_allowUser;
+      end
+      default : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_3_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_3_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_3_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_3_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_3_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_3_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_3_allowUser;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2465,134 +2506,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2605,30 +2646,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2640,27 +2681,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2673,30 +2714,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2709,12 +2750,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2727,12 +2768,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2745,12 +2786,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2763,48 +2804,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2817,12 +2858,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2835,12 +2876,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2852,88 +2893,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2946,12 +2987,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
-      default : _zz_52_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
@@ -2965,64 +3006,64 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_110)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_110_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_110_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_110_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_110_string = "URS1        ";
-      default : _zz_110_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_111)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_111_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_111_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_111_string = "BITWISE ";
-      default : _zz_111_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_112)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_112_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_112_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_112_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_112_string = "PC ";
-      default : _zz_112_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_113)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_113_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_113_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_113_string = "AND_1";
-      default : _zz_113_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_114)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_114_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_114_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_114_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_114_string = "SRA_1    ";
-      default : _zz_114_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_115)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_115_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_115_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_115_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_115_string = "JALR";
-      default : _zz_115_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_116)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_116_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_116_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_116_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_116_string = "ECALL";
-      default : _zz_116_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3053,28 +3094,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -3115,7 +3156,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_323) + $signed(_zz_331));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -3123,49 +3164,49 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_333;
-  assign execute_REGFILE_WRITE_DATA = _zz_118;
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_215[1 : 0];
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_335[0];
-  assign decode_IS_RS1_SIGNED = _zz_336[0];
-  assign decode_IS_DIV = _zz_337[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[35];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[34];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[33];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_338[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_339[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_340[0];
-  assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
-  assign decode_IS_SFENCE_VMA = _zz_341[0];
-  assign decode_MEMORY_MANAGMENT = _zz_342[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[32];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[29];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[22];
+  assign decode_IS_SFENCE_VMA = _zz_decode_IS_RS2_SIGNED[21];
+  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_RS2_SIGNED[20];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[19];
+  assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_343[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_344[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_345[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
-  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
@@ -3184,25 +3225,26 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
+  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_140;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_346[0];
-  assign decode_RS1_USE = _zz_347[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_265)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
-    if(DBusCachedPlugin_forceDatapath)begin
-      _zz_31 = MmuPlugin_dBusAccess_cmd_payload_address;
+    if(DBusCachedPlugin_forceDatapath) begin
+      _zz_decode_RS2 = MmuPlugin_dBusAccess_cmd_payload_address;
     end
   end
 
@@ -3212,148 +3254,165 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_129)begin
-      if((_zz_130 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_131;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_266)begin
-      if(_zz_267)begin
-        if(_zz_133)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_268)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_135)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_269)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_137)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_129)begin
-      if((_zz_130 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_131;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_266)begin
-      if(_zz_267)begin
-        if(_zz_132)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_268)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_134)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_269)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_136)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_126;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_270)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_348[0];
-  assign decode_SRC_ADD_ZERO = _zz_349[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_124;
-  assign execute_SRC1 = _zz_119;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_350[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_473) == 32'h00001073),{(_zz_474 == _zz_475),{_zz_476,{_zz_477,_zz_478}}}}}}} != 25'h0);
-  assign writeBack_IS_SFENCE_VMA = memory_to_writeBack_IS_SFENCE_VMA;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 25'h0);
+  assign execute_IS_SFENCE_VMA2 = decode_to_execute_IS_SFENCE_VMA2;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_322)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_407;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_408;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_LRSC = memory_to_writeBack_MEMORY_LRSC;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
-  assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  always @(*) begin
+    execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        execute_MEMORY_AMO = 1'b0;
+      end
+    end
+  end
+
+  always @(*) begin
+    execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        execute_MEMORY_LRSC = 1'b0;
+      end
+    end
+  end
+
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
@@ -3361,223 +3420,224 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_351[0];
-  assign decode_MEMORY_LRSC = _zz_352[0];
-  assign decode_MEMORY_ENABLE = _zz_353[0];
-  assign decode_FLUSH_ALL = _zz_354[0];
-  always @ (*) begin
+  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_271)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_272)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_273)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_274)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_53 = execute_FORMAL_PC_NEXT;
-    if(CsrPlugin_redoInterface_valid)begin
-      _zz_53 = CsrPlugin_redoInterface_payload;
+  always @(*) begin
+    _zz_execute_to_memory_FORMAL_PC_NEXT = execute_FORMAL_PC_NEXT;
+    if(CsrPlugin_redoInterface_valid) begin
+      _zz_execute_to_memory_FORMAL_PC_NEXT = CsrPlugin_redoInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_54 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_55 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_55 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((decode_arbitration_isValid && (_zz_127 || _zz_128)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(CsrPlugin_pipelineLiberator_active) begin
+      decode_arbitration_haltByOther = 1'b1;
+    end
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_275)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_275)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_238 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_276)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_265)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeInstruction)begin
-        execute_arbitration_flushNext = 1'b1;
-      end
+    if(CsrPlugin_selfException_valid) begin
+      execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_270)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_277)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_278)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3586,51 +3646,53 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_277)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_278)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_276)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_277)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_278)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_277)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_278)begin
-      case(_zz_279)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3646,60 +3708,66 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h0);
-  assign _zz_56 = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
-  assign _zz_57 = (_zz_56 & (~ _zz_355));
-  assign _zz_58 = _zz_57[3];
-  assign _zz_59 = _zz_57[4];
-  assign _zz_60 = (_zz_57[1] || _zz_58);
-  assign _zz_61 = (_zz_57[2] || _zz_58);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_242;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[4];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_357);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3707,265 +3775,280 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_62);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_63);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_63);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_64 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_64);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_64);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_65;
-  assign _zz_65 = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_68)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_68 = _zz_69;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_68;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_70;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_71 = _zz_358[11];
-  always @ (*) begin
-    _zz_72[18] = _zz_71;
-    _zz_72[17] = _zz_71;
-    _zz_72[16] = _zz_71;
-    _zz_72[15] = _zz_71;
-    _zz_72[14] = _zz_71;
-    _zz_72[13] = _zz_71;
-    _zz_72[12] = _zz_71;
-    _zz_72[11] = _zz_71;
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_359[31]));
-    if(_zz_77)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_73 = _zz_360[19];
-  always @ (*) begin
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_75 = _zz_361[11];
-  always @ (*) begin
-    _zz_76[18] = _zz_75;
-    _zz_76[17] = _zz_75;
-    _zz_76[16] = _zz_75;
-    _zz_76[15] = _zz_75;
-    _zz_76[14] = _zz_75;
-    _zz_76[13] = _zz_75;
-    _zz_76[12] = _zz_75;
-    _zz_76[11] = _zz_75;
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7] = _zz_75;
-    _zz_76[6] = _zz_75;
-    _zz_76[5] = _zz_75;
-    _zz_76[4] = _zz_75;
-    _zz_76[3] = _zz_75;
-    _zz_76[2] = _zz_75;
-    _zz_76[1] = _zz_75;
-    _zz_76[0] = _zz_75;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_77 = _zz_362[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_77 = _zz_363[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_78 = _zz_364[19];
-  always @ (*) begin
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_80 = _zz_365[11];
-  always @ (*) begin
-    _zz_81[18] = _zz_80;
-    _zz_81[17] = _zz_80;
-    _zz_81[16] = _zz_80;
-    _zz_81[15] = _zz_80;
-    _zz_81[14] = _zz_80;
-    _zz_81[13] = _zz_80;
-    _zz_81[12] = _zz_80;
-    _zz_81[11] = _zz_80;
-    _zz_81[10] = _zz_80;
-    _zz_81[9] = _zz_80;
-    _zz_81[8] = _zz_80;
-    _zz_81[7] = _zz_80;
-    _zz_81[6] = _zz_80;
-    _zz_81[5] = _zz_80;
-    _zz_81[4] = _zz_80;
-    _zz_81[3] = _zz_80;
-    _zz_81[2] = _zz_80;
-    _zz_81[1] = _zz_80;
-    _zz_81[0] = _zz_80;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_79,{{{_zz_496,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_81,{{{_zz_497,_zz_498},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_206 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_207 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_208 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_207;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_210 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_211 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_212 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_274)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_272)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_213 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_272)begin
-      _zz_213 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_273)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_271)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_273)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_271)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_205 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_239 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3973,328 +4056,318 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  always @ (*) begin
-    _zz_51 = 1'b0;
-    if(decode_INSTRUCTION[25])begin
-      if(decode_MEMORY_LRSC)begin
-        _zz_51 = 1'b1;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  always @(*) begin
+    _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
+    if(when_DBusCachedPlugin_l311) begin
+      if(decode_MEMORY_LRSC) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
-      if(decode_MEMORY_AMO)begin
-        _zz_51 = 1'b1;
+      if(decode_MEMORY_AMO) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l311 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
-    _zz_214 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        if(_zz_281)begin
-          _zz_214 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        if(when_DBusCachedPlugin_l499) begin
+          dataCache_1_io_cpu_execute_isValid = 1'b1;
         end
       end
     end
   end
 
-  always @ (*) begin
-    _zz_215 = execute_SRC_ADD;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        _zz_215 = MmuPlugin_dBusAccess_cmd_payload_address;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_address = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
   end
 
-  always @ (*) begin
-    _zz_216 = execute_MEMORY_WR;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        _zz_216 = MmuPlugin_dBusAccess_cmd_payload_write;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_wr = execute_MEMORY_WR;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_args_wr = 1'b0;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_84 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_84 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_84 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_217 = _zz_84;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        _zz_217 = MmuPlugin_dBusAccess_cmd_payload_data;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_size = execute_DBusCachedPlugin_size;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_args_size = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
-  always @ (*) begin
-    _zz_218 = execute_DBusCachedPlugin_size;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        _zz_218 = MmuPlugin_dBusAccess_cmd_payload_size;
-      end
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
+    if(execute_MEMORY_LRSC) begin
+      dataCache_1_io_cpu_execute_args_isLrsc = 1'b1;
     end
   end
 
-  assign _zz_238 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  always @ (*) begin
-    _zz_219 = 1'b0;
-    if(execute_MEMORY_LRSC)begin
-      _zz_219 = 1'b1;
-    end
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        _zz_219 = 1'b0;
-      end
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  always @(*) begin
+    dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+    if(memory_IS_DBUS_SHARING) begin
+      dataCache_1_io_cpu_memory_isValid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_220 = execute_MEMORY_AMO;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        _zz_220 = 1'b0;
-      end
-    end
-  end
-
-  assign _zz_222 = execute_INSTRUCTION[31 : 29];
-  assign _zz_221 = execute_INSTRUCTION[27];
-  always @ (*) begin
-    _zz_223 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-    if(memory_IS_DBUS_SHARING)begin
-      _zz_223 = 1'b1;
-    end
-  end
-
-  assign _zz_224 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_223;
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_224;
-  always @ (*) begin
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
+  always @(*) begin
     DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
-    if(memory_IS_DBUS_SHARING)begin
+    if(memory_IS_DBUS_SHARING) begin
       DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b1;
     end
   end
 
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_225 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_225 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_226 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-    if(writeBack_IS_DBUS_SHARING)begin
-      _zz_226 = 1'b1;
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_IS_DBUS_SHARING) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b1;
+    end
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
     end
   end
 
-  assign _zz_227 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_228 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_282)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_282)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_282)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_366};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_367};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_86[31] = _zz_85;
-    _zz_86[30] = _zz_85;
-    _zz_86[29] = _zz_85;
-    _zz_86[28] = _zz_85;
-    _zz_86[27] = _zz_85;
-    _zz_86[26] = _zz_85;
-    _zz_86[25] = _zz_85;
-    _zz_86[24] = _zz_85;
-    _zz_86[23] = _zz_85;
-    _zz_86[22] = _zz_85;
-    _zz_86[21] = _zz_85;
-    _zz_86[20] = _zz_85;
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15] = _zz_85;
-    _zz_86[14] = _zz_85;
-    _zz_86[13] = _zz_85;
-    _zz_86[12] = _zz_85;
-    _zz_86[11] = _zz_85;
-    _zz_86[10] = _zz_85;
-    _zz_86[9] = _zz_85;
-    _zz_86[8] = _zz_85;
-    _zz_86[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+    if(when_DBusCachedPlugin_l474) begin
+      writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
+    end
   end
 
-  assign _zz_87 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_88[31] = _zz_87;
-    _zz_88[30] = _zz_87;
-    _zz_88[29] = _zz_87;
-    _zz_88[28] = _zz_87;
-    _zz_88[27] = _zz_87;
-    _zz_88[26] = _zz_87;
-    _zz_88[25] = _zz_87;
-    _zz_88[24] = _zz_87;
-    _zz_88[23] = _zz_87;
-    _zz_88[22] = _zz_87;
-    _zz_88[21] = _zz_87;
-    _zz_88[20] = _zz_87;
-    _zz_88[19] = _zz_87;
-    _zz_88[18] = _zz_87;
-    _zz_88[17] = _zz_87;
-    _zz_88[16] = _zz_87;
-    _zz_88[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign when_DBusCachedPlugin_l474 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_320)
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_88;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  always @(*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
-        if(_zz_281)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        if(when_DBusCachedPlugin_l499) begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_280)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l498 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign when_DBusCachedPlugin_l499 = (! dataCache_1_io_cpu_execute_refilling);
   assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
-  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1_io_cpu_writeBack_data;
+  assign MmuPlugin_dBusAccess_rsp_payload_data = writeBack_DBusCachedPlugin_rspRf;
   assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1_io_cpu_writeBack_unalignedAccess || dataCache_1_io_cpu_writeBack_accessError);
   assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1_io_cpu_redo;
   assign MmuPlugin_ports_0_dirty = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+    if(when_MmuPlugin_l125) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
-    if((CsrPlugin_privilege == 2'b11))begin
+    if(when_MmuPlugin_l126) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
   end
 
-  always @ (*) begin
-    MmuPlugin_ports_0_cacheHitsCalc[0] = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[1] = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[2] = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[3] = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-  end
-
+  assign when_MmuPlugin_l125 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l126 = (CsrPlugin_privilege == 2'b11);
+  assign MmuPlugin_ports_0_cacheHitsCalc = {((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_0_cacheHitsCalc)) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_0_cacheHitsCalc_1))),{((MmuPlugin_ports_0_cache_1_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_2) && (MmuPlugin_ports_0_cache_1_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_3)),((MmuPlugin_ports_0_cache_0_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_4) && (MmuPlugin_ports_0_cache_0_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_0_cacheHit = (MmuPlugin_ports_0_cacheHitsCalc != 4'b0000);
-  assign _zz_89 = MmuPlugin_ports_0_cacheHitsCalc[3];
-  assign _zz_90 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_89);
-  assign _zz_91 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_89);
-  assign _zz_92 = {_zz_91,_zz_90};
-  assign MmuPlugin_ports_0_cacheLine_valid = _zz_243;
-  assign MmuPlugin_ports_0_cacheLine_exception = _zz_244;
-  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_245;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_246;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_247;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_248;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_249;
-  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_250;
-  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_251;
-  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_252;
-  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_253;
-  always @ (*) begin
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_1 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_MmuPlugin_ports_0_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_2 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_MmuPlugin_ports_0_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_3 = {_zz_MmuPlugin_ports_0_cacheLine_valid_2,_zz_MmuPlugin_ports_0_cacheLine_valid_1};
+  assign MmuPlugin_ports_0_cacheLine_valid = _zz_MmuPlugin_ports_0_cacheLine_valid_4;
+  assign MmuPlugin_ports_0_cacheLine_exception = _zz_MmuPlugin_ports_0_cacheLine_exception;
+  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_MmuPlugin_ports_0_cacheLine_superPage;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1;
+  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_MmuPlugin_ports_0_cacheLine_allowRead;
+  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_MmuPlugin_ports_0_cacheLine_allowWrite;
+  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_MmuPlugin_ports_0_cacheLine_allowExecute;
+  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_MmuPlugin_ports_0_cacheLine_allowUser;
+  always @(*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(_zz_283)begin
-      if(_zz_284)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274) begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4303,63 +4376,63 @@ module VexRiscv (
   assign MmuPlugin_ports_0_entryToReplace_willClear = 1'b0;
   assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_0_entryToReplace_willOverflow = (MmuPlugin_ports_0_entryToReplace_willOverflowIfInc && MmuPlugin_ports_0_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_369);
-    if(MmuPlugin_ports_0_entryToReplace_willClear)begin
+  always @(*) begin
+    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_MmuPlugin_ports_0_entryToReplace_valueNext);
+    if(MmuPlugin_ports_0_entryToReplace_willClear) begin
       MmuPlugin_ports_0_entryToReplace_valueNext = 2'b00;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
       IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_0_dirty) && MmuPlugin_ports_0_cacheHit) && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_0_dirty || (! MmuPlugin_ports_0_cacheHit));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
@@ -4377,45 +4450,42 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_0_cacheHitsCalc[3];
   assign IBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_0_cache_3_physicalAddress_1,(MmuPlugin_ports_0_cache_3_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_3_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
   assign MmuPlugin_ports_1_dirty = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+    if(when_MmuPlugin_l125_1) begin
       MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
     end
-    if((CsrPlugin_privilege == 2'b11))begin
-      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11)))begin
+    if(when_MmuPlugin_l126_1) begin
+      if(when_MmuPlugin_l128) begin
         MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
       end
     end
   end
 
-  always @ (*) begin
-    MmuPlugin_ports_1_cacheHitsCalc[0] = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[1] = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[2] = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[3] = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-  end
-
+  assign when_MmuPlugin_l125_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l126_1 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l128 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
+  assign MmuPlugin_ports_1_cacheHitsCalc = {((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_1_cacheHitsCalc)) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_1_cacheHitsCalc_1))),{((MmuPlugin_ports_1_cache_1_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_2) && (MmuPlugin_ports_1_cache_1_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_3)),((MmuPlugin_ports_1_cache_0_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_4) && (MmuPlugin_ports_1_cache_0_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_1_cacheHit = (MmuPlugin_ports_1_cacheHitsCalc != 4'b0000);
-  assign _zz_93 = MmuPlugin_ports_1_cacheHitsCalc[3];
-  assign _zz_94 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_93);
-  assign _zz_95 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_93);
-  assign _zz_96 = {_zz_95,_zz_94};
-  assign MmuPlugin_ports_1_cacheLine_valid = _zz_254;
-  assign MmuPlugin_ports_1_cacheLine_exception = _zz_255;
-  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_256;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_257;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_258;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_259;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_260;
-  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_261;
-  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_262;
-  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_263;
-  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_264;
-  always @ (*) begin
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_1 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_MmuPlugin_ports_1_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_2 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_MmuPlugin_ports_1_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_3 = {_zz_MmuPlugin_ports_1_cacheLine_valid_2,_zz_MmuPlugin_ports_1_cacheLine_valid_1};
+  assign MmuPlugin_ports_1_cacheLine_valid = _zz_MmuPlugin_ports_1_cacheLine_valid_4;
+  assign MmuPlugin_ports_1_cacheLine_exception = _zz_MmuPlugin_ports_1_cacheLine_exception;
+  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_MmuPlugin_ports_1_cacheLine_superPage;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1;
+  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_MmuPlugin_ports_1_cacheLine_allowRead;
+  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_MmuPlugin_ports_1_cacheLine_allowWrite;
+  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_MmuPlugin_ports_1_cacheLine_allowExecute;
+  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_MmuPlugin_ports_1_cacheLine_allowUser;
+  always @(*) begin
     MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(_zz_283)begin
-      if(_zz_285)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274_1) begin
         MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4424,63 +4494,63 @@ module VexRiscv (
   assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
   assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_371);
-    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
+  always @(*) begin
+    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_MmuPlugin_ports_1_entryToReplace_valueNext);
+    if(MmuPlugin_ports_1_entryToReplace_willClear) begin
       MmuPlugin_ports_1_entryToReplace_valueNext = 2'b00;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
       DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_1_dirty) && MmuPlugin_ports_1_cacheHit) && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_1_dirty || (! MmuPlugin_ports_1_cacheHit));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
@@ -4497,20 +4567,21 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_1_cache_2_physicalAddress_1,(MmuPlugin_ports_1_cache_2_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_2_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
   assign DBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_1_cacheHitsCalc[3];
   assign DBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_1_cache_3_physicalAddress_1,(MmuPlugin_ports_1_cache_3_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_3_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
-  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_372[0];
-  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_373[0];
-  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_374[0];
-  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_375[0];
-  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_376[0];
-  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_377[0];
-  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_378[0];
-  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_379[0];
+  assign MmuPlugin_shared_dBusRsp_pte_V = MmuPlugin_shared_dBusRspStaged_payload_data[0];
+  assign MmuPlugin_shared_dBusRsp_pte_R = MmuPlugin_shared_dBusRspStaged_payload_data[1];
+  assign MmuPlugin_shared_dBusRsp_pte_W = MmuPlugin_shared_dBusRspStaged_payload_data[2];
+  assign MmuPlugin_shared_dBusRsp_pte_X = MmuPlugin_shared_dBusRspStaged_payload_data[3];
+  assign MmuPlugin_shared_dBusRsp_pte_U = MmuPlugin_shared_dBusRspStaged_payload_data[4];
+  assign MmuPlugin_shared_dBusRsp_pte_G = MmuPlugin_shared_dBusRspStaged_payload_data[5];
+  assign MmuPlugin_shared_dBusRsp_pte_A = MmuPlugin_shared_dBusRspStaged_payload_data[6];
+  assign MmuPlugin_shared_dBusRsp_pte_D = MmuPlugin_shared_dBusRspStaged_payload_data[7];
   assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_shared_dBusRspStaged_payload_data[9 : 8];
   assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_shared_dBusRspStaged_payload_data[19 : 10];
   assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
   assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
-  always @ (*) begin
+  assign when_MmuPlugin_l205 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
+  always @(*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
@@ -4530,8 +4601,8 @@ module VexRiscv (
 
   assign MmuPlugin_dBusAccess_cmd_payload_write = 1'b0;
   assign MmuPlugin_dBusAccess_cmd_payload_size = 2'b10;
-  always @ (*) begin
-    MmuPlugin_dBusAccess_cmd_payload_address = 32'h0;
+  always @(*) begin
+    MmuPlugin_dBusAccess_cmd_payload_address = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
@@ -4548,84 +4619,95 @@ module VexRiscv (
     endcase
   end
 
-  assign MmuPlugin_dBusAccess_cmd_payload_data = 32'h0;
+  assign MmuPlugin_dBusAccess_cmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
   assign MmuPlugin_dBusAccess_cmd_payload_writeMask = 4'bxxxx;
-  always @ (*) begin
-    _zz_97[0] = (((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit));
-    _zz_97[1] = (((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit));
+  assign _zz_MmuPlugin_shared_refills = {(((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit)),(((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit))};
+  always @(*) begin
+    _zz_MmuPlugin_shared_refills_1[0] = _zz_MmuPlugin_shared_refills[1];
+    _zz_MmuPlugin_shared_refills_1[1] = _zz_MmuPlugin_shared_refills[0];
   end
 
-  assign _zz_98 = _zz_97;
-  always @ (*) begin
-    _zz_99[0] = _zz_98[1];
-    _zz_99[1] = _zz_98[0];
+  assign _zz_MmuPlugin_shared_refills_2 = (_zz_MmuPlugin_shared_refills_1 & (~ _zz__zz_MmuPlugin_shared_refills_2));
+  always @(*) begin
+    _zz_MmuPlugin_shared_refills_3[0] = _zz_MmuPlugin_shared_refills_2[1];
+    _zz_MmuPlugin_shared_refills_3[1] = _zz_MmuPlugin_shared_refills_2[0];
   end
 
-  assign _zz_100 = (_zz_99 & (~ _zz_380));
-  always @ (*) begin
-    _zz_101[0] = _zz_100[1];
-    _zz_101[1] = _zz_100[0];
-  end
-
-  assign MmuPlugin_shared_refills = _zz_101;
-  assign _zz_102 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign MmuPlugin_shared_refills = _zz_MmuPlugin_shared_refills_3;
+  assign when_MmuPlugin_l217 = (MmuPlugin_shared_refills != 2'b00);
+  assign _zz_MmuPlugin_shared_vpn_0 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign when_MmuPlugin_l243 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
   assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[0]);
   assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[1]);
-  assign _zz_104 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_105 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_106 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_107 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_108 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_109 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_103 = {(_zz_109 != 1'b0),{(_zz_109 != 1'b0),{((_zz_499 == _zz_500) != 1'b0),{(_zz_501 != 1'b0),{(_zz_502 != _zz_503),{_zz_504,{_zz_505,_zz_506}}}}}}};
-  assign _zz_110 = _zz_103[2 : 1];
-  assign _zz_49 = _zz_110;
-  assign _zz_111 = _zz_103[7 : 6];
-  assign _zz_48 = _zz_111;
-  assign _zz_112 = _zz_103[9 : 8];
-  assign _zz_47 = _zz_112;
-  assign _zz_113 = _zz_103[23 : 22];
-  assign _zz_46 = _zz_113;
-  assign _zz_114 = _zz_103[25 : 24];
-  assign _zz_45 = _zz_114;
-  assign _zz_115 = _zz_103[27 : 26];
-  assign _zz_44 = _zz_115;
-  assign _zz_116 = _zz_103[30 : 29];
-  assign _zz_43 = _zz_116;
+  assign when_MmuPlugin_l272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign when_MmuPlugin_l274 = MmuPlugin_shared_portSortedOh[0];
+  assign when_MmuPlugin_l280 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l280_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l280_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l280_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l274_1 = MmuPlugin_shared_portSortedOh[1];
+  assign when_MmuPlugin_l280_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l280_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l280_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l280_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l304 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_7 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_7 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[26 : 25];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[28 : 27];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[31 : 30];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_240;
-  assign decode_RegFilePlugin_rs2Data = _zz_241;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_117)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_117)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_117)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -4634,353 +4716,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_118 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_118 = {31'd0, _zz_381};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_118 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_119 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_119 = {29'd0, _zz_382};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_119 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_119 = {27'd0, _zz_383};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_120 = _zz_384[11];
-  always @ (*) begin
-    _zz_121[19] = _zz_120;
-    _zz_121[18] = _zz_120;
-    _zz_121[17] = _zz_120;
-    _zz_121[16] = _zz_120;
-    _zz_121[15] = _zz_120;
-    _zz_121[14] = _zz_120;
-    _zz_121[13] = _zz_120;
-    _zz_121[12] = _zz_120;
-    _zz_121[11] = _zz_120;
-    _zz_121[10] = _zz_120;
-    _zz_121[9] = _zz_120;
-    _zz_121[8] = _zz_120;
-    _zz_121[7] = _zz_120;
-    _zz_121[6] = _zz_120;
-    _zz_121[5] = _zz_120;
-    _zz_121[4] = _zz_120;
-    _zz_121[3] = _zz_120;
-    _zz_121[2] = _zz_120;
-    _zz_121[1] = _zz_120;
-    _zz_121[0] = _zz_120;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_122 = _zz_385[11];
-  always @ (*) begin
-    _zz_123[19] = _zz_122;
-    _zz_123[18] = _zz_122;
-    _zz_123[17] = _zz_122;
-    _zz_123[16] = _zz_122;
-    _zz_123[15] = _zz_122;
-    _zz_123[14] = _zz_122;
-    _zz_123[13] = _zz_122;
-    _zz_123[12] = _zz_122;
-    _zz_123[11] = _zz_122;
-    _zz_123[10] = _zz_122;
-    _zz_123[9] = _zz_122;
-    _zz_123[8] = _zz_122;
-    _zz_123[7] = _zz_122;
-    _zz_123[6] = _zz_122;
-    _zz_123[5] = _zz_122;
-    _zz_123[4] = _zz_122;
-    _zz_123[3] = _zz_122;
-    _zz_123[2] = _zz_122;
-    _zz_123[1] = _zz_122;
-    _zz_123[0] = _zz_122;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_124 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_124 = {_zz_121,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_124 = {_zz_123,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_124 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_386;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_125[0] = execute_SRC1[31];
-    _zz_125[1] = execute_SRC1[30];
-    _zz_125[2] = execute_SRC1[29];
-    _zz_125[3] = execute_SRC1[28];
-    _zz_125[4] = execute_SRC1[27];
-    _zz_125[5] = execute_SRC1[26];
-    _zz_125[6] = execute_SRC1[25];
-    _zz_125[7] = execute_SRC1[24];
-    _zz_125[8] = execute_SRC1[23];
-    _zz_125[9] = execute_SRC1[22];
-    _zz_125[10] = execute_SRC1[21];
-    _zz_125[11] = execute_SRC1[20];
-    _zz_125[12] = execute_SRC1[19];
-    _zz_125[13] = execute_SRC1[18];
-    _zz_125[14] = execute_SRC1[17];
-    _zz_125[15] = execute_SRC1[16];
-    _zz_125[16] = execute_SRC1[15];
-    _zz_125[17] = execute_SRC1[14];
-    _zz_125[18] = execute_SRC1[13];
-    _zz_125[19] = execute_SRC1[12];
-    _zz_125[20] = execute_SRC1[11];
-    _zz_125[21] = execute_SRC1[10];
-    _zz_125[22] = execute_SRC1[9];
-    _zz_125[23] = execute_SRC1[8];
-    _zz_125[24] = execute_SRC1[7];
-    _zz_125[25] = execute_SRC1[6];
-    _zz_125[26] = execute_SRC1[5];
-    _zz_125[27] = execute_SRC1[4];
-    _zz_125[28] = execute_SRC1[3];
-    _zz_125[29] = execute_SRC1[2];
-    _zz_125[30] = execute_SRC1[1];
-    _zz_125[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_125 : execute_SRC1);
-  always @ (*) begin
-    _zz_126[0] = memory_SHIFT_RIGHT[31];
-    _zz_126[1] = memory_SHIFT_RIGHT[30];
-    _zz_126[2] = memory_SHIFT_RIGHT[29];
-    _zz_126[3] = memory_SHIFT_RIGHT[28];
-    _zz_126[4] = memory_SHIFT_RIGHT[27];
-    _zz_126[5] = memory_SHIFT_RIGHT[26];
-    _zz_126[6] = memory_SHIFT_RIGHT[25];
-    _zz_126[7] = memory_SHIFT_RIGHT[24];
-    _zz_126[8] = memory_SHIFT_RIGHT[23];
-    _zz_126[9] = memory_SHIFT_RIGHT[22];
-    _zz_126[10] = memory_SHIFT_RIGHT[21];
-    _zz_126[11] = memory_SHIFT_RIGHT[20];
-    _zz_126[12] = memory_SHIFT_RIGHT[19];
-    _zz_126[13] = memory_SHIFT_RIGHT[18];
-    _zz_126[14] = memory_SHIFT_RIGHT[17];
-    _zz_126[15] = memory_SHIFT_RIGHT[16];
-    _zz_126[16] = memory_SHIFT_RIGHT[15];
-    _zz_126[17] = memory_SHIFT_RIGHT[14];
-    _zz_126[18] = memory_SHIFT_RIGHT[13];
-    _zz_126[19] = memory_SHIFT_RIGHT[12];
-    _zz_126[20] = memory_SHIFT_RIGHT[11];
-    _zz_126[21] = memory_SHIFT_RIGHT[10];
-    _zz_126[22] = memory_SHIFT_RIGHT[9];
-    _zz_126[23] = memory_SHIFT_RIGHT[8];
-    _zz_126[24] = memory_SHIFT_RIGHT[7];
-    _zz_126[25] = memory_SHIFT_RIGHT[6];
-    _zz_126[26] = memory_SHIFT_RIGHT[5];
-    _zz_126[27] = memory_SHIFT_RIGHT[4];
-    _zz_126[28] = memory_SHIFT_RIGHT[3];
-    _zz_126[29] = memory_SHIFT_RIGHT[2];
-    _zz_126[30] = memory_SHIFT_RIGHT[1];
-    _zz_126[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_127 = 1'b0;
-    if(_zz_286)begin
-      if(_zz_287)begin
-        if(_zz_132)begin
-          _zz_127 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_288)begin
-      if(_zz_289)begin
-        if(_zz_134)begin
-          _zz_127 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_290)begin
-      if(_zz_291)begin
-        if(_zz_136)begin
-          _zz_127 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_127 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_128 = 1'b0;
-    if(_zz_286)begin
-      if(_zz_287)begin
-        if(_zz_133)begin
-          _zz_128 = 1'b1;
-        end
-      end
-    end
-    if(_zz_288)begin
-      if(_zz_289)begin
-        if(_zz_135)begin
-          _zz_128 = 1'b1;
-        end
-      end
-    end
-    if(_zz_290)begin
-      if(_zz_291)begin
-        if(_zz_137)begin
-          _zz_128 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_128 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_132 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_133 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_134 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_135 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_136 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_137 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_138 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_138 == 3'b000)) begin
-        _zz_139 = execute_BranchPlugin_eq;
-    end else if((_zz_138 == 3'b001)) begin
-        _zz_139 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_138 & 3'b101) == 3'b101))) begin
-        _zz_139 = (! execute_SRC_LESS);
-    end else begin
-        _zz_139 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_140 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_140 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_140 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_140 = _zz_139;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_141 = _zz_393[11];
-  always @ (*) begin
-    _zz_142[19] = _zz_141;
-    _zz_142[18] = _zz_141;
-    _zz_142[17] = _zz_141;
-    _zz_142[16] = _zz_141;
-    _zz_142[15] = _zz_141;
-    _zz_142[14] = _zz_141;
-    _zz_142[13] = _zz_141;
-    _zz_142[12] = _zz_141;
-    _zz_142[11] = _zz_141;
-    _zz_142[10] = _zz_141;
-    _zz_142[9] = _zz_141;
-    _zz_142[8] = _zz_141;
-    _zz_142[7] = _zz_141;
-    _zz_142[6] = _zz_141;
-    _zz_142[5] = _zz_141;
-    _zz_142[4] = _zz_141;
-    _zz_142[3] = _zz_141;
-    _zz_142[2] = _zz_141;
-    _zz_142[1] = _zz_141;
-    _zz_142[0] = _zz_141;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_143 = _zz_394[19];
-  always @ (*) begin
-    _zz_144[10] = _zz_143;
-    _zz_144[9] = _zz_143;
-    _zz_144[8] = _zz_143;
-    _zz_144[7] = _zz_143;
-    _zz_144[6] = _zz_143;
-    _zz_144[5] = _zz_143;
-    _zz_144[4] = _zz_143;
-    _zz_144[3] = _zz_143;
-    _zz_144[2] = _zz_143;
-    _zz_144[1] = _zz_143;
-    _zz_144[0] = _zz_143;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_145 = _zz_395[11];
-  always @ (*) begin
-    _zz_146[18] = _zz_145;
-    _zz_146[17] = _zz_145;
-    _zz_146[16] = _zz_145;
-    _zz_146[15] = _zz_145;
-    _zz_146[14] = _zz_145;
-    _zz_146[13] = _zz_145;
-    _zz_146[12] = _zz_145;
-    _zz_146[11] = _zz_145;
-    _zz_146[10] = _zz_145;
-    _zz_146[9] = _zz_145;
-    _zz_146[8] = _zz_145;
-    _zz_146[7] = _zz_145;
-    _zz_146[6] = _zz_145;
-    _zz_146[5] = _zz_145;
-    _zz_146[4] = _zz_145;
-    _zz_146[3] = _zz_145;
-    _zz_146[2] = _zz_145;
-    _zz_146[1] = _zz_145;
-    _zz_146[0] = _zz_145;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_147 = (_zz_396[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_147 = _zz_397[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_147 = _zz_398[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_147);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -4991,80 +5096,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_148 = _zz_399[11];
-  always @ (*) begin
-    _zz_149[19] = _zz_148;
-    _zz_149[18] = _zz_148;
-    _zz_149[17] = _zz_148;
-    _zz_149[16] = _zz_148;
-    _zz_149[15] = _zz_148;
-    _zz_149[14] = _zz_148;
-    _zz_149[13] = _zz_148;
-    _zz_149[12] = _zz_148;
-    _zz_149[11] = _zz_148;
-    _zz_149[10] = _zz_148;
-    _zz_149[9] = _zz_148;
-    _zz_149[8] = _zz_148;
-    _zz_149[7] = _zz_148;
-    _zz_149[6] = _zz_148;
-    _zz_149[5] = _zz_148;
-    _zz_149[4] = _zz_148;
-    _zz_149[3] = _zz_148;
-    _zz_149[2] = _zz_148;
-    _zz_149[1] = _zz_148;
-    _zz_149[0] = _zz_148;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_149,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_151,{{{_zz_698,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_153,{{{_zz_699,_zz_700},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_402};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_150 = _zz_400[19];
-  always @ (*) begin
-    _zz_151[10] = _zz_150;
-    _zz_151[9] = _zz_150;
-    _zz_151[8] = _zz_150;
-    _zz_151[7] = _zz_150;
-    _zz_151[6] = _zz_150;
-    _zz_151[5] = _zz_150;
-    _zz_151[4] = _zz_150;
-    _zz_151[3] = _zz_150;
-    _zz_151[2] = _zz_150;
-    _zz_151[1] = _zz_150;
-    _zz_151[0] = _zz_150;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_152 = _zz_401[11];
-  always @ (*) begin
-    _zz_153[18] = _zz_152;
-    _zz_153[17] = _zz_152;
-    _zz_153[16] = _zz_152;
-    _zz_153[15] = _zz_152;
-    _zz_153[14] = _zz_152;
-    _zz_153[13] = _zz_152;
-    _zz_153[12] = _zz_152;
-    _zz_153[11] = _zz_152;
-    _zz_153[10] = _zz_152;
-    _zz_153[9] = _zz_152;
-    _zz_153[8] = _zz_152;
-    _zz_153[7] = _zz_152;
-    _zz_153[6] = _zz_152;
-    _zz_153[5] = _zz_152;
-    _zz_153[4] = _zz_152;
-    _zz_153[3] = _zz_152;
-    _zz_153[2] = _zz_152;
-    _zz_153[1] = _zz_152;
-    _zz_153[0] = _zz_152;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -5074,9 +5179,9 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
-    CsrPlugin_privilege = _zz_154;
-    if(CsrPlugin_forceMachineWire)begin
+  always @(*) begin
+    CsrPlugin_privilege = _zz_CsrPlugin_privilege;
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
@@ -5084,82 +5189,93 @@ module VexRiscv (
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeInstruction)begin
-        CsrPlugin_redoInterface_valid = 1'b1;
-      end
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
+      CsrPlugin_redoInterface_valid = 1'b1;
     end
   end
 
   assign CsrPlugin_redoInterface_payload = decode_PC;
-  assign _zz_155 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_156 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_157 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_158 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_159 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_160 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  always @ (*) begin
+  always @(*) begin
+    CsrPlugin_rescheduleLogic_rescheduleNext = 1'b0;
+    if(when_CsrPlugin_l803) begin
+      CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
+    end
+    if(execute_CsrPlugin_csr_384) begin
+      if(execute_CsrPlugin_writeInstruction) begin
+        CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
+      end
+    end
+  end
+
+  assign when_CsrPlugin_l803 = (execute_arbitration_isValid && execute_IS_SFENCE_VMA);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_when_CsrPlugin_l952_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
       4'b0000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_1) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0010 : begin
-        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_2) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_3) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_4) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_5) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_6) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_7) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_8) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_9) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_10) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_11) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
@@ -5168,81 +5284,114 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l866 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
+  assign when_CsrPlugin_l866_3 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_4 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_5 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_6 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_7 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
+  assign when_CsrPlugin_l866_8 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
+  assign when_CsrPlugin_l866_9 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
+  assign when_CsrPlugin_l866_10 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
+  assign when_CsrPlugin_l866_11 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_161 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_162 = _zz_403[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_275)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign when_CsrPlugin_l946_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign when_CsrPlugin_l952_3 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign when_CsrPlugin_l952_4 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign when_CsrPlugin_l952_5 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign when_CsrPlugin_l952_6 = ((_zz_when_CsrPlugin_l952_3 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_7 = ((_zz_when_CsrPlugin_l952_4 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_8 = ((_zz_when_CsrPlugin_l952_5 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
@@ -5256,8 +5405,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
         CsrPlugin_xtvec_base = CsrPlugin_stvec_base;
@@ -5270,151 +5419,160 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_256)begin
+    if(execute_CsrPlugin_csr_256) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_384)begin
+    if(execute_CsrPlugin_csr_384) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_770)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_770) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_771)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_771) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_324)begin
+    if(execute_CsrPlugin_csr_324) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_260)begin
+    if(execute_CsrPlugin_csr_260) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_261)begin
+    if(execute_CsrPlugin_csr_261) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_321)begin
+    if(execute_CsrPlugin_csr_321) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_320)begin
+    if(execute_CsrPlugin_csr_320) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_322)begin
+    if(execute_CsrPlugin_csr_322) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_323)begin
+    if(execute_CsrPlugin_csr_323) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_2496)begin
+    if(execute_CsrPlugin_csr_2496) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3520)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3520) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_292)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_293)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_294)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_293)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_294)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5430,48 +5588,58 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_292)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_292)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  always @ (*) begin
-    execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-    if(execute_CsrPlugin_csr_836)begin
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  always @(*) begin
+    execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_readToWriteData[9 : 9] = CsrPlugin_sip_SEIP_SOFT;
     end
-    if(execute_CsrPlugin_csr_324)begin
+    if(execute_CsrPlugin_csr_324) begin
       execute_CsrPlugin_readToWriteData[9 : 9] = CsrPlugin_sip_SEIP_SOFT;
     end
   end
 
-  always @ (*) begin
-    case(_zz_321)
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || execute_IS_SFENCE_VMA));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_295)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5484,8 +5652,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_295)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5504,81 +5672,160 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_405) + $signed(_zz_406));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_270)begin
-      if(_zz_296)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_297)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_410);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_163 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_163[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_411);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_412 : _zz_413);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_414[31:0];
-  assign _zz_164 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_165 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_166 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_167[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_167[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_169 = (_zz_168 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_169 != 32'h0);
-  assign _zz_171 = (_zz_170 & externalInterruptArray_regNext);
-  assign externalInterruptS = (_zz_171 != 32'h0);
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_52 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_3 = (_zz_CsrPlugin_csrMapping_readDataInit_2 & externalInterruptArray_regNext);
+  assign externalInterruptS = (_zz_CsrPlugin_csrMapping_readDataInit_3 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_36 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_68 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_69 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5599,267 +5846,305 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_172[12 : 0] = 13'h1000;
-      _zz_172[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_173[19 : 19] = MmuPlugin_status_mxr;
-      _zz_173[18 : 18] = MmuPlugin_status_sum;
-      _zz_173[17 : 17] = MmuPlugin_status_mprv;
-      _zz_173[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_173[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_173[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_173[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_173[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_173[1 : 1] = CsrPlugin_sstatus_SIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
-  always @ (*) begin
-    _zz_174 = 32'h0;
-    if(execute_CsrPlugin_csr_256)begin
-      _zz_174[19 : 19] = MmuPlugin_status_mxr;
-      _zz_174[18 : 18] = MmuPlugin_status_sum;
-      _zz_174[17 : 17] = MmuPlugin_status_mprv;
-      _zz_174[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_174[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_174[1 : 1] = CsrPlugin_sstatus_SIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_256) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_384)begin
-      _zz_175[31 : 31] = MmuPlugin_satp_mode;
-      _zz_175[30 : 22] = MmuPlugin_satp_asid;
-      _zz_175[19 : 0] = MmuPlugin_satp_ppn;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_384) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = MmuPlugin_satp_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[30 : 22] = MmuPlugin_satp_asid;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[19 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_176[0 : 0] = 1'b1;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[0 : 0] = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_177[1 : 0] = 2'b10;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 0] = 2'b10;
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_178[1 : 0] = 2'b11;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = 2'b11;
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_179[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_179[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_179[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_179[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_179[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_179[9 : 9] = CsrPlugin_sip_SEIP_OR;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_180[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_180[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_180[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_180[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_180[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_180[1 : 1] = CsrPlugin_sie_SSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_181[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_182[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_183 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_183[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_183[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_184 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_184[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_185 = 32'h0;
-    if(execute_CsrPlugin_csr_324)begin
-      _zz_185[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_185[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_185[9 : 9] = CsrPlugin_sip_SEIP_OR;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_324) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
-  always @ (*) begin
-    _zz_186 = 32'h0;
-    if(execute_CsrPlugin_csr_260)begin
-      _zz_186[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_186[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_186[1 : 1] = CsrPlugin_sie_SSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_260) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_187 = 32'h0;
-    if(execute_CsrPlugin_csr_261)begin
-      _zz_187[31 : 2] = CsrPlugin_stvec_base;
-      _zz_187[1 : 0] = CsrPlugin_stvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_261) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 2] = CsrPlugin_stvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_19[1 : 0] = CsrPlugin_stvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_188 = 32'h0;
-    if(execute_CsrPlugin_csr_321)begin
-      _zz_188[31 : 0] = CsrPlugin_sepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_321) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_sepc;
     end
   end
 
-  always @ (*) begin
-    _zz_189 = 32'h0;
-    if(execute_CsrPlugin_csr_320)begin
-      _zz_189[31 : 0] = CsrPlugin_sscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_320) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_190 = 32'h0;
-    if(execute_CsrPlugin_csr_322)begin
-      _zz_190[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_190[3 : 0] = CsrPlugin_scause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_322) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_191 = 32'h0;
-    if(execute_CsrPlugin_csr_323)begin
-      _zz_191[31 : 0] = CsrPlugin_stval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_323) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = CsrPlugin_stval;
     end
   end
 
-  always @ (*) begin
-    _zz_192 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_192[31 : 0] = _zz_168;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_193 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_193[31 : 0] = _zz_169;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  always @ (*) begin
-    _zz_194 = 32'h0;
-    if(execute_CsrPlugin_csr_2496)begin
-      _zz_194[31 : 0] = _zz_170;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h0;
+    if(execute_CsrPlugin_csr_2496) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_26[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_2;
     end
   end
 
-  always @ (*) begin
-    _zz_195 = 32'h0;
-    if(execute_CsrPlugin_csr_3520)begin
-      _zz_195[31 : 0] = _zz_171;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_27 = 32'h0;
+    if(execute_CsrPlugin_csr_3520) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_27[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_3;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_172 | _zz_173) | (_zz_174 | _zz_175)) | ((_zz_176 | _zz_177) | (_zz_178 | _zz_701))) | (((_zz_179 | _zz_180) | (_zz_181 | _zz_182)) | ((_zz_183 | _zz_184) | (_zz_185 | _zz_186)))) | ((((_zz_187 | _zz_188) | (_zz_189 | _zz_190)) | ((_zz_191 | _zz_192) | (_zz_193 | _zz_194))) | _zz_195));
-  assign iBusWishbone_ADR = {_zz_469,_zz_196};
-  assign iBusWishbone_CTI = ((_zz_196 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7)) | ((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_28))) | (((_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12) | (_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14)) | ((_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16) | (_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20) | (_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22)) | ((_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24) | (_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | _zz_CsrPlugin_csrMapping_readDataInit_27));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_298)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_298)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_197;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_203 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_199 = dBus_cmd_valid;
-  assign _zz_201 = dBus_cmd_payload_wr;
-  assign _zz_202 = (_zz_198 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_200 && (_zz_201 || _zz_202));
-  assign dBusWishbone_ADR = ((_zz_203 ? {{dBus_cmd_payload_address[31 : 5],_zz_198},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_203 ? (_zz_202 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_201 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_201;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_200 = (_zz_199 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_199;
-  assign dBusWishbone_STB = _zz_199;
-  assign dBus_rsp_valid = _zz_204;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_67 <= 1'b0;
-      _zz_69 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_82;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_83;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
@@ -5877,9 +6162,9 @@ module VexRiscv (
       MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
       MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
       MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
-      _zz_117 <= 1'b1;
-      _zz_129 <= 1'b0;
-      _zz_154 <= 2'b11;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
+      _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -5922,204 +6207,204 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_168 <= 32'h0;
-      _zz_170 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit_2 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
-      _zz_196 <= 3'b000;
-      _zz_197 <= 1'b0;
-      _zz_198 <= 3'b000;
-      _zz_204 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_65)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_69 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_69 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_299)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
       MmuPlugin_ports_0_entryToReplace_value <= MmuPlugin_ports_0_entryToReplace_valueNext;
-      if(contextSwitching)begin
-        if(MmuPlugin_ports_0_cache_0_exception)begin
+      if(contextSwitching) begin
+        if(MmuPlugin_ports_0_cache_0_exception) begin
           MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_1_exception)begin
+        if(MmuPlugin_ports_0_cache_1_exception) begin
           MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_2_exception)begin
+        if(MmuPlugin_ports_0_cache_2_exception) begin
           MmuPlugin_ports_0_cache_2_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_3_exception)begin
+        if(MmuPlugin_ports_0_cache_3_exception) begin
           MmuPlugin_ports_0_cache_3_valid <= 1'b0;
         end
       end
       MmuPlugin_ports_1_entryToReplace_value <= MmuPlugin_ports_1_entryToReplace_valueNext;
-      if(contextSwitching)begin
-        if(MmuPlugin_ports_1_cache_0_exception)begin
+      if(contextSwitching) begin
+        if(MmuPlugin_ports_1_cache_0_exception) begin
           MmuPlugin_ports_1_cache_0_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_1_exception)begin
+        if(MmuPlugin_ports_1_cache_1_exception) begin
           MmuPlugin_ports_1_cache_1_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_2_exception)begin
+        if(MmuPlugin_ports_1_cache_2_exception) begin
           MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_3_exception)begin
+        if(MmuPlugin_ports_1_cache_3_exception) begin
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
       end
       MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
       case(MmuPlugin_shared_state_1)
         `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-          if(_zz_300)begin
+          if(when_MmuPlugin_l217) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
-          if(MmuPlugin_dBusAccess_cmd_ready)begin
+          if(MmuPlugin_dBusAccess_cmd_ready) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
-          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+          if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
-            if((MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception))begin
+            if(when_MmuPlugin_l243) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
             end
-            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
             end
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
-          if(MmuPlugin_dBusAccess_cmd_ready)begin
+          if(MmuPlugin_dBusAccess_cmd_ready) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
           end
         end
         default : begin
-          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+          if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             end
           end
         end
       endcase
-      if(_zz_283)begin
-        if(_zz_284)begin
-          if(_zz_301)begin
+      if(when_MmuPlugin_l272) begin
+        if(when_MmuPlugin_l274) begin
+          if(when_MmuPlugin_l280) begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(_zz_302)begin
+          if(when_MmuPlugin_l280_1) begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(_zz_303)begin
+          if(when_MmuPlugin_l280_2) begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(_zz_304)begin
+          if(when_MmuPlugin_l280_3) begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(_zz_285)begin
-          if(_zz_305)begin
+        if(when_MmuPlugin_l274_1) begin
+          if(when_MmuPlugin_l280_4) begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(_zz_306)begin
+          if(when_MmuPlugin_l280_5) begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(_zz_307)begin
+          if(when_MmuPlugin_l280_6) begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(_zz_308)begin
+          if(when_MmuPlugin_l280_7) begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
       end
-      if((writeBack_arbitration_isValid && writeBack_IS_SFENCE_VMA))begin
+      if(when_MmuPlugin_l304) begin
         MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6129,83 +6414,83 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_117 <= 1'b0;
-      _zz_129 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_309)begin
-        if(_zz_310)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_311)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_312)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(_zz_313)begin
-        if(_zz_314)begin
+      if(when_CsrPlugin_l946_1) begin
+        if(when_CsrPlugin_l952_3) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_315)begin
+        if(when_CsrPlugin_l952_4) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_316)begin
+        if(when_CsrPlugin_l952_5) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_317)begin
+        if(when_CsrPlugin_l952_6) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_318)begin
+        if(when_CsrPlugin_l952_7) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_319)begin
+        if(when_CsrPlugin_l952_8) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_277)begin
-        _zz_154 <= CsrPlugin_targetPrivilege;
+      if(when_CsrPlugin_l1019) begin
+        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b01 : begin
             CsrPlugin_sstatus_SIE <= 1'b0;
@@ -6221,78 +6506,82 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_278)begin
-        case(_zz_279)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_154 <= CsrPlugin_mstatus_MPP;
+            _zz_CsrPlugin_privilege <= CsrPlugin_mstatus_MPP;
           end
           2'b01 : begin
             CsrPlugin_sstatus_SPP <= 1'b0;
             CsrPlugin_sstatus_SIE <= CsrPlugin_sstatus_SPIE;
             CsrPlugin_sstatus_SPIE <= 1'b1;
-            _zz_154 <= {1'b0,CsrPlugin_sstatus_SPP};
+            _zz_CsrPlugin_privilege <= {1'b0,CsrPlugin_sstatus_SPP};
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_160,{_zz_159,{_zz_158,{_zz_157,{_zz_156,_zz_155}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_5,{_zz_when_CsrPlugin_l952_4,{_zz_when_CsrPlugin_l952_3,{_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! memory_arbitration_isStuck))begin
+      if(when_Pipeline_l124_57) begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Pipeline_l124_58) begin
         memory_to_writeBack_IS_DBUS_SHARING <= memory_IS_DBUS_SHARING;
       end
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(MmuPlugin_dBusAccess_rsp_valid)begin
+      if(MmuPlugin_dBusAccess_rsp_valid) begin
         memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_424[0];
-          MmuPlugin_status_sum <= _zz_425[0];
-          MmuPlugin_status_mprv <= _zz_426[0];
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_427[0];
-          CsrPlugin_mstatus_MIE <= _zz_428[0];
-          CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_429[0];
-          CsrPlugin_sstatus_SIE <= _zz_430[0];
+      if(MmuPlugin_dBusAccess_rsp_valid) begin
+        memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
+      end
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_status_mxr <= CsrPlugin_csrMapping_writeDataSignal[19];
+          MmuPlugin_status_sum <= CsrPlugin_csrMapping_writeDataSignal[18];
+          MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          CsrPlugin_sstatus_SPP <= CsrPlugin_csrMapping_writeDataSignal[8 : 8];
+          CsrPlugin_sstatus_SPIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sstatus_SIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_256)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_431[0];
-          MmuPlugin_status_sum <= _zz_432[0];
-          MmuPlugin_status_mprv <= _zz_433[0];
-          CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_434[0];
-          CsrPlugin_sstatus_SIE <= _zz_435[0];
+      if(execute_CsrPlugin_csr_256) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_status_mxr <= CsrPlugin_csrMapping_writeDataSignal[19];
+          MmuPlugin_status_sum <= CsrPlugin_csrMapping_writeDataSignal[18];
+          MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
+          CsrPlugin_sstatus_SPP <= CsrPlugin_csrMapping_writeDataSignal[8 : 8];
+          CsrPlugin_sstatus_SPIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sstatus_SIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_384)begin
-        if(execute_CsrPlugin_writeInstruction)begin
+      if(execute_CsrPlugin_csr_384) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_satp_mode <= CsrPlugin_csrMapping_writeDataSignal[31];
           MmuPlugin_ports_0_cache_0_valid <= 1'b0;
           MmuPlugin_ports_0_cache_1_valid <= 1'b0;
           MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6302,122 +6591,119 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_valid <= 1'b0;
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_satp_mode <= _zz_436[0];
+      end
+      if(execute_CsrPlugin_csr_836) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sip_STIP <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sip_SSIP <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_sip_SEIP_SOFT <= CsrPlugin_csrMapping_writeDataSignal[9];
         end
       end
-      if(execute_CsrPlugin_csr_836)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_438[0];
-          CsrPlugin_sip_SSIP <= _zz_439[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_440[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          CsrPlugin_sie_SEIE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_sie_STIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sie_SSIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_441[0];
-          CsrPlugin_mie_MTIE <= _zz_442[0];
-          CsrPlugin_mie_MSIE <= _zz_443[0];
-          CsrPlugin_sie_SEIE <= _zz_444[0];
-          CsrPlugin_sie_STIE <= _zz_445[0];
-          CsrPlugin_sie_SSIE <= _zz_446[0];
+      if(execute_CsrPlugin_csr_770) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_medeleg_IAM <= CsrPlugin_csrMapping_writeDataSignal[0];
+          CsrPlugin_medeleg_IAF <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_medeleg_II <= CsrPlugin_csrMapping_writeDataSignal[2];
+          CsrPlugin_medeleg_LAM <= CsrPlugin_csrMapping_writeDataSignal[4];
+          CsrPlugin_medeleg_LAF <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_medeleg_SAM <= CsrPlugin_csrMapping_writeDataSignal[6];
+          CsrPlugin_medeleg_SAF <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_medeleg_EU <= CsrPlugin_csrMapping_writeDataSignal[8];
+          CsrPlugin_medeleg_ES <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_medeleg_IPF <= CsrPlugin_csrMapping_writeDataSignal[12];
+          CsrPlugin_medeleg_LPF <= CsrPlugin_csrMapping_writeDataSignal[13];
+          CsrPlugin_medeleg_SPF <= CsrPlugin_csrMapping_writeDataSignal[15];
         end
       end
-      if(execute_CsrPlugin_csr_770)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_medeleg_IAM <= _zz_447[0];
-          CsrPlugin_medeleg_IAF <= _zz_448[0];
-          CsrPlugin_medeleg_II <= _zz_449[0];
-          CsrPlugin_medeleg_LAM <= _zz_450[0];
-          CsrPlugin_medeleg_LAF <= _zz_451[0];
-          CsrPlugin_medeleg_SAM <= _zz_452[0];
-          CsrPlugin_medeleg_SAF <= _zz_453[0];
-          CsrPlugin_medeleg_EU <= _zz_454[0];
-          CsrPlugin_medeleg_ES <= _zz_455[0];
-          CsrPlugin_medeleg_IPF <= _zz_456[0];
-          CsrPlugin_medeleg_LPF <= _zz_457[0];
-          CsrPlugin_medeleg_SPF <= _zz_458[0];
+      if(execute_CsrPlugin_csr_771) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mideleg_SE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_mideleg_ST <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_mideleg_SS <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_771)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mideleg_SE <= _zz_459[0];
-          CsrPlugin_mideleg_ST <= _zz_460[0];
-          CsrPlugin_mideleg_SS <= _zz_461[0];
+      if(execute_CsrPlugin_csr_324) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sip_STIP <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sip_SSIP <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_sip_SEIP_SOFT <= CsrPlugin_csrMapping_writeDataSignal[9];
         end
       end
-      if(execute_CsrPlugin_csr_324)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_462[0];
-          CsrPlugin_sip_SSIP <= _zz_463[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_464[0];
+      if(execute_CsrPlugin_csr_260) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sie_SEIE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_sie_STIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sie_SSIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_260)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sie_SEIE <= _zz_465[0];
-          CsrPlugin_sie_STIE <= _zz_466[0];
-          CsrPlugin_sie_SSIE <= _zz_467[0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_168 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_2496) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_2496)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_170 <= execute_CsrPlugin_writeData[31 : 0];
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      if(_zz_298)begin
-        if(iBusWishbone_ACK)begin
-          _zz_196 <= (_zz_196 + 3'b001);
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_197 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_199 && _zz_200))begin
-        _zz_198 <= (_zz_198 + 3'b001);
-        if(_zz_202)begin
-          _zz_198 <= 3'b000;
-        end
-      end
-      _zz_204 <= ((_zz_199 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_70 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_299)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
     MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
     MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
-    if((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)))begin
+    if(when_MmuPlugin_l205) begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -6432,10 +6718,10 @@ module VexRiscv (
     end
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-        if(_zz_300)begin
+        if(when_MmuPlugin_l217) begin
           MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
-          MmuPlugin_shared_vpn_1 <= _zz_102[31 : 22];
-          MmuPlugin_shared_vpn_0 <= _zz_102[21 : 12];
+          MmuPlugin_shared_vpn_1 <= _zz_MmuPlugin_shared_vpn_0[31 : 22];
+          MmuPlugin_shared_vpn_0 <= _zz_MmuPlugin_shared_vpn_0[21 : 12];
         end
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -6447,9 +6733,9 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(_zz_283)begin
-      if(_zz_284)begin
-        if(_zz_301)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274) begin
+        if(when_MmuPlugin_l280) begin
           MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6461,7 +6747,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_302)begin
+        if(when_MmuPlugin_l280_1) begin
           MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6473,7 +6759,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_303)begin
+        if(when_MmuPlugin_l280_2) begin
           MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6485,7 +6771,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_304)begin
+        if(when_MmuPlugin_l280_3) begin
           MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6498,8 +6784,8 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
-      if(_zz_285)begin
-        if(_zz_305)begin
+      if(when_MmuPlugin_l274_1) begin
+        if(when_MmuPlugin_l280_4) begin
           MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6511,7 +6797,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_306)begin
+        if(when_MmuPlugin_l280_5) begin
           MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6523,7 +6809,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_307)begin
+        if(when_MmuPlugin_l280_6) begin
           MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6535,7 +6821,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_308)begin
+        if(when_MmuPlugin_l280_7) begin
           MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6549,79 +6835,79 @@ module VexRiscv (
         end
       end
     end
-    _zz_130 <= _zz_40[11 : 7];
-    _zz_131 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_sip_SEIP_INPUT <= externalInterruptS;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_275)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_162 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_162 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_309)begin
-      if(_zz_310)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_311)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_312)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(_zz_313)begin
-      if(_zz_314)begin
+    if(when_CsrPlugin_l946_1) begin
+      if(when_CsrPlugin_l952_3) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_315)begin
+      if(when_CsrPlugin_l952_4) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_316)begin
+      if(when_CsrPlugin_l952_5) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_317)begin
+      if(when_CsrPlugin_l952_6) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_318)begin
+      if(when_CsrPlugin_l952_7) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_319)begin
+      if(when_CsrPlugin_l952_8) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_277)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b01 : begin
           CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_sepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -6629,7 +6915,7 @@ module VexRiscv (
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -6637,365 +6923,368 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_270)begin
-      if(_zz_296)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_415[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_297)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_166 ? (~ _zz_167) : _zz_167) + _zz_421);
-      memory_DivPlugin_rs2 <= ((_zz_165 ? (~ execute_RS2) : execute_RS2) + _zz_423);
-      memory_DivPlugin_div_needRevert <= ((_zz_166 ^ (_zz_165 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_55;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_execute_to_memory_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_28) begin
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_30) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
+    end
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_34) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_35) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_36) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_39) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_40) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_41) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_55) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_56) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_59) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_60) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_63) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_64) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_65) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_66) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_67) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_68) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_69) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_384 <= (decode_INSTRUCTION[31 : 20] == 12'h180);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_770 <= (decode_INSTRUCTION[31 : 20] == 12'h302);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_771 <= (decode_INSTRUCTION[31 : 20] == 12'h303);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_324 <= (decode_INSTRUCTION[31 : 20] == 12'h144);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_260 <= (decode_INSTRUCTION[31 : 20] == 12'h104);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_261 <= (decode_INSTRUCTION[31 : 20] == 12'h105);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_321 <= (decode_INSTRUCTION[31 : 20] == 12'h141);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_320 <= (decode_INSTRUCTION[31 : 20] == 12'h140);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_322 <= (decode_INSTRUCTION[31 : 20] == 12'h142);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_323 <= (decode_INSTRUCTION[31 : 20] == 12'h143);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_24) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_25) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_26) begin
       execute_CsrPlugin_csr_2496 <= (decode_INSTRUCTION[31 : 20] == 12'h9c0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_27) begin
       execute_CsrPlugin_csr_3520 <= (decode_INSTRUCTION[31 : 20] == 12'hdc0);
     end
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        MmuPlugin_satp_asid <= execute_CsrPlugin_writeData[30 : 22];
-        MmuPlugin_satp_ppn <= execute_CsrPlugin_writeData[19 : 0];
+    if(execute_CsrPlugin_csr_384) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        MmuPlugin_satp_asid <= CsrPlugin_csrMapping_writeDataSignal[30 : 22];
+        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[19 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_437[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_261)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_stvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_stvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_261) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_stvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_stvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_321)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_sepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_321) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_sepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_320)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_sscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_320) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_sscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_322)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_scause_interrupt <= _zz_468[0];
-        CsrPlugin_scause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_322) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_scause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_scause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_323)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_stval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_323) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_stval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -7008,9 +7297,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_isLrsc,
   input               io_cpu_execute_args_isAmo,
@@ -7044,6 +7332,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -7059,9 +7348,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -7069,7 +7359,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -7078,38 +7368,23 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire                _zz_19;
-  wire                _zz_20;
-  wire                _zz_21;
-  wire                _zz_22;
-  wire       [2:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [0:0]    _zz_25;
-  wire       [9:0]    _zz_26;
-  wire       [9:0]    _zz_27;
-  wire       [31:0]   _zz_28;
-  wire       [31:0]   _zz_29;
-  wire       [31:0]   _zz_30;
-  wire       [31:0]   _zz_31;
-  wire       [1:0]    _zz_32;
-  wire       [31:0]   _zz_33;
-  wire       [1:0]    _zz_34;
-  wire       [1:0]    _zz_35;
-  wire       [0:0]    _zz_36;
-  wire       [0:0]    _zz_37;
-  wire       [0:0]    _zz_38;
-  wire       [2:0]    _zz_39;
-  wire       [1:0]    _zz_40;
-  wire       [21:0]   _zz_41;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [31:0]   _zz_stageB_amo_addSub;
+  wire       [31:0]   _zz_stageB_amo_addSub_1;
+  wire       [31:0]   _zz_stageB_amo_addSub_2;
+  wire       [31:0]   _zz_stageB_amo_addSub_3;
+  wire       [31:0]   _zz_stageB_amo_addSub_4;
+  wire       [1:0]    _zz_stageB_amo_addSub_5;
+  wire       [1:0]    _zz_stageB_amo_addSub_6;
+  wire       [1:0]    _zz_stageB_amo_addSub_7;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -7134,38 +7409,45 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
   reg                 stageA_request_isAmo;
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
   reg                 stageB_request_isAmo;
@@ -7173,6 +7455,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -7190,25 +7473,36 @@ module DataCache (
   reg        [31:0]   stageB_mmuRsp_ways_2_physical;
   reg                 stageB_mmuRsp_ways_3_sel;
   reg        [31:0]   stageB_mmuRsp_ways_3_physical;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   reg                 stageB_lrSc_reserved;
+  wire                when_DataCache_l866;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -7217,14 +7511,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
+  wire       [2:0]    switch_Misc_l199;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l984;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l997;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1010;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -7236,73 +7542,62 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_42;
-  reg [7:0] _zz_43;
-  reg [7:0] _zz_44;
-  reg [7:0] _zz_45;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign _zz_16 = (! stageB_amo_internal_resultRegValid);
-  assign _zz_17 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_18 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_19 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_20 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign _zz_21 = (! stageB_flusher_hold);
-  assign _zz_22 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_23 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
-  assign _zz_24 = _zz_4[0 : 0];
-  assign _zz_25 = _zz_4[1 : 1];
-  assign _zz_26 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_27 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_28 = ($signed(_zz_29) + $signed(_zz_33));
-  assign _zz_29 = ($signed(_zz_30) + $signed(_zz_31));
-  assign _zz_30 = stageB_request_data;
-  assign _zz_31 = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_32 = (stageB_amo_compare ? _zz_34 : _zz_35);
-  assign _zz_33 = {{30{_zz_32[1]}}, _zz_32};
-  assign _zz_34 = 2'b01;
-  assign _zz_35 = 2'b00;
-  assign _zz_36 = 1'b1;
-  assign _zz_37 = (! stageB_lrSc_reserved);
-  assign _zz_38 = loader_counter_willIncrement;
-  assign _zz_39 = {2'd0, _zz_38};
-  assign _zz_40 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_41 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
+  assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
+  assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
+  assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
+  assign _zz_stageB_amo_addSub_6 = 2'b01;
+  assign _zz_stageB_amo_addSub_7 = 2'b00;
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_41;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_45, _zz_44, _zz_43, _zz_42};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_42 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_43 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_44 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_45 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -7317,327 +7612,348 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_24[0];
-  assign ways_0_tagsReadRsp_error = _zz_25[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_36[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_26)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_27)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(_zz_19)begin
+          if(when_DataCache_l984) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l866 = ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_request_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
+  always @(*) begin
+    stageB_requestDataBypass = io_cpu_writeBack_storeData;
+    if(stageB_request_isAmo) begin
+      stageB_requestDataBypass[31 : 0] = stageB_amo_resultReg;
     end
   end
 
   assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
   assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
-  assign stageB_amo_addSub = _zz_28;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
+  assign stageB_amo_addSub = _zz_stageB_amo_addSub;
+  assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_23)
+  assign switch_Misc_l199 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  always @(*) begin
+    case(switch_Misc_l199)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
       3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] ^ stageB_dataMux[31 : 0]);
       end
       3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] | stageB_dataMux[31 : 0]);
       end
       3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] & stageB_dataMux[31 : 0]);
       end
       default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
+        stageB_amo_result = (stageB_amo_selectRf ? io_cpu_writeBack_storeData[31 : 0] : stageB_dataMux[31 : 0]);
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7645,103 +7961,87 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(_zz_20)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(_zz_19)begin
+          if(when_DataCache_l984) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 io_mem_cmd_valid = 1'b0;
               end
             end
-            if(_zz_20)begin
+            if(when_DataCache_l1005) begin
               io_mem_cmd_valid = 1'b0;
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               io_mem_cmd_valid = 1'b0;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -7749,12 +8049,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -7765,23 +8065,44 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l984 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l997 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1010 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_37};
-    end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -7789,26 +8110,29 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_39);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
       stageA_request_isAmo <= io_cpu_execute_args_isAmo;
@@ -7816,18 +8140,17 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
       stageB_request_isAmo <= stageA_request_isAmo;
@@ -7835,7 +8158,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -7854,48 +8177,39 @@ module DataCache (
       stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
       stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_21)begin
-        if(_zz_22)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
     stageB_amo_resultReg <= stageB_amo_result;
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -7904,27 +8218,29 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_21)begin
-          if(! _zz_22) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
-      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+      if(when_DataCache_l866) begin
         stageB_lrSc_reserved <= (! stageB_request_wr);
       end
-      if(_zz_13)begin
+      if(when_DataCache_l1051) begin
         stageB_lrSc_reserved <= stageB_lrSc_reserved;
       end
       `ifndef SYNTHESIS
@@ -7932,28 +8248,27 @@ module DataCache (
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_18)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_40[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -8011,13 +8326,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -8026,8 +8337,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -8041,22 +8357,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -8074,82 +8393,85 @@ module InstructionCache (
   reg        [31:0]   decodeStage_mmuRsp_ways_2_physical;
   reg                 decodeStage_mmuRsp_ways_3_sel;
   reg        [31:0]   decodeStage_mmuRsp_ways_3_physical;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -8165,30 +8487,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -8196,51 +8523,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -8259,10 +8586,10 @@ module InstructionCache (
       decodeStage_mmuRsp_ways_3_sel <= io_cpu_fetch_mmuRsp_ways_3_sel;
       decodeStage_mmuRsp_ways_3_physical <= io_cpu_fetch_mmuRsp_ways_3_physical;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -89,66 +89,42 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_208;
-  wire                _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire                _zz_212;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  reg                 _zz_216;
-  reg                 _zz_217;
-  reg        [31:0]   _zz_218;
-  reg                 _zz_219;
-  reg        [31:0]   _zz_220;
-  reg        [1:0]    _zz_221;
-  reg                 _zz_222;
-  reg                 _zz_223;
-  wire                _zz_224;
-  wire       [2:0]    _zz_225;
-  reg                 _zz_226;
-  wire       [31:0]   _zz_227;
-  reg                 _zz_228;
-  reg                 _zz_229;
-  wire                _zz_230;
-  wire       [31:0]   _zz_231;
-  wire                _zz_232;
-  wire                _zz_233;
-  wire                _zz_234;
-  wire                _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire                _zz_238;
-  wire                _zz_239;
-  wire       [3:0]    _zz_240;
-  wire                _zz_241;
-  wire                _zz_242;
-  reg        [31:0]   _zz_243;
-  reg        [31:0]   _zz_244;
-  reg        [31:0]   _zz_245;
-  reg                 _zz_246;
-  reg                 _zz_247;
-  reg                 _zz_248;
-  reg        [9:0]    _zz_249;
-  reg        [9:0]    _zz_250;
-  reg        [9:0]    _zz_251;
-  reg        [9:0]    _zz_252;
-  reg                 _zz_253;
-  reg                 _zz_254;
-  reg                 _zz_255;
-  reg                 _zz_256;
-  reg                 _zz_257;
-  reg                 _zz_258;
-  reg                 _zz_259;
-  reg        [9:0]    _zz_260;
-  reg        [9:0]    _zz_261;
-  reg        [9:0]    _zz_262;
-  reg        [9:0]    _zz_263;
-  reg                 _zz_264;
-  reg                 _zz_265;
-  reg                 _zz_266;
-  reg                 _zz_267;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  reg                 dataCache_1_io_cpu_execute_isValid;
+  reg        [31:0]   dataCache_1_io_cpu_execute_address;
+  reg                 dataCache_1_io_cpu_execute_args_wr;
+  reg        [1:0]    dataCache_1_io_cpu_execute_args_size;
+  reg                 dataCache_1_io_cpu_execute_args_isLrsc;
+  wire                dataCache_1_io_cpu_execute_args_amoCtrl_swap;
+  wire       [2:0]    dataCache_1_io_cpu_execute_args_amoCtrl_alu;
+  reg                 dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -171,6 +147,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -179,457 +156,360 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_268;
-  wire                _zz_269;
-  wire                _zz_270;
-  wire                _zz_271;
-  wire                _zz_272;
-  wire                _zz_273;
-  wire                _zz_274;
-  wire                _zz_275;
-  wire                _zz_276;
-  wire                _zz_277;
-  wire                _zz_278;
-  wire                _zz_279;
-  wire                _zz_280;
-  wire                _zz_281;
-  wire                _zz_282;
-  wire                _zz_283;
-  wire                _zz_284;
-  wire       [1:0]    _zz_285;
-  wire                _zz_286;
-  wire                _zz_287;
-  wire                _zz_288;
-  wire                _zz_289;
-  wire                _zz_290;
-  wire                _zz_291;
-  wire                _zz_292;
-  wire                _zz_293;
-  wire                _zz_294;
-  wire                _zz_295;
-  wire                _zz_296;
-  wire                _zz_297;
-  wire                _zz_298;
-  wire                _zz_299;
-  wire                _zz_300;
-  wire       [1:0]    _zz_301;
-  wire                _zz_302;
-  wire                _zz_303;
-  wire       [5:0]    _zz_304;
-  wire                _zz_305;
-  wire                _zz_306;
-  wire                _zz_307;
-  wire                _zz_308;
-  wire                _zz_309;
-  wire                _zz_310;
-  wire                _zz_311;
-  wire                _zz_312;
-  wire                _zz_313;
-  wire                _zz_314;
-  wire                _zz_315;
-  wire                _zz_316;
-  wire                _zz_317;
-  wire                _zz_318;
-  wire                _zz_319;
-  wire                _zz_320;
-  wire                _zz_321;
-  wire                _zz_322;
-  wire                _zz_323;
-  wire                _zz_324;
-  wire                _zz_325;
-  wire                _zz_326;
-  wire       [1:0]    _zz_327;
-  wire                _zz_328;
-  wire       [1:0]    _zz_329;
-  wire       [51:0]   _zz_330;
-  wire       [51:0]   _zz_331;
-  wire       [51:0]   _zz_332;
-  wire       [32:0]   _zz_333;
-  wire       [51:0]   _zz_334;
-  wire       [49:0]   _zz_335;
-  wire       [51:0]   _zz_336;
-  wire       [49:0]   _zz_337;
-  wire       [51:0]   _zz_338;
-  wire       [32:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire       [32:0]   _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [0:0]    _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [0:0]    _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [0:0]    _zz_348;
-  wire       [0:0]    _zz_349;
-  wire       [0:0]    _zz_350;
-  wire       [0:0]    _zz_351;
-  wire       [0:0]    _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [0:0]    _zz_354;
-  wire       [0:0]    _zz_355;
-  wire       [0:0]    _zz_356;
-  wire       [0:0]    _zz_357;
-  wire       [0:0]    _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [0:0]    _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [0:0]    _zz_362;
-  wire       [4:0]    _zz_363;
-  wire       [2:0]    _zz_364;
-  wire       [31:0]   _zz_365;
-  wire       [11:0]   _zz_366;
-  wire       [31:0]   _zz_367;
-  wire       [19:0]   _zz_368;
-  wire       [11:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire       [31:0]   _zz_371;
-  wire       [19:0]   _zz_372;
-  wire       [11:0]   _zz_373;
-  wire       [2:0]    _zz_374;
-  wire       [2:0]    _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [1:0]    _zz_377;
-  wire       [0:0]    _zz_378;
-  wire       [1:0]    _zz_379;
-  wire       [0:0]    _zz_380;
-  wire       [0:0]    _zz_381;
-  wire       [0:0]    _zz_382;
-  wire       [0:0]    _zz_383;
-  wire       [0:0]    _zz_384;
-  wire       [0:0]    _zz_385;
-  wire       [0:0]    _zz_386;
-  wire       [0:0]    _zz_387;
-  wire       [1:0]    _zz_388;
-  wire       [0:0]    _zz_389;
-  wire       [2:0]    _zz_390;
-  wire       [4:0]    _zz_391;
-  wire       [11:0]   _zz_392;
-  wire       [11:0]   _zz_393;
-  wire       [31:0]   _zz_394;
-  wire       [31:0]   _zz_395;
-  wire       [31:0]   _zz_396;
-  wire       [31:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [31:0]   _zz_399;
-  wire       [31:0]   _zz_400;
-  wire       [11:0]   _zz_401;
-  wire       [19:0]   _zz_402;
-  wire       [11:0]   _zz_403;
-  wire       [31:0]   _zz_404;
-  wire       [31:0]   _zz_405;
-  wire       [31:0]   _zz_406;
-  wire       [11:0]   _zz_407;
-  wire       [19:0]   _zz_408;
-  wire       [11:0]   _zz_409;
-  wire       [2:0]    _zz_410;
-  wire       [1:0]    _zz_411;
-  wire       [1:0]    _zz_412;
-  wire       [65:0]   _zz_413;
-  wire       [65:0]   _zz_414;
-  wire       [31:0]   _zz_415;
-  wire       [31:0]   _zz_416;
-  wire       [0:0]    _zz_417;
-  wire       [5:0]    _zz_418;
-  wire       [32:0]   _zz_419;
-  wire       [31:0]   _zz_420;
-  wire       [31:0]   _zz_421;
-  wire       [32:0]   _zz_422;
-  wire       [32:0]   _zz_423;
-  wire       [32:0]   _zz_424;
-  wire       [32:0]   _zz_425;
-  wire       [0:0]    _zz_426;
-  wire       [32:0]   _zz_427;
-  wire       [0:0]    _zz_428;
-  wire       [32:0]   _zz_429;
-  wire       [0:0]    _zz_430;
-  wire       [31:0]   _zz_431;
-  wire       [0:0]    _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [0:0]    _zz_434;
-  wire       [0:0]    _zz_435;
-  wire       [0:0]    _zz_436;
-  wire       [0:0]    _zz_437;
-  wire       [0:0]    _zz_438;
-  wire       [0:0]    _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [0:0]    _zz_441;
-  wire       [0:0]    _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [0:0]    _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [0:0]    _zz_446;
-  wire       [0:0]    _zz_447;
-  wire       [0:0]    _zz_448;
-  wire       [0:0]    _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [0:0]    _zz_451;
-  wire       [0:0]    _zz_452;
-  wire       [0:0]    _zz_453;
-  wire       [0:0]    _zz_454;
-  wire       [0:0]    _zz_455;
-  wire       [0:0]    _zz_456;
-  wire       [0:0]    _zz_457;
-  wire       [0:0]    _zz_458;
-  wire       [0:0]    _zz_459;
-  wire       [0:0]    _zz_460;
-  wire       [0:0]    _zz_461;
-  wire       [0:0]    _zz_462;
-  wire       [0:0]    _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [0:0]    _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [0:0]    _zz_467;
-  wire       [0:0]    _zz_468;
-  wire       [0:0]    _zz_469;
-  wire       [0:0]    _zz_470;
-  wire       [0:0]    _zz_471;
-  wire       [0:0]    _zz_472;
-  wire       [0:0]    _zz_473;
-  wire       [0:0]    _zz_474;
-  wire       [0:0]    _zz_475;
-  wire       [0:0]    _zz_476;
-  wire       [26:0]   _zz_477;
-  wire                _zz_478;
-  wire                _zz_479;
-  wire       [2:0]    _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire       [31:0]   _zz_483;
-  wire                _zz_484;
-  wire       [0:0]    _zz_485;
-  wire       [17:0]   _zz_486;
-  wire       [31:0]   _zz_487;
-  wire       [31:0]   _zz_488;
-  wire       [31:0]   _zz_489;
-  wire                _zz_490;
-  wire       [0:0]    _zz_491;
-  wire       [11:0]   _zz_492;
-  wire       [31:0]   _zz_493;
-  wire       [31:0]   _zz_494;
-  wire       [31:0]   _zz_495;
-  wire                _zz_496;
-  wire       [0:0]    _zz_497;
-  wire       [5:0]    _zz_498;
-  wire       [31:0]   _zz_499;
-  wire       [31:0]   _zz_500;
-  wire       [31:0]   _zz_501;
-  wire                _zz_502;
-  wire                _zz_503;
-  wire                _zz_504;
-  wire                _zz_505;
-  wire                _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [0:0]    _zz_508;
-  wire       [0:0]    _zz_509;
-  wire                _zz_510;
-  wire       [0:0]    _zz_511;
-  wire       [29:0]   _zz_512;
-  wire       [31:0]   _zz_513;
-  wire                _zz_514;
-  wire                _zz_515;
-  wire                _zz_516;
-  wire       [1:0]    _zz_517;
-  wire       [1:0]    _zz_518;
-  wire                _zz_519;
-  wire       [0:0]    _zz_520;
-  wire       [25:0]   _zz_521;
-  wire       [31:0]   _zz_522;
-  wire       [31:0]   _zz_523;
-  wire       [31:0]   _zz_524;
-  wire       [31:0]   _zz_525;
-  wire                _zz_526;
-  wire                _zz_527;
-  wire       [1:0]    _zz_528;
-  wire       [1:0]    _zz_529;
-  wire                _zz_530;
-  wire       [0:0]    _zz_531;
-  wire       [22:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire       [31:0]   _zz_536;
-  wire                _zz_537;
-  wire       [0:0]    _zz_538;
-  wire       [0:0]    _zz_539;
-  wire                _zz_540;
-  wire       [0:0]    _zz_541;
-  wire       [0:0]    _zz_542;
-  wire                _zz_543;
-  wire       [0:0]    _zz_544;
-  wire       [19:0]   _zz_545;
-  wire       [31:0]   _zz_546;
-  wire       [31:0]   _zz_547;
-  wire       [31:0]   _zz_548;
-  wire                _zz_549;
-  wire                _zz_550;
-  wire                _zz_551;
-  wire       [0:0]    _zz_552;
-  wire       [0:0]    _zz_553;
-  wire                _zz_554;
-  wire       [0:0]    _zz_555;
-  wire       [16:0]   _zz_556;
-  wire       [31:0]   _zz_557;
-  wire       [31:0]   _zz_558;
-  wire       [31:0]   _zz_559;
-  wire       [0:0]    _zz_560;
-  wire       [2:0]    _zz_561;
-  wire       [0:0]    _zz_562;
-  wire       [0:0]    _zz_563;
-  wire                _zz_564;
-  wire       [0:0]    _zz_565;
-  wire       [13:0]   _zz_566;
-  wire       [31:0]   _zz_567;
-  wire       [31:0]   _zz_568;
-  wire       [31:0]   _zz_569;
-  wire                _zz_570;
-  wire                _zz_571;
-  wire       [31:0]   _zz_572;
-  wire       [31:0]   _zz_573;
-  wire       [31:0]   _zz_574;
-  wire       [0:0]    _zz_575;
-  wire       [4:0]    _zz_576;
-  wire       [2:0]    _zz_577;
-  wire       [2:0]    _zz_578;
-  wire                _zz_579;
-  wire       [0:0]    _zz_580;
-  wire       [10:0]   _zz_581;
-  wire       [31:0]   _zz_582;
-  wire       [31:0]   _zz_583;
-  wire       [31:0]   _zz_584;
-  wire       [31:0]   _zz_585;
-  wire                _zz_586;
-  wire       [0:0]    _zz_587;
-  wire       [2:0]    _zz_588;
-  wire                _zz_589;
-  wire       [0:0]    _zz_590;
-  wire       [0:0]    _zz_591;
-  wire       [0:0]    _zz_592;
-  wire       [3:0]    _zz_593;
-  wire       [4:0]    _zz_594;
-  wire       [4:0]    _zz_595;
-  wire                _zz_596;
-  wire       [0:0]    _zz_597;
-  wire       [8:0]    _zz_598;
-  wire       [31:0]   _zz_599;
-  wire       [31:0]   _zz_600;
-  wire       [31:0]   _zz_601;
-  wire                _zz_602;
-  wire       [0:0]    _zz_603;
-  wire       [0:0]    _zz_604;
-  wire       [31:0]   _zz_605;
-  wire       [31:0]   _zz_606;
-  wire       [31:0]   _zz_607;
-  wire       [31:0]   _zz_608;
-  wire       [31:0]   _zz_609;
-  wire       [31:0]   _zz_610;
-  wire       [31:0]   _zz_611;
-  wire                _zz_612;
-  wire       [0:0]    _zz_613;
-  wire       [1:0]    _zz_614;
-  wire       [0:0]    _zz_615;
-  wire       [2:0]    _zz_616;
-  wire       [0:0]    _zz_617;
-  wire       [5:0]    _zz_618;
-  wire       [1:0]    _zz_619;
-  wire       [1:0]    _zz_620;
-  wire                _zz_621;
-  wire       [0:0]    _zz_622;
-  wire       [6:0]    _zz_623;
-  wire       [31:0]   _zz_624;
-  wire       [31:0]   _zz_625;
-  wire       [31:0]   _zz_626;
-  wire       [31:0]   _zz_627;
-  wire       [31:0]   _zz_628;
-  wire       [31:0]   _zz_629;
-  wire       [31:0]   _zz_630;
-  wire       [31:0]   _zz_631;
-  wire                _zz_632;
-  wire       [31:0]   _zz_633;
-  wire       [31:0]   _zz_634;
-  wire                _zz_635;
-  wire       [0:0]    _zz_636;
-  wire       [0:0]    _zz_637;
-  wire                _zz_638;
-  wire       [0:0]    _zz_639;
-  wire       [3:0]    _zz_640;
-  wire                _zz_641;
-  wire       [0:0]    _zz_642;
-  wire       [0:0]    _zz_643;
-  wire       [0:0]    _zz_644;
-  wire       [0:0]    _zz_645;
-  wire                _zz_646;
-  wire       [0:0]    _zz_647;
-  wire       [4:0]    _zz_648;
-  wire       [31:0]   _zz_649;
-  wire       [31:0]   _zz_650;
-  wire       [31:0]   _zz_651;
-  wire       [31:0]   _zz_652;
-  wire       [31:0]   _zz_653;
-  wire       [31:0]   _zz_654;
-  wire       [31:0]   _zz_655;
-  wire       [31:0]   _zz_656;
-  wire       [31:0]   _zz_657;
-  wire                _zz_658;
-  wire       [0:0]    _zz_659;
-  wire       [1:0]    _zz_660;
-  wire       [31:0]   _zz_661;
-  wire       [31:0]   _zz_662;
-  wire       [31:0]   _zz_663;
-  wire       [31:0]   _zz_664;
-  wire       [31:0]   _zz_665;
-  wire                _zz_666;
-  wire       [4:0]    _zz_667;
-  wire       [4:0]    _zz_668;
-  wire                _zz_669;
-  wire       [0:0]    _zz_670;
-  wire       [2:0]    _zz_671;
-  wire       [31:0]   _zz_672;
-  wire       [31:0]   _zz_673;
-  wire       [31:0]   _zz_674;
-  wire                _zz_675;
-  wire       [31:0]   _zz_676;
-  wire                _zz_677;
-  wire       [0:0]    _zz_678;
-  wire       [2:0]    _zz_679;
-  wire       [0:0]    _zz_680;
-  wire       [0:0]    _zz_681;
-  wire       [2:0]    _zz_682;
-  wire       [2:0]    _zz_683;
-  wire                _zz_684;
-  wire       [0:0]    _zz_685;
-  wire       [0:0]    _zz_686;
-  wire       [31:0]   _zz_687;
-  wire       [31:0]   _zz_688;
-  wire       [31:0]   _zz_689;
-  wire       [31:0]   _zz_690;
-  wire                _zz_691;
-  wire       [0:0]    _zz_692;
-  wire       [0:0]    _zz_693;
-  wire       [31:0]   _zz_694;
-  wire       [31:0]   _zz_695;
-  wire                _zz_696;
-  wire       [0:0]    _zz_697;
-  wire       [0:0]    _zz_698;
-  wire       [0:0]    _zz_699;
-  wire       [1:0]    _zz_700;
-  wire       [1:0]    _zz_701;
-  wire       [1:0]    _zz_702;
-  wire       [0:0]    _zz_703;
-  wire       [0:0]    _zz_704;
-  wire       [31:0]   _zz_705;
-  wire       [31:0]   _zz_706;
-  wire       [31:0]   _zz_707;
-  wire       [31:0]   _zz_708;
-  wire       [31:0]   _zz_709;
-  wire       [31:0]   _zz_710;
-  wire       [31:0]   _zz_711;
-  wire       [31:0]   _zz_712;
-  wire                _zz_713;
-  wire                _zz_714;
-  wire                _zz_715;
-  wire       [31:0]   _zz_716;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [17:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
+  wire                _zz_decode_LEGAL_INSTRUCTION_21;
+  wire                _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [4:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_7;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspRf;
+  wire       [9:0]    _zz_MmuPlugin_ports_0_cacheHitsCalc;
+  wire       [9:0]    _zz_MmuPlugin_ports_0_cacheHitsCalc_1;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_2;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_3;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_4;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_5;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_valid_4;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_exception;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_superPage;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowRead;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowWrite;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowExecute;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowUser;
+  wire       [1:0]    _zz_MmuPlugin_ports_0_entryToReplace_valueNext;
+  wire       [0:0]    _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1;
+  wire       [9:0]    _zz_MmuPlugin_ports_1_cacheHitsCalc;
+  wire       [9:0]    _zz_MmuPlugin_ports_1_cacheHitsCalc_1;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_2;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_3;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_4;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_5;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_valid_4;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_exception;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_superPage;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowRead;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowWrite;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowExecute;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowUser;
+  wire       [1:0]    _zz_MmuPlugin_ports_1_entryToReplace_valueNext;
+  wire       [0:0]    _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1;
+  wire       [1:0]    _zz__zz_MmuPlugin_shared_refills_2;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire       [30:0]   _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [26:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [23:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_166;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_168;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_169;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_170;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_171;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_172;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_173;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_174;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_175;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_176;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_177;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_178;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_179;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_180;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_181;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_182;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_183;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_184;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_185;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_186;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_187;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_188;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_189;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_190;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_191;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_192;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_193;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_194;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_195;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_196;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_197;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_198;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_199;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_200;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_201;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_202;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_203;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_204;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -641,8 +521,8 @@ module VexRiscv (
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire                execute_IS_DBUS_SHARING;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
@@ -654,49 +534,49 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire                memory_IS_SFENCE_VMA;
-  wire                execute_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA;
+  wire                decode_IS_SFENCE_VMA2;
   wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_LRSC;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -719,11 +599,12 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
+  wire                execute_IS_SFENCE_VMA;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -731,10 +612,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -744,54 +625,55 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  wire                writeBack_IS_SFENCE_VMA;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  wire                execute_IS_SFENCE_VMA2;
   wire                writeBack_IS_DBUS_SHARING;
   wire                memory_IS_DBUS_SHARING;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   _zz_decode_RS2_2;
+  wire                writeBack_MEMORY_LRSC;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MEMORY_AMO;
-  wire                execute_MEMORY_LRSC;
+  reg                 execute_MEMORY_AMO;
+  reg                 execute_MEMORY_LRSC;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
@@ -801,7 +683,7 @@ module VexRiscv (
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_AMO;
   wire                decode_MEMORY_LRSC;
-  reg                 _zz_51;
+  reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
   reg                 IBusCachedPlugin_rsp_issueDetected_4;
@@ -809,11 +691,11 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53;
-  reg        [31:0]   _zz_54;
-  reg        [31:0]   _zz_55;
+  reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -908,7 +790,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -942,7 +824,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_56;
+  reg                 _zz_when_DBusCachedPlugin_l386;
   reg                 MmuPlugin_dBusAccess_cmd_valid;
   reg                 MmuPlugin_dBusAccess_cmd_ready;
   reg        [31:0]   MmuPlugin_dBusAccess_cmd_payload_address;
@@ -962,6 +844,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -982,32 +869,38 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [4:0]    _zz_57;
-  wire       [4:0]    _zz_58;
-  wire                _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
+  wire       [4:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [4:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -1030,16 +923,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_63;
-  wire                _zz_64;
-  wire                _zz_65;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_66;
-  wire                _zz_67;
-  reg                 _zz_68;
-  wire                _zz_69;
-  reg                 _zz_70;
-  reg        [31:0]   _zz_71;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1047,22 +942,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_72;
-  reg        [18:0]   _zz_73;
-  wire                _zz_74;
-  reg        [10:0]   _zz_75;
-  wire                _zz_76;
-  reg        [18:0]   _zz_77;
-  reg                 _zz_78;
-  wire                _zz_79;
-  reg        [10:0]   _zz_80;
-  wire                _zz_81;
-  reg        [18:0]   _zz_82;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1070,7 +972,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_83;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1078,6 +980,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -1085,7 +992,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -1093,8 +1000,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -1102,27 +1010,44 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_84;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l311;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_85;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_86;
-  reg        [31:0]   _zz_87;
-  wire                _zz_88;
-  reg        [31:0]   _zz_89;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire                when_DBusCachedPlugin_l474;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
+  wire                when_DBusCachedPlugin_l484;
   reg                 DBusCachedPlugin_forceDatapath;
+  wire                when_DBusCachedPlugin_l498;
+  wire                when_DBusCachedPlugin_l499;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
@@ -1175,12 +1100,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
   wire                MmuPlugin_ports_0_dirty;
   reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
-  reg        [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
+  wire                when_MmuPlugin_l125;
+  wire                when_MmuPlugin_l126;
+  wire       [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
-  wire                _zz_90;
-  wire                _zz_91;
-  wire                _zz_92;
-  wire       [1:0]    _zz_93;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid_1;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid_2;
+  wire       [1:0]    _zz_MmuPlugin_ports_0_cacheLine_valid_3;
   wire                MmuPlugin_ports_0_cacheLine_valid;
   wire                MmuPlugin_ports_0_cacheLine_exception;
   wire                MmuPlugin_ports_0_cacheLine_superPage;
@@ -1244,12 +1171,15 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
   wire                MmuPlugin_ports_1_dirty;
   reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
-  reg        [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
+  wire                when_MmuPlugin_l125_1;
+  wire                when_MmuPlugin_l126_1;
+  wire                when_MmuPlugin_l128;
+  wire       [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
-  wire                _zz_94;
-  wire                _zz_95;
-  wire                _zz_96;
-  wire       [1:0]    _zz_97;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid_1;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid_2;
+  wire       [1:0]    _zz_MmuPlugin_ports_1_cacheLine_valid_3;
   wire                MmuPlugin_ports_1_cacheLine_valid;
   wire                MmuPlugin_ports_1_cacheLine_exception;
   wire                MmuPlugin_ports_1_cacheLine_superPage;
@@ -1288,6 +1218,7 @@ module VexRiscv (
   wire       [11:0]   MmuPlugin_shared_dBusRsp_pte_PPN1;
   wire                MmuPlugin_shared_dBusRsp_exception;
   wire                MmuPlugin_shared_dBusRsp_leaf;
+  wire                when_MmuPlugin_l205;
   reg                 MmuPlugin_shared_pteBuffer_V;
   reg                 MmuPlugin_shared_pteBuffer_R;
   reg                 MmuPlugin_shared_pteBuffer_W;
@@ -1299,27 +1230,42 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_shared_pteBuffer_RSW;
   reg        [9:0]    MmuPlugin_shared_pteBuffer_PPN0;
   reg        [11:0]   MmuPlugin_shared_pteBuffer_PPN1;
-  reg        [1:0]    _zz_98;
-  wire       [1:0]    _zz_99;
-  reg        [1:0]    _zz_100;
+  wire       [1:0]    _zz_MmuPlugin_shared_refills;
+  reg        [1:0]    _zz_MmuPlugin_shared_refills_1;
   wire       [1:0]    MmuPlugin_shared_refills;
-  wire       [1:0]    _zz_101;
-  reg        [1:0]    _zz_102;
-  wire       [31:0]   _zz_103;
-  wire       [35:0]   _zz_104;
-  wire                _zz_105;
-  wire                _zz_106;
-  wire                _zz_107;
-  wire                _zz_108;
-  wire                _zz_109;
-  wire                _zz_110;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_111;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_112;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_113;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_114;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_115;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_116;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_117;
+  wire       [1:0]    _zz_MmuPlugin_shared_refills_2;
+  reg        [1:0]    _zz_MmuPlugin_shared_refills_3;
+  wire                when_MmuPlugin_l217;
+  wire       [31:0]   _zz_MmuPlugin_shared_vpn_0;
+  wire                when_MmuPlugin_l243;
+  wire                when_MmuPlugin_l272;
+  wire                when_MmuPlugin_l274;
+  wire                when_MmuPlugin_l280;
+  wire                when_MmuPlugin_l280_1;
+  wire                when_MmuPlugin_l280_2;
+  wire                when_MmuPlugin_l280_3;
+  wire                when_MmuPlugin_l274_1;
+  wire                when_MmuPlugin_l280_4;
+  wire                when_MmuPlugin_l280_5;
+  wire                when_MmuPlugin_l280_6;
+  wire                when_MmuPlugin_l280_7;
+  wire                when_MmuPlugin_l304;
+  wire       [36:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz_decode_IS_RS2_SIGNED_7;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1327,54 +1273,72 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_118;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_119;
-  reg        [31:0]   _zz_120;
-  wire                _zz_121;
-  reg        [19:0]   _zz_122;
-  wire                _zz_123;
-  reg        [19:0]   _zz_124;
-  reg        [31:0]   _zz_125;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_126;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_127;
-  reg                 _zz_128;
-  reg                 _zz_129;
-  reg                 _zz_130;
-  reg        [4:0]    _zz_131;
-  reg        [31:0]   _zz_132;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_139;
-  reg                 _zz_140;
-  reg                 _zz_141;
-  wire                _zz_142;
-  reg        [19:0]   _zz_143;
-  wire                _zz_144;
-  reg        [10:0]   _zz_145;
-  wire                _zz_146;
-  reg        [18:0]   _zz_147;
-  reg                 _zz_148;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_149;
-  reg        [19:0]   _zz_150;
-  wire                _zz_151;
-  reg        [10:0]   _zz_152;
-  wire                _zz_153;
-  reg        [18:0]   _zz_154;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_155;
+  reg        [1:0]    _zz_CsrPlugin_privilege;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1431,12 +1395,14 @@ module VexRiscv (
   reg        [21:0]   CsrPlugin_satp_PPN;
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
-  wire                _zz_156;
-  wire                _zz_157;
-  wire                _zz_158;
-  wire                _zz_159;
-  wire                _zz_160;
-  wire                _zz_161;
+  reg                 CsrPlugin_rescheduleLogic_rescheduleNext;
+  wire                when_CsrPlugin_l803;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
+  wire                _zz_when_CsrPlugin_l952_3;
+  wire                _zz_when_CsrPlugin_l952_4;
+  wire                _zz_when_CsrPlugin_l952_5;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1448,41 +1414,87 @@ module VexRiscv (
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
+  wire                when_CsrPlugin_l866;
+  wire                when_CsrPlugin_l866_1;
+  wire                when_CsrPlugin_l866_2;
+  wire                when_CsrPlugin_l866_3;
+  wire                when_CsrPlugin_l866_4;
+  wire                when_CsrPlugin_l866_5;
+  wire                when_CsrPlugin_l866_6;
+  wire                when_CsrPlugin_l866_7;
+  wire                when_CsrPlugin_l866_8;
+  wire                when_CsrPlugin_l866_9;
+  wire                when_CsrPlugin_l866_10;
+  wire                when_CsrPlugin_l866_11;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_162;
-  wire                _zz_163;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l946_1;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l952_3;
+  wire                when_CsrPlugin_l952_4;
+  wire                when_CsrPlugin_l952_5;
+  wire                when_CsrPlugin_l952_6;
+  wire                when_CsrPlugin_l952_7;
+  wire                when_CsrPlugin_l952_8;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   reg        [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1490,6 +1502,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1502,21 +1516,28 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_164;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_165;
-  wire                _zz_166;
-  wire                _zz_167;
-  reg        [32:0]   _zz_168;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_169;
-  wire       [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  wire       [31:0]   _zz_172;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1524,221 +1545,349 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_173;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_LRSC;
+  wire                when_Pipeline_l124_27;
+  reg                 execute_to_memory_MEMORY_LRSC;
+  wire                when_Pipeline_l124_28;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_MEMORY_AMO;
+  wire                when_Pipeline_l124_30;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_31;
+  reg                 decode_to_execute_IS_SFENCE_VMA2;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_SFENCE_VMA;
-  reg                 execute_to_memory_IS_SFENCE_VMA;
-  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_34;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_36;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_37;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_38;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_39;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_40;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_41;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_43;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_44;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_46;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_49;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_50;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_51;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_52;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_53;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_54;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_55;
   reg                 decode_to_execute_DO_EBREAK;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_56;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_57;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_58;
   reg                 execute_to_memory_IS_DBUS_SHARING;
+  wire                when_Pipeline_l124_59;
   reg                 memory_to_writeBack_IS_DBUS_SHARING;
+  wire                when_Pipeline_l124_60;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_61;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_62;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_63;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_64;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_65;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_66;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_67;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_68;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_69;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_70;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_174;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_256;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_384;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_770;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_771;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_324;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_260;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_261;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_321;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_320;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_322;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_323;
+  wire                when_CsrPlugin_l1264_24;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_25;
   reg                 execute_CsrPlugin_csr_4032;
+  wire                when_CsrPlugin_l1264_26;
   reg                 execute_CsrPlugin_csr_2496;
+  wire                when_CsrPlugin_l1264_27;
   reg                 execute_CsrPlugin_csr_3520;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [31:0]   _zz_183;
-  reg        [31:0]   _zz_184;
-  reg        [31:0]   _zz_185;
-  reg        [31:0]   _zz_186;
-  reg        [31:0]   _zz_187;
-  reg        [31:0]   _zz_188;
-  reg        [31:0]   _zz_189;
-  reg        [31:0]   _zz_190;
-  reg        [31:0]   _zz_191;
-  reg        [31:0]   _zz_192;
-  reg        [31:0]   _zz_193;
-  reg        [31:0]   _zz_194;
-  reg        [31:0]   _zz_195;
-  reg        [31:0]   _zz_196;
-  reg        [31:0]   _zz_197;
-  reg        [31:0]   _zz_198;
-  reg        [2:0]    _zz_199;
-  reg                 _zz_200;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  reg                 _zz_207;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
   reg [47:0] MmuPlugin_shared_state_1_string;
-  reg [95:0] _zz_111_string;
-  reg [63:0] _zz_112_string;
-  reg [23:0] _zz_113_string;
-  reg [39:0] _zz_114_string;
-  reg [71:0] _zz_115_string;
-  reg [31:0] _zz_116_string;
-  reg [39:0] _zz_117_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1747,767 +1896,672 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_268 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_269 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_270 = 1'b1;
-  assign _zz_271 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_272 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_273 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_274 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_275 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_276 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_277 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_278 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_279 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_280 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_281 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_282 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_283 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_284 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_285 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_286 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
-  assign _zz_287 = (! dataCache_1_io_cpu_execute_refilling);
-  assign _zz_288 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_289 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign _zz_290 = MmuPlugin_shared_portSortedOh[0];
-  assign _zz_291 = MmuPlugin_shared_portSortedOh[1];
-  assign _zz_292 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_293 = (1'b0 || (! 1'b1));
-  assign _zz_294 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_295 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_296 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_297 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_298 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_299 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_300 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_301 = execute_INSTRUCTION[13 : 12];
-  assign _zz_302 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_303 = (! memory_arbitration_isStuck);
-  assign _zz_304 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_305 = (iBus_cmd_valid || (_zz_199 != 3'b000));
-  assign _zz_306 = (_zz_242 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_307 = (MmuPlugin_shared_refills != 2'b00);
-  assign _zz_308 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
-  assign _zz_309 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
-  assign _zz_310 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
-  assign _zz_311 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
-  assign _zz_312 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
-  assign _zz_313 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
-  assign _zz_314 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
-  assign _zz_315 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
-  assign _zz_316 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
-  assign _zz_317 = ((_zz_156 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign _zz_318 = ((_zz_157 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign _zz_319 = ((_zz_158 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign _zz_320 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_321 = ((_zz_156 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
-  assign _zz_322 = ((_zz_157 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
-  assign _zz_323 = ((_zz_158 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
-  assign _zz_324 = ((_zz_159 && 1'b1) && (! 1'b0));
-  assign _zz_325 = ((_zz_160 && 1'b1) && (! 1'b0));
-  assign _zz_326 = ((_zz_161 && 1'b1) && (! 1'b0));
-  assign _zz_327 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_328 = execute_INSTRUCTION[13];
-  assign _zz_329 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_330 = ($signed(_zz_331) + $signed(_zz_336));
-  assign _zz_331 = ($signed(_zz_332) + $signed(_zz_334));
-  assign _zz_332 = 52'h0;
-  assign _zz_333 = {1'b0,memory_MUL_LL};
-  assign _zz_334 = {{19{_zz_333[32]}}, _zz_333};
-  assign _zz_335 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_336 = {{2{_zz_335[49]}}, _zz_335};
-  assign _zz_337 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_338 = {{2{_zz_337[49]}}, _zz_337};
-  assign _zz_339 = ($signed(_zz_341) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_340 = _zz_339[31 : 0];
-  assign _zz_341 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_342 = _zz_104[34 : 34];
-  assign _zz_343 = _zz_104[33 : 33];
-  assign _zz_344 = _zz_104[32 : 32];
-  assign _zz_345 = _zz_104[31 : 31];
-  assign _zz_346 = _zz_104[28 : 28];
-  assign _zz_347 = _zz_104[21 : 21];
-  assign _zz_348 = _zz_104[20 : 20];
-  assign _zz_349 = _zz_104[19 : 19];
-  assign _zz_350 = _zz_104[13 : 13];
-  assign _zz_351 = _zz_104[12 : 12];
-  assign _zz_352 = _zz_104[11 : 11];
-  assign _zz_353 = _zz_104[35 : 35];
-  assign _zz_354 = _zz_104[17 : 17];
-  assign _zz_355 = _zz_104[5 : 5];
-  assign _zz_356 = _zz_104[3 : 3];
-  assign _zz_357 = _zz_104[18 : 18];
-  assign _zz_358 = _zz_104[10 : 10];
-  assign _zz_359 = _zz_104[16 : 16];
-  assign _zz_360 = _zz_104[15 : 15];
-  assign _zz_361 = _zz_104[4 : 4];
-  assign _zz_362 = _zz_104[0 : 0];
-  assign _zz_363 = (_zz_57 - 5'h01);
-  assign _zz_364 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_365 = {29'd0, _zz_364};
-  assign _zz_366 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_367 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_368 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_369 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_370 = {{_zz_75,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_371 = {{_zz_77,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_372 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_373 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_374 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_375 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_376 = MmuPlugin_ports_0_entryToReplace_willIncrement;
-  assign _zz_377 = {1'd0, _zz_376};
-  assign _zz_378 = MmuPlugin_ports_1_entryToReplace_willIncrement;
-  assign _zz_379 = {1'd0, _zz_378};
-  assign _zz_380 = MmuPlugin_shared_dBusRspStaged_payload_data[0 : 0];
-  assign _zz_381 = MmuPlugin_shared_dBusRspStaged_payload_data[1 : 1];
-  assign _zz_382 = MmuPlugin_shared_dBusRspStaged_payload_data[2 : 2];
-  assign _zz_383 = MmuPlugin_shared_dBusRspStaged_payload_data[3 : 3];
-  assign _zz_384 = MmuPlugin_shared_dBusRspStaged_payload_data[4 : 4];
-  assign _zz_385 = MmuPlugin_shared_dBusRspStaged_payload_data[5 : 5];
-  assign _zz_386 = MmuPlugin_shared_dBusRspStaged_payload_data[6 : 6];
-  assign _zz_387 = MmuPlugin_shared_dBusRspStaged_payload_data[7 : 7];
-  assign _zz_388 = (_zz_100 - 2'b01);
-  assign _zz_389 = execute_SRC_LESS;
-  assign _zz_390 = 3'b100;
-  assign _zz_391 = execute_INSTRUCTION[19 : 15];
-  assign _zz_392 = execute_INSTRUCTION[31 : 20];
-  assign _zz_393 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_394 = ($signed(_zz_395) + $signed(_zz_398));
-  assign _zz_395 = ($signed(_zz_396) + $signed(_zz_397));
-  assign _zz_396 = execute_SRC1;
-  assign _zz_397 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_398 = (execute_SRC_USE_SUB_LESS ? _zz_399 : _zz_400);
-  assign _zz_399 = 32'h00000001;
-  assign _zz_400 = 32'h0;
-  assign _zz_401 = execute_INSTRUCTION[31 : 20];
-  assign _zz_402 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_403 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_404 = {_zz_143,execute_INSTRUCTION[31 : 20]};
-  assign _zz_405 = {{_zz_145,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_406 = {{_zz_147,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_407 = execute_INSTRUCTION[31 : 20];
-  assign _zz_408 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_409 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_410 = 3'b100;
-  assign _zz_411 = (_zz_162 & (~ _zz_412));
-  assign _zz_412 = (_zz_162 - 2'b01);
-  assign _zz_413 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_414 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_415 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_416 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_417 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_418 = {5'd0, _zz_417};
-  assign _zz_419 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_420 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_421 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_422 = {_zz_164,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_423 = _zz_424;
-  assign _zz_424 = _zz_425;
-  assign _zz_425 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_165) : _zz_165)} + _zz_427);
-  assign _zz_426 = memory_DivPlugin_div_needRevert;
-  assign _zz_427 = {32'd0, _zz_426};
-  assign _zz_428 = _zz_167;
-  assign _zz_429 = {32'd0, _zz_428};
-  assign _zz_430 = _zz_166;
-  assign _zz_431 = {31'd0, _zz_430};
-  assign _zz_432 = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_433 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_434 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_435 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_436 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_437 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_438 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_439 = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_440 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_441 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_442 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_443 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_444 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_445 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_446 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_447 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_448 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_449 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_450 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_451 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_452 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_453 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_454 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_455 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_456 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_457 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_458 = execute_CsrPlugin_writeData[4 : 4];
-  assign _zz_459 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_460 = execute_CsrPlugin_writeData[6 : 6];
-  assign _zz_461 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_462 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_463 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_464 = execute_CsrPlugin_writeData[12 : 12];
-  assign _zz_465 = execute_CsrPlugin_writeData[13 : 13];
-  assign _zz_466 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_467 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_468 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_469 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_470 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_471 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_472 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_473 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_474 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_475 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_476 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_477 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_478 = 1'b1;
-  assign _zz_479 = 1'b1;
-  assign _zz_480 = {_zz_60,{_zz_62,_zz_61}};
-  assign _zz_481 = 32'h0000107f;
-  assign _zz_482 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_483 = 32'h00002073;
-  assign _zz_484 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_485 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_486 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_487) == 32'h00000003),{(_zz_488 == _zz_489),{_zz_490,{_zz_491,_zz_492}}}}}};
-  assign _zz_487 = 32'h0000505f;
-  assign _zz_488 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_489 = 32'h00000063;
-  assign _zz_490 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_491 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_492 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_493) == 32'h0000500f),{(_zz_494 == _zz_495),{_zz_496,{_zz_497,_zz_498}}}}}};
-  assign _zz_493 = 32'h01f0707f;
-  assign _zz_494 = (decode_INSTRUCTION & 32'hbc00707f);
-  assign _zz_495 = 32'h00005013;
-  assign _zz_496 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_497 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_498 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_499) == 32'h12000073),{(_zz_500 == _zz_501),{_zz_502,_zz_503}}}}};
-  assign _zz_499 = 32'hfe007fff;
-  assign _zz_500 = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_501 = 32'h10200073;
-  assign _zz_502 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_503 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_504 = decode_INSTRUCTION[31];
-  assign _zz_505 = decode_INSTRUCTION[31];
-  assign _zz_506 = decode_INSTRUCTION[7];
-  assign _zz_507 = 32'h10103050;
-  assign _zz_508 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_509 = 1'b0;
-  assign _zz_510 = (((decode_INSTRUCTION & _zz_513) == 32'h02000030) != 1'b0);
-  assign _zz_511 = ({_zz_514,_zz_515} != 2'b00);
-  assign _zz_512 = {(_zz_516 != 1'b0),{(_zz_517 != _zz_518),{_zz_519,{_zz_520,_zz_521}}}};
-  assign _zz_513 = 32'h02004074;
-  assign _zz_514 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_515 = ((decode_INSTRUCTION & 32'h12203050) == 32'h10000050);
-  assign _zz_516 = ((decode_INSTRUCTION & 32'h02103050) == 32'h00000050);
-  assign _zz_517 = {(_zz_522 == _zz_523),(_zz_524 == _zz_525)};
-  assign _zz_518 = 2'b00;
-  assign _zz_519 = ({_zz_106,_zz_526} != 2'b00);
-  assign _zz_520 = (_zz_527 != 1'b0);
-  assign _zz_521 = {(_zz_528 != _zz_529),{_zz_530,{_zz_531,_zz_532}}};
-  assign _zz_522 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_523 = 32'h00001050;
-  assign _zz_524 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_525 = 32'h00002050;
-  assign _zz_526 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_527 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_528 = {(_zz_533 == _zz_534),(_zz_535 == _zz_536)};
-  assign _zz_529 = 2'b00;
-  assign _zz_530 = ({_zz_537,{_zz_538,_zz_539}} != 3'b000);
-  assign _zz_531 = (_zz_540 != 1'b0);
-  assign _zz_532 = {(_zz_541 != _zz_542),{_zz_543,{_zz_544,_zz_545}}};
-  assign _zz_533 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_534 = 32'h00005010;
-  assign _zz_535 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_536 = 32'h00005020;
-  assign _zz_537 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_538 = ((decode_INSTRUCTION & _zz_546) == 32'h00001010);
-  assign _zz_539 = ((decode_INSTRUCTION & _zz_547) == 32'h00001010);
-  assign _zz_540 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_541 = ((decode_INSTRUCTION & _zz_548) == 32'h00002000);
-  assign _zz_542 = 1'b0;
-  assign _zz_543 = ({_zz_549,_zz_550} != 2'b00);
-  assign _zz_544 = (_zz_551 != 1'b0);
-  assign _zz_545 = {(_zz_552 != _zz_553),{_zz_554,{_zz_555,_zz_556}}};
-  assign _zz_546 = 32'h00007034;
-  assign _zz_547 = 32'h02007054;
-  assign _zz_548 = 32'h00003000;
-  assign _zz_549 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_550 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_551 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
-  assign _zz_552 = ((decode_INSTRUCTION & _zz_557) == 32'h00004008);
-  assign _zz_553 = 1'b0;
-  assign _zz_554 = ((_zz_558 == _zz_559) != 1'b0);
-  assign _zz_555 = ({_zz_560,_zz_561} != 4'b0000);
-  assign _zz_556 = {(_zz_562 != _zz_563),{_zz_564,{_zz_565,_zz_566}}};
-  assign _zz_557 = 32'h00004048;
-  assign _zz_558 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_559 = 32'h00000024;
-  assign _zz_560 = ((decode_INSTRUCTION & _zz_567) == 32'h00000020);
-  assign _zz_561 = {(_zz_568 == _zz_569),{_zz_570,_zz_571}};
-  assign _zz_562 = ((decode_INSTRUCTION & _zz_572) == 32'h00000008);
-  assign _zz_563 = 1'b0;
-  assign _zz_564 = ((_zz_573 == _zz_574) != 1'b0);
-  assign _zz_565 = ({_zz_575,_zz_576} != 6'h0);
-  assign _zz_566 = {(_zz_577 != _zz_578),{_zz_579,{_zz_580,_zz_581}}};
-  assign _zz_567 = 32'h00000034;
-  assign _zz_568 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_569 = 32'h00000020;
-  assign _zz_570 = ((decode_INSTRUCTION & _zz_582) == 32'h08000020);
-  assign _zz_571 = ((decode_INSTRUCTION & _zz_583) == 32'h00000020);
-  assign _zz_572 = 32'h10000008;
-  assign _zz_573 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_574 = 32'h10000008;
-  assign _zz_575 = (_zz_584 == _zz_585);
-  assign _zz_576 = {_zz_586,{_zz_587,_zz_588}};
-  assign _zz_577 = {_zz_589,{_zz_590,_zz_591}};
-  assign _zz_578 = 3'b000;
-  assign _zz_579 = ({_zz_592,_zz_593} != 5'h0);
-  assign _zz_580 = (_zz_594 != _zz_595);
-  assign _zz_581 = {_zz_596,{_zz_597,_zz_598}};
-  assign _zz_582 = 32'h08000070;
-  assign _zz_583 = 32'h10000070;
-  assign _zz_584 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_585 = 32'h00002040;
-  assign _zz_586 = ((decode_INSTRUCTION & _zz_599) == 32'h00001040);
-  assign _zz_587 = (_zz_600 == _zz_601);
-  assign _zz_588 = {_zz_602,{_zz_603,_zz_604}};
-  assign _zz_589 = ((decode_INSTRUCTION & _zz_605) == 32'h08000020);
-  assign _zz_590 = (_zz_606 == _zz_607);
-  assign _zz_591 = (_zz_608 == _zz_609);
-  assign _zz_592 = (_zz_610 == _zz_611);
-  assign _zz_593 = {_zz_612,{_zz_613,_zz_614}};
-  assign _zz_594 = {_zz_109,{_zz_615,_zz_616}};
-  assign _zz_595 = 5'h0;
-  assign _zz_596 = ({_zz_617,_zz_618} != 7'h0);
-  assign _zz_597 = (_zz_619 != _zz_620);
-  assign _zz_598 = {_zz_621,{_zz_622,_zz_623}};
-  assign _zz_599 = 32'h00001040;
-  assign _zz_600 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_601 = 32'h00000040;
-  assign _zz_602 = ((decode_INSTRUCTION & _zz_624) == 32'h00000040);
-  assign _zz_603 = (_zz_625 == _zz_626);
-  assign _zz_604 = (_zz_627 == _zz_628);
-  assign _zz_605 = 32'h08000020;
-  assign _zz_606 = (decode_INSTRUCTION & 32'h10000020);
-  assign _zz_607 = 32'h00000020;
-  assign _zz_608 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_609 = 32'h00000020;
-  assign _zz_610 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_611 = 32'h00000040;
-  assign _zz_612 = ((decode_INSTRUCTION & _zz_629) == 32'h00004020);
-  assign _zz_613 = (_zz_630 == _zz_631);
-  assign _zz_614 = {_zz_109,_zz_632};
-  assign _zz_615 = (_zz_633 == _zz_634);
-  assign _zz_616 = {_zz_635,{_zz_636,_zz_637}};
-  assign _zz_617 = _zz_106;
-  assign _zz_618 = {_zz_638,{_zz_639,_zz_640}};
-  assign _zz_619 = {_zz_108,_zz_641};
-  assign _zz_620 = 2'b00;
-  assign _zz_621 = ({_zz_642,_zz_643} != 2'b00);
-  assign _zz_622 = (_zz_644 != _zz_645);
-  assign _zz_623 = {_zz_646,{_zz_647,_zz_648}};
-  assign _zz_624 = 32'h02100040;
-  assign _zz_625 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_626 = 32'h0;
-  assign _zz_627 = (decode_INSTRUCTION & 32'h18002008);
-  assign _zz_628 = 32'h10002008;
-  assign _zz_629 = 32'h00004020;
-  assign _zz_630 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_631 = 32'h00000010;
-  assign _zz_632 = ((decode_INSTRUCTION & _zz_649) == 32'h00000020);
-  assign _zz_633 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_634 = 32'h00002010;
-  assign _zz_635 = ((decode_INSTRUCTION & _zz_650) == 32'h00000010);
-  assign _zz_636 = (_zz_651 == _zz_652);
-  assign _zz_637 = (_zz_653 == _zz_654);
-  assign _zz_638 = ((decode_INSTRUCTION & _zz_655) == 32'h00001010);
-  assign _zz_639 = (_zz_656 == _zz_657);
-  assign _zz_640 = {_zz_658,{_zz_659,_zz_660}};
-  assign _zz_641 = ((decode_INSTRUCTION & _zz_661) == 32'h00000020);
-  assign _zz_642 = _zz_108;
-  assign _zz_643 = (_zz_662 == _zz_663);
-  assign _zz_644 = (_zz_664 == _zz_665);
-  assign _zz_645 = 1'b0;
-  assign _zz_646 = (_zz_666 != 1'b0);
-  assign _zz_647 = (_zz_667 != _zz_668);
-  assign _zz_648 = {_zz_669,{_zz_670,_zz_671}};
-  assign _zz_649 = 32'h02000028;
-  assign _zz_650 = 32'h00001030;
-  assign _zz_651 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_652 = 32'h00000020;
-  assign _zz_653 = (decode_INSTRUCTION & 32'h02002068);
-  assign _zz_654 = 32'h00002020;
-  assign _zz_655 = 32'h00001010;
-  assign _zz_656 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_657 = 32'h00002010;
-  assign _zz_658 = ((decode_INSTRUCTION & _zz_672) == 32'h00002008);
-  assign _zz_659 = (_zz_673 == _zz_674);
-  assign _zz_660 = {_zz_109,_zz_675};
-  assign _zz_661 = 32'h00000070;
-  assign _zz_662 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_663 = 32'h0;
-  assign _zz_664 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_665 = 32'h00004010;
-  assign _zz_666 = ((decode_INSTRUCTION & _zz_676) == 32'h00002010);
-  assign _zz_667 = {_zz_677,{_zz_678,_zz_679}};
-  assign _zz_668 = 5'h0;
-  assign _zz_669 = ({_zz_680,_zz_681} != 2'b00);
-  assign _zz_670 = (_zz_682 != _zz_683);
-  assign _zz_671 = {_zz_684,{_zz_685,_zz_686}};
-  assign _zz_672 = 32'h00002008;
-  assign _zz_673 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_674 = 32'h00000010;
-  assign _zz_675 = ((decode_INSTRUCTION & _zz_687) == 32'h0);
-  assign _zz_676 = 32'h00006014;
-  assign _zz_677 = ((decode_INSTRUCTION & _zz_688) == 32'h0);
-  assign _zz_678 = (_zz_689 == _zz_690);
-  assign _zz_679 = {_zz_691,{_zz_692,_zz_693}};
-  assign _zz_680 = _zz_107;
-  assign _zz_681 = (_zz_694 == _zz_695);
-  assign _zz_682 = {_zz_696,{_zz_697,_zz_698}};
-  assign _zz_683 = 3'b000;
-  assign _zz_684 = ({_zz_699,_zz_700} != 3'b000);
-  assign _zz_685 = (_zz_701 != _zz_702);
-  assign _zz_686 = (_zz_703 != _zz_704);
-  assign _zz_687 = 32'h00000028;
-  assign _zz_688 = 32'h00000044;
-  assign _zz_689 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_690 = 32'h0;
-  assign _zz_691 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_692 = ((decode_INSTRUCTION & _zz_705) == 32'h00001000);
-  assign _zz_693 = _zz_107;
-  assign _zz_694 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_695 = 32'h0;
-  assign _zz_696 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_697 = ((decode_INSTRUCTION & _zz_706) == 32'h00002010);
-  assign _zz_698 = ((decode_INSTRUCTION & _zz_707) == 32'h40000030);
-  assign _zz_699 = _zz_106;
-  assign _zz_700 = {_zz_105,(_zz_708 == _zz_709)};
-  assign _zz_701 = {_zz_105,(_zz_710 == _zz_711)};
-  assign _zz_702 = 2'b00;
-  assign _zz_703 = ((decode_INSTRUCTION & _zz_712) == 32'h00001008);
-  assign _zz_704 = 1'b0;
-  assign _zz_705 = 32'h00005004;
-  assign _zz_706 = 32'h00002014;
-  assign _zz_707 = 32'h40000034;
-  assign _zz_708 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_709 = 32'h00000004;
-  assign _zz_710 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz_711 = 32'h00000004;
-  assign _zz_712 = 32'h00005048;
-  assign _zz_713 = execute_INSTRUCTION[31];
-  assign _zz_714 = execute_INSTRUCTION[31];
-  assign _zz_715 = execute_INSTRUCTION[7];
-  assign _zz_716 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_478) begin
-      _zz_243 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 5'h01);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
+  assign _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1 = MmuPlugin_ports_0_entryToReplace_willIncrement;
+  assign _zz_MmuPlugin_ports_0_entryToReplace_valueNext = {1'd0, _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1};
+  assign _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1 = MmuPlugin_ports_1_entryToReplace_willIncrement;
+  assign _zz_MmuPlugin_ports_1_entryToReplace_valueNext = {1'd0, _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1};
+  assign _zz__zz_MmuPlugin_shared_refills_2 = (_zz_MmuPlugin_shared_refills_1 - 2'b01);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_7 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,{_zz_IBusCachedPlugin_jump_pcLoad_payload_5,_zz_IBusCachedPlugin_jump_pcLoad_payload_4}};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h0000500f),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'h01f0707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005013;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h12000073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),{_zz_decode_LEGAL_INSTRUCTION_21,_zz_decode_LEGAL_INSTRUCTION_22}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hfe007fff;
+  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_21 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_22 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_1 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_2 = (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_3 = (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_4 = (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_5 = (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_1 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_2 = (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_3 = (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_4 = (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_5 = (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz__zz_decode_IS_RS2_SIGNED = 32'h10103050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_4) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = ({_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_7} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = {(_zz__zz_decode_IS_RS2_SIGNED_9 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_10 != _zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_16,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_20}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h02004074;
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h12203050) == 32'h10000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h02103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(_zz__zz_decode_IS_RS2_SIGNED_11 == _zz__zz_decode_IS_RS2_SIGNED_12),(_zz__zz_decode_IS_RS2_SIGNED_13 == _zz__zz_decode_IS_RS2_SIGNED_14)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ({_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_17} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (_zz__zz_decode_IS_RS2_SIGNED_19 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = {(_zz__zz_decode_IS_RS2_SIGNED_21 != _zz__zz_decode_IS_RS2_SIGNED_26),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ({_zz__zz_decode_IS_RS2_SIGNED_28,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_31}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (_zz__zz_decode_IS_RS2_SIGNED_34 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(_zz__zz_decode_IS_RS2_SIGNED_36 != _zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_39,{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_43}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00005020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_32) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ({_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_41} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = (_zz_decode_IS_RS2_SIGNED_6 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(_zz__zz_decode_IS_RS2_SIGNED_44 != _zz__zz_decode_IS_RS2_SIGNED_45),{_zz__zz_decode_IS_RS2_SIGNED_46,{_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_51}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00007034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00003000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = _zz_decode_IS_RS2_SIGNED_6;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_47) == 32'h00004008) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((_zz__zz_decode_IS_RS2_SIGNED_49 == _zz__zz_decode_IS_RS2_SIGNED_50) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = {({_zz__zz_decode_IS_RS2_SIGNED_52,_zz__zz_decode_IS_RS2_SIGNED_54} != 4'b0000),{(_zz__zz_decode_IS_RS2_SIGNED_61 != _zz__zz_decode_IS_RS2_SIGNED_63),{_zz__zz_decode_IS_RS2_SIGNED_64,{_zz__zz_decode_IS_RS2_SIGNED_67,_zz__zz_decode_IS_RS2_SIGNED_86}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000024;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_53) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = {(_zz__zz_decode_IS_RS2_SIGNED_55 == _zz__zz_decode_IS_RS2_SIGNED_56),{_zz__zz_decode_IS_RS2_SIGNED_57,_zz__zz_decode_IS_RS2_SIGNED_59}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_62) == 32'h00000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((_zz__zz_decode_IS_RS2_SIGNED_65 == _zz__zz_decode_IS_RS2_SIGNED_66) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = ({_zz__zz_decode_IS_RS2_SIGNED_68,_zz__zz_decode_IS_RS2_SIGNED_71} != 6'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = {(_zz__zz_decode_IS_RS2_SIGNED_87 != _zz__zz_decode_IS_RS2_SIGNED_96),{_zz__zz_decode_IS_RS2_SIGNED_97,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_125}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_58) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_60) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h10000008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (_zz__zz_decode_IS_RS2_SIGNED_69 == _zz__zz_decode_IS_RS2_SIGNED_70);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = {_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_74,_zz__zz_decode_IS_RS2_SIGNED_77}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz__zz_decode_IS_RS2_SIGNED_88,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_93}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = ({_zz__zz_decode_IS_RS2_SIGNED_98,_zz__zz_decode_IS_RS2_SIGNED_101} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (_zz__zz_decode_IS_RS2_SIGNED_111 != _zz__zz_decode_IS_RS2_SIGNED_124);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = {_zz__zz_decode_IS_RS2_SIGNED_126,{_zz__zz_decode_IS_RS2_SIGNED_143,_zz__zz_decode_IS_RS2_SIGNED_148}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = 32'h08000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h10000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_73) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = (_zz__zz_decode_IS_RS2_SIGNED_75 == _zz__zz_decode_IS_RS2_SIGNED_76);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = {_zz__zz_decode_IS_RS2_SIGNED_78,{_zz__zz_decode_IS_RS2_SIGNED_80,_zz__zz_decode_IS_RS2_SIGNED_83}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h08000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = (_zz__zz_decode_IS_RS2_SIGNED_94 == _zz__zz_decode_IS_RS2_SIGNED_95);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = (_zz__zz_decode_IS_RS2_SIGNED_99 == _zz__zz_decode_IS_RS2_SIGNED_100);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = {_zz__zz_decode_IS_RS2_SIGNED_102,{_zz__zz_decode_IS_RS2_SIGNED_104,_zz__zz_decode_IS_RS2_SIGNED_107}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = {_zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_112,_zz__zz_decode_IS_RS2_SIGNED_115}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ({_zz__zz_decode_IS_RS2_SIGNED_127,_zz__zz_decode_IS_RS2_SIGNED_128} != 7'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (_zz__zz_decode_IS_RS2_SIGNED_144 != _zz__zz_decode_IS_RS2_SIGNED_147);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = {_zz__zz_decode_IS_RS2_SIGNED_149,{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_159}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_79) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (_zz__zz_decode_IS_RS2_SIGNED_81 == _zz__zz_decode_IS_RS2_SIGNED_82);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = (_zz__zz_decode_IS_RS2_SIGNED_84 == _zz__zz_decode_IS_RS2_SIGNED_85);
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h08000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h10000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_103) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (_zz__zz_decode_IS_RS2_SIGNED_105 == _zz__zz_decode_IS_RS2_SIGNED_106);
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_108};
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = {_zz__zz_decode_IS_RS2_SIGNED_116,{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_121}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = {_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_131,_zz__zz_decode_IS_RS2_SIGNED_134}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = {_zz_decode_IS_RS2_SIGNED_4,_zz__zz_decode_IS_RS2_SIGNED_145};
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = ({_zz__zz_decode_IS_RS2_SIGNED_150,_zz__zz_decode_IS_RS2_SIGNED_151} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = (_zz__zz_decode_IS_RS2_SIGNED_155 != _zz__zz_decode_IS_RS2_SIGNED_158);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = {_zz__zz_decode_IS_RS2_SIGNED_160,{_zz__zz_decode_IS_RS2_SIGNED_163,_zz__zz_decode_IS_RS2_SIGNED_176}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = 32'h02100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = (decode_INSTRUCTION & 32'h18002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = 32'h10002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_109) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (_zz__zz_decode_IS_RS2_SIGNED_119 == _zz__zz_decode_IS_RS2_SIGNED_120);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = (_zz__zz_decode_IS_RS2_SIGNED_122 == _zz__zz_decode_IS_RS2_SIGNED_123);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_130) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = (_zz__zz_decode_IS_RS2_SIGNED_132 == _zz__zz_decode_IS_RS2_SIGNED_133);
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = {_zz__zz_decode_IS_RS2_SIGNED_135,{_zz__zz_decode_IS_RS2_SIGNED_137,_zz__zz_decode_IS_RS2_SIGNED_140}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_146) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (_zz__zz_decode_IS_RS2_SIGNED_152 == _zz__zz_decode_IS_RS2_SIGNED_153);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = (_zz__zz_decode_IS_RS2_SIGNED_156 == _zz__zz_decode_IS_RS2_SIGNED_157);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = (_zz__zz_decode_IS_RS2_SIGNED_161 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (_zz__zz_decode_IS_RS2_SIGNED_164 != _zz__zz_decode_IS_RS2_SIGNED_175);
+  assign _zz__zz_decode_IS_RS2_SIGNED_176 = {_zz__zz_decode_IS_RS2_SIGNED_177,{_zz__zz_decode_IS_RS2_SIGNED_182,_zz__zz_decode_IS_RS2_SIGNED_190}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h02000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = (decode_INSTRUCTION & 32'h02002068);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_136) == 32'h00002008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (_zz__zz_decode_IS_RS2_SIGNED_138 == _zz__zz_decode_IS_RS2_SIGNED_139);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {_zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_141};
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_162) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = {_zz__zz_decode_IS_RS2_SIGNED_165,{_zz__zz_decode_IS_RS2_SIGNED_167,_zz__zz_decode_IS_RS2_SIGNED_170}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_175 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_177 = ({_zz__zz_decode_IS_RS2_SIGNED_178,_zz__zz_decode_IS_RS2_SIGNED_179} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_182 = (_zz__zz_decode_IS_RS2_SIGNED_183 != _zz__zz_decode_IS_RS2_SIGNED_189);
+  assign _zz__zz_decode_IS_RS2_SIGNED_190 = {_zz__zz_decode_IS_RS2_SIGNED_191,{_zz__zz_decode_IS_RS2_SIGNED_196,_zz__zz_decode_IS_RS2_SIGNED_201}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00002008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_142) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_166) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_167 = (_zz__zz_decode_IS_RS2_SIGNED_168 == _zz__zz_decode_IS_RS2_SIGNED_169);
+  assign _zz__zz_decode_IS_RS2_SIGNED_170 = {_zz__zz_decode_IS_RS2_SIGNED_171,{_zz__zz_decode_IS_RS2_SIGNED_172,_zz__zz_decode_IS_RS2_SIGNED_174}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_178 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_179 = (_zz__zz_decode_IS_RS2_SIGNED_180 == _zz__zz_decode_IS_RS2_SIGNED_181);
+  assign _zz__zz_decode_IS_RS2_SIGNED_183 = {_zz__zz_decode_IS_RS2_SIGNED_184,{_zz__zz_decode_IS_RS2_SIGNED_185,_zz__zz_decode_IS_RS2_SIGNED_187}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_189 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_191 = ({_zz__zz_decode_IS_RS2_SIGNED_192,_zz__zz_decode_IS_RS2_SIGNED_193} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_196 = (_zz__zz_decode_IS_RS2_SIGNED_197 != _zz__zz_decode_IS_RS2_SIGNED_200);
+  assign _zz__zz_decode_IS_RS2_SIGNED_201 = (_zz__zz_decode_IS_RS2_SIGNED_202 != _zz__zz_decode_IS_RS2_SIGNED_204);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00000028;
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_168 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_IS_RS2_SIGNED_169 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_171 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_172 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_173) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_174 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_180 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_RS2_SIGNED_181 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_184 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_185 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_186) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_187 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_188) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_192 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_193 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_194 == _zz__zz_decode_IS_RS2_SIGNED_195)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_197 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_198 == _zz__zz_decode_IS_RS2_SIGNED_199)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_200 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_202 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_203) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_204 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_173 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_186 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_188 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_194 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_195 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_198 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_199 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_203 = 32'h00005048;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_28 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_479) begin
-      _zz_244 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_208                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_209                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_210                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_211                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_212                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]           ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_213                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_214                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_215                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_216                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_174[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical           ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_217                                            ), //i
-    .io_cpu_execute_address                    (_zz_218[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (_zz_219                                            ), //i
-    .io_cpu_execute_args_data                  (_zz_220[31:0]                                      ), //i
-    .io_cpu_execute_args_size                  (_zz_221[1:0]                                       ), //i
-    .io_cpu_execute_args_isLrsc                (_zz_222                                            ), //i
-    .io_cpu_execute_args_isAmo                 (_zz_223                                            ), //i
-    .io_cpu_execute_args_amoCtrl_swap          (_zz_224                                            ), //i
-    .io_cpu_execute_args_amoCtrl_alu           (_zz_225[2:0]                                       ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_226                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_227[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_228                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]  ), //i
-    .io_cpu_writeBack_isValid                  (_zz_229                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_230                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_231[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_232                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_233                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_234                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_235                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_236                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_237                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_238                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_239                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_240[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_241                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_242                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (dataCache_1_io_cpu_execute_args_wr             ), //i
+    .io_cpu_execute_args_size                  (dataCache_1_io_cpu_execute_args_size           ), //i
+    .io_cpu_execute_args_isLrsc                (dataCache_1_io_cpu_execute_args_isLrsc         ), //i
+    .io_cpu_execute_args_isAmo                 (execute_MEMORY_AMO                             ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (dataCache_1_io_cpu_execute_args_amoCtrl_swap   ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (dataCache_1_io_cpu_execute_args_amoCtrl_alu    ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical    ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_480)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_7)
       3'b000 : begin
-        _zz_245 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = DBusCachedPlugin_redoBranch_payload;
       end
       3'b001 : begin
-        _zz_245 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = CsrPlugin_jumpInterface_payload;
       end
       3'b010 : begin
-        _zz_245 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = BranchPlugin_jumpInterface_payload;
       end
       3'b011 : begin
-        _zz_245 = CsrPlugin_redoInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = CsrPlugin_redoInterface_payload;
       end
       default : begin
-        _zz_245 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_93)
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
       2'b00 : begin
-        _zz_246 = MmuPlugin_ports_0_cache_0_valid;
-        _zz_247 = MmuPlugin_ports_0_cache_0_exception;
-        _zz_248 = MmuPlugin_ports_0_cache_0_superPage;
-        _zz_249 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
-        _zz_250 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
-        _zz_251 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
-        _zz_252 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
-        _zz_253 = MmuPlugin_ports_0_cache_0_allowRead;
-        _zz_254 = MmuPlugin_ports_0_cache_0_allowWrite;
-        _zz_255 = MmuPlugin_ports_0_cache_0_allowExecute;
-        _zz_256 = MmuPlugin_ports_0_cache_0_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
       end
       2'b01 : begin
-        _zz_246 = MmuPlugin_ports_0_cache_1_valid;
-        _zz_247 = MmuPlugin_ports_0_cache_1_exception;
-        _zz_248 = MmuPlugin_ports_0_cache_1_superPage;
-        _zz_249 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
-        _zz_250 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
-        _zz_251 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
-        _zz_252 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
-        _zz_253 = MmuPlugin_ports_0_cache_1_allowRead;
-        _zz_254 = MmuPlugin_ports_0_cache_1_allowWrite;
-        _zz_255 = MmuPlugin_ports_0_cache_1_allowExecute;
-        _zz_256 = MmuPlugin_ports_0_cache_1_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       2'b10 : begin
-        _zz_246 = MmuPlugin_ports_0_cache_2_valid;
-        _zz_247 = MmuPlugin_ports_0_cache_2_exception;
-        _zz_248 = MmuPlugin_ports_0_cache_2_superPage;
-        _zz_249 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
-        _zz_250 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
-        _zz_251 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
-        _zz_252 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
-        _zz_253 = MmuPlugin_ports_0_cache_2_allowRead;
-        _zz_254 = MmuPlugin_ports_0_cache_2_allowWrite;
-        _zz_255 = MmuPlugin_ports_0_cache_2_allowExecute;
-        _zz_256 = MmuPlugin_ports_0_cache_2_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
       end
       default : begin
-        _zz_246 = MmuPlugin_ports_0_cache_3_valid;
-        _zz_247 = MmuPlugin_ports_0_cache_3_exception;
-        _zz_248 = MmuPlugin_ports_0_cache_3_superPage;
-        _zz_249 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
-        _zz_250 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
-        _zz_251 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
-        _zz_252 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
-        _zz_253 = MmuPlugin_ports_0_cache_3_allowRead;
-        _zz_254 = MmuPlugin_ports_0_cache_3_allowWrite;
-        _zz_255 = MmuPlugin_ports_0_cache_3_allowExecute;
-        _zz_256 = MmuPlugin_ports_0_cache_3_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_97)
-      2'b00 : begin
-        _zz_257 = MmuPlugin_ports_1_cache_0_valid;
-        _zz_258 = MmuPlugin_ports_1_cache_0_exception;
-        _zz_259 = MmuPlugin_ports_1_cache_0_superPage;
-        _zz_260 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
-        _zz_261 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
-        _zz_262 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
-        _zz_263 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
-        _zz_264 = MmuPlugin_ports_1_cache_0_allowRead;
-        _zz_265 = MmuPlugin_ports_1_cache_0_allowWrite;
-        _zz_266 = MmuPlugin_ports_1_cache_0_allowExecute;
-        _zz_267 = MmuPlugin_ports_1_cache_0_allowUser;
-      end
-      2'b01 : begin
-        _zz_257 = MmuPlugin_ports_1_cache_1_valid;
-        _zz_258 = MmuPlugin_ports_1_cache_1_exception;
-        _zz_259 = MmuPlugin_ports_1_cache_1_superPage;
-        _zz_260 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
-        _zz_261 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
-        _zz_262 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
-        _zz_263 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
-        _zz_264 = MmuPlugin_ports_1_cache_1_allowRead;
-        _zz_265 = MmuPlugin_ports_1_cache_1_allowWrite;
-        _zz_266 = MmuPlugin_ports_1_cache_1_allowExecute;
-        _zz_267 = MmuPlugin_ports_1_cache_1_allowUser;
-      end
-      2'b10 : begin
-        _zz_257 = MmuPlugin_ports_1_cache_2_valid;
-        _zz_258 = MmuPlugin_ports_1_cache_2_exception;
-        _zz_259 = MmuPlugin_ports_1_cache_2_superPage;
-        _zz_260 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
-        _zz_261 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
-        _zz_262 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
-        _zz_263 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
-        _zz_264 = MmuPlugin_ports_1_cache_2_allowRead;
-        _zz_265 = MmuPlugin_ports_1_cache_2_allowWrite;
-        _zz_266 = MmuPlugin_ports_1_cache_2_allowExecute;
-        _zz_267 = MmuPlugin_ports_1_cache_2_allowUser;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       default : begin
-        _zz_257 = MmuPlugin_ports_1_cache_3_valid;
-        _zz_258 = MmuPlugin_ports_1_cache_3_exception;
-        _zz_259 = MmuPlugin_ports_1_cache_3_superPage;
-        _zz_260 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
-        _zz_261 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
-        _zz_262 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
-        _zz_263 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
-        _zz_264 = MmuPlugin_ports_1_cache_3_allowRead;
-        _zz_265 = MmuPlugin_ports_1_cache_3_allowWrite;
-        _zz_266 = MmuPlugin_ports_1_cache_3_allowExecute;
-        _zz_267 = MmuPlugin_ports_1_cache_3_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_MmuPlugin_ports_0_cacheLine_valid_3)
+      2'b00 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_0_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_0_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_0_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_0_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_0_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_0_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_0_allowUser;
+      end
+      2'b01 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_1_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_1_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_1_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_1_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_1_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_1_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_1_allowUser;
+      end
+      2'b10 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_2_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_2_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_2_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_2_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_2_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_2_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_2_allowUser;
+      end
+      default : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_3_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_3_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_3_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_3_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_3_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_3_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_3_allowUser;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_MmuPlugin_ports_1_cacheLine_valid_3)
+      2'b00 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_0_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_0_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_0_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_0_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_0_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_0_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_0_allowUser;
+      end
+      2'b01 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_1_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_1_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_1_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_1_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_1_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_1_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_1_allowUser;
+      end
+      2'b10 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_2_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_2_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_2_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_2_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_2_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_2_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_2_allowUser;
+      end
+      default : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_3_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_3_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_3_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_3_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_3_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_3_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_3_allowUser;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2520,134 +2574,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2660,30 +2714,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2695,27 +2749,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2728,30 +2782,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2764,12 +2818,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2782,12 +2836,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2800,12 +2854,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2818,48 +2872,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2872,12 +2926,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2890,12 +2944,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2907,88 +2961,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3001,12 +3055,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
-      default : _zz_52_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
@@ -3020,64 +3074,64 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_111)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_111_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_111_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_111_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_111_string = "URS1        ";
-      default : _zz_111_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_112)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_112_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_112_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_112_string = "BITWISE ";
-      default : _zz_112_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_113)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_113_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_113_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_113_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_113_string = "PC ";
-      default : _zz_113_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_114)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_114_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_114_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_114_string = "AND_1";
-      default : _zz_114_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_115)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_115_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_115_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_115_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_115_string = "SRA_1    ";
-      default : _zz_115_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_116)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_116_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_116_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_116_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_116_string = "JALR";
-      default : _zz_116_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_117)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_117_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_117_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_117_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_117_string = "ECALL";
-      default : _zz_117_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3108,28 +3162,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -3170,7 +3224,7 @@ module VexRiscv (
   end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_330) + $signed(_zz_338));
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -3178,57 +3232,57 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_340;
-  assign execute_REGFILE_WRITE_DATA = _zz_119;
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_218[1 : 0];
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_342[0];
-  assign decode_IS_RS1_SIGNED = _zz_343[0];
-  assign decode_IS_DIV = _zz_344[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[35];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[34];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[33];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_345[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_346[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_347[0];
-  assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
-  assign decode_IS_SFENCE_VMA = _zz_348[0];
-  assign decode_MEMORY_MANAGMENT = _zz_349[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[32];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[29];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[22];
+  assign decode_IS_SFENCE_VMA = _zz_decode_IS_RS2_SIGNED[21];
+  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_RS2_SIGNED[20];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[19];
+  assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_350[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_351[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_352[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
-  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_353[0];
+  assign decode_IS_EBREAK = _zz_decode_IS_RS2_SIGNED[36];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3242,25 +3296,26 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
+  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_141;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_354[0];
-  assign decode_RS1_USE = _zz_355[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_268)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
-    if(DBusCachedPlugin_forceDatapath)begin
-      _zz_31 = MmuPlugin_dBusAccess_cmd_payload_address;
+    if(DBusCachedPlugin_forceDatapath) begin
+      _zz_decode_RS2 = MmuPlugin_dBusAccess_cmd_payload_address;
     end
   end
 
@@ -3270,148 +3325,165 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_130)begin
-      if((_zz_131 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_132;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_269)begin
-      if(_zz_270)begin
-        if(_zz_134)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_271)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_136)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_272)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_138)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_130)begin
-      if((_zz_131 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_132;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_269)begin
-      if(_zz_270)begin
-        if(_zz_133)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_271)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_135)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_272)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_137)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_127;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_273)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_356[0];
-  assign decode_SRC_ADD_ZERO = _zz_357[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_125;
-  assign execute_SRC1 = _zz_120;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_358[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_481) == 32'h00001073),{(_zz_482 == _zz_483),{_zz_484,{_zz_485,_zz_486}}}}}}} != 25'h0);
-  assign writeBack_IS_SFENCE_VMA = memory_to_writeBack_IS_SFENCE_VMA;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 25'h0);
+  assign execute_IS_SFENCE_VMA2 = decode_to_execute_IS_SFENCE_VMA2;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_329)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_415;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_416;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_LRSC = memory_to_writeBack_MEMORY_LRSC;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
-  assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  always @(*) begin
+    execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        execute_MEMORY_AMO = 1'b0;
+      end
+    end
+  end
+
+  always @(*) begin
+    execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        execute_MEMORY_LRSC = 1'b0;
+      end
+    end
+  end
+
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
@@ -3419,70 +3491,70 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_359[0];
-  assign decode_MEMORY_LRSC = _zz_360[0];
-  assign decode_MEMORY_ENABLE = _zz_361[0];
-  assign decode_FLUSH_ALL = _zz_362[0];
-  always @ (*) begin
+  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_274)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_275)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_276)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_277)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_53 = execute_FORMAL_PC_NEXT;
-    if(CsrPlugin_redoInterface_valid)begin
-      _zz_53 = CsrPlugin_redoInterface_payload;
+  always @(*) begin
+    _zz_execute_to_memory_FORMAL_PC_NEXT = execute_FORMAL_PC_NEXT;
+    if(CsrPlugin_redoInterface_valid) begin
+      _zz_execute_to_memory_FORMAL_PC_NEXT = CsrPlugin_redoInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_54 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_55 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_55 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_174)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -3491,174 +3563,175 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((decode_arbitration_isValid && (_zz_128 || _zz_129)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(CsrPlugin_pipelineLiberator_active) begin
+      decode_arbitration_haltByOther = 1'b1;
+    end
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_278)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_278)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_241 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_279)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_268)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_280)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_280)begin
-      if(_zz_281)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_280)begin
-      if(_zz_281)begin
-        execute_arbitration_flushNext = 1'b1;
-      end
+    if(CsrPlugin_selfException_valid) begin
+      execute_arbitration_flushNext = 1'b1;
     end
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeInstruction)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_273)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_282)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_283)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3667,75 +3740,77 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_282)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_283)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_280)begin
-      if(_zz_281)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_284)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_56 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_56 = 1'b1;
+  always @(*) begin
+    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    if(DebugPlugin_godmode) begin
+      _zz_when_DBusCachedPlugin_l386 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_279)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_282)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_283)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_282)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_283)begin
-      case(_zz_285)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3748,81 +3823,93 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h0);
-  assign _zz_57 = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
-  assign _zz_58 = (_zz_57 & (~ _zz_363));
-  assign _zz_59 = _zz_58[3];
-  assign _zz_60 = _zz_58[4];
-  assign _zz_61 = (_zz_58[1] || _zz_59);
-  assign _zz_62 = (_zz_58[2] || _zz_59);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_245;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[4];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_365);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3830,66 +3917,75 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_63);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_63);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_64 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_64);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_64);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_65 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_65);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_65);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_66;
-  assign _zz_66 = ((1'b0 && (! _zz_67)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_67 = _zz_68;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_67;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_69)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_69 = _zz_70;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_69;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_71;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_174)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3901,207 +3997,213 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_72 = _zz_366[11];
-  always @ (*) begin
-    _zz_73[18] = _zz_72;
-    _zz_73[17] = _zz_72;
-    _zz_73[16] = _zz_72;
-    _zz_73[15] = _zz_72;
-    _zz_73[14] = _zz_72;
-    _zz_73[13] = _zz_72;
-    _zz_73[12] = _zz_72;
-    _zz_73[11] = _zz_72;
-    _zz_73[10] = _zz_72;
-    _zz_73[9] = _zz_72;
-    _zz_73[8] = _zz_72;
-    _zz_73[7] = _zz_72;
-    _zz_73[6] = _zz_72;
-    _zz_73[5] = _zz_72;
-    _zz_73[4] = _zz_72;
-    _zz_73[3] = _zz_72;
-    _zz_73[2] = _zz_72;
-    _zz_73[1] = _zz_72;
-    _zz_73[0] = _zz_72;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_367[31]));
-    if(_zz_78)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_74 = _zz_368[19];
-  always @ (*) begin
-    _zz_75[10] = _zz_74;
-    _zz_75[9] = _zz_74;
-    _zz_75[8] = _zz_74;
-    _zz_75[7] = _zz_74;
-    _zz_75[6] = _zz_74;
-    _zz_75[5] = _zz_74;
-    _zz_75[4] = _zz_74;
-    _zz_75[3] = _zz_74;
-    _zz_75[2] = _zz_74;
-    _zz_75[1] = _zz_74;
-    _zz_75[0] = _zz_74;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_76 = _zz_369[11];
-  always @ (*) begin
-    _zz_77[18] = _zz_76;
-    _zz_77[17] = _zz_76;
-    _zz_77[16] = _zz_76;
-    _zz_77[15] = _zz_76;
-    _zz_77[14] = _zz_76;
-    _zz_77[13] = _zz_76;
-    _zz_77[12] = _zz_76;
-    _zz_77[11] = _zz_76;
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_78 = _zz_370[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_78 = _zz_371[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_79 = _zz_372[19];
-  always @ (*) begin
-    _zz_80[10] = _zz_79;
-    _zz_80[9] = _zz_79;
-    _zz_80[8] = _zz_79;
-    _zz_80[7] = _zz_79;
-    _zz_80[6] = _zz_79;
-    _zz_80[5] = _zz_79;
-    _zz_80[4] = _zz_79;
-    _zz_80[3] = _zz_79;
-    _zz_80[2] = _zz_79;
-    _zz_80[1] = _zz_79;
-    _zz_80[0] = _zz_79;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_81 = _zz_373[11];
-  always @ (*) begin
-    _zz_82[18] = _zz_81;
-    _zz_82[17] = _zz_81;
-    _zz_82[16] = _zz_81;
-    _zz_82[15] = _zz_81;
-    _zz_82[14] = _zz_81;
-    _zz_82[13] = _zz_81;
-    _zz_82[12] = _zz_81;
-    _zz_82[11] = _zz_81;
-    _zz_82[10] = _zz_81;
-    _zz_82[9] = _zz_81;
-    _zz_82[8] = _zz_81;
-    _zz_82[7] = _zz_81;
-    _zz_82[6] = _zz_81;
-    _zz_82[5] = _zz_81;
-    _zz_82[4] = _zz_81;
-    _zz_82[3] = _zz_81;
-    _zz_82[2] = _zz_81;
-    _zz_82[1] = _zz_81;
-    _zz_82[0] = _zz_81;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_80,{{{_zz_504,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_82,{{{_zz_505,_zz_506},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_209 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_210 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_211 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_210;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_213 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_214 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_215 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_277)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_275)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_216 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_275)begin
-      _zz_216 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_276)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_274)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_276)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_274)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_208 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_242 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -4109,328 +4211,318 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  always @ (*) begin
-    _zz_51 = 1'b0;
-    if(decode_INSTRUCTION[25])begin
-      if(decode_MEMORY_LRSC)begin
-        _zz_51 = 1'b1;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  always @(*) begin
+    _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
+    if(when_DBusCachedPlugin_l311) begin
+      if(decode_MEMORY_LRSC) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
-      if(decode_MEMORY_AMO)begin
-        _zz_51 = 1'b1;
+      if(decode_MEMORY_AMO) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l311 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
-    _zz_217 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        if(_zz_287)begin
-          _zz_217 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        if(when_DBusCachedPlugin_l499) begin
+          dataCache_1_io_cpu_execute_isValid = 1'b1;
         end
       end
     end
   end
 
-  always @ (*) begin
-    _zz_218 = execute_SRC_ADD;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        _zz_218 = MmuPlugin_dBusAccess_cmd_payload_address;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_address = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
   end
 
-  always @ (*) begin
-    _zz_219 = execute_MEMORY_WR;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        _zz_219 = MmuPlugin_dBusAccess_cmd_payload_write;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_wr = execute_MEMORY_WR;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_args_wr = 1'b0;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_85 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_85 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_85 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_220 = _zz_85;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        _zz_220 = MmuPlugin_dBusAccess_cmd_payload_data;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_size = execute_DBusCachedPlugin_size;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_args_size = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
-  always @ (*) begin
-    _zz_221 = execute_DBusCachedPlugin_size;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        _zz_221 = MmuPlugin_dBusAccess_cmd_payload_size;
-      end
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
+    if(execute_MEMORY_LRSC) begin
+      dataCache_1_io_cpu_execute_args_isLrsc = 1'b1;
     end
   end
 
-  assign _zz_241 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  always @ (*) begin
-    _zz_222 = 1'b0;
-    if(execute_MEMORY_LRSC)begin
-      _zz_222 = 1'b1;
-    end
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        _zz_222 = 1'b0;
-      end
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  always @(*) begin
+    dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+    if(memory_IS_DBUS_SHARING) begin
+      dataCache_1_io_cpu_memory_isValid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_223 = execute_MEMORY_AMO;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        _zz_223 = 1'b0;
-      end
-    end
-  end
-
-  assign _zz_225 = execute_INSTRUCTION[31 : 29];
-  assign _zz_224 = execute_INSTRUCTION[27];
-  always @ (*) begin
-    _zz_226 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-    if(memory_IS_DBUS_SHARING)begin
-      _zz_226 = 1'b1;
-    end
-  end
-
-  assign _zz_227 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_226;
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_227;
-  always @ (*) begin
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
+  always @(*) begin
     DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
-    if(memory_IS_DBUS_SHARING)begin
+    if(memory_IS_DBUS_SHARING) begin
       DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b1;
     end
   end
 
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_228 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_56 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_228 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_229 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-    if(writeBack_IS_DBUS_SHARING)begin
-      _zz_229 = 1'b1;
+  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_IS_DBUS_SHARING) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b1;
+    end
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
     end
   end
 
-  assign _zz_230 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_231 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_288)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_288)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_288)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_374};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_375};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_86 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_87[31] = _zz_86;
-    _zz_87[30] = _zz_86;
-    _zz_87[29] = _zz_86;
-    _zz_87[28] = _zz_86;
-    _zz_87[27] = _zz_86;
-    _zz_87[26] = _zz_86;
-    _zz_87[25] = _zz_86;
-    _zz_87[24] = _zz_86;
-    _zz_87[23] = _zz_86;
-    _zz_87[22] = _zz_86;
-    _zz_87[21] = _zz_86;
-    _zz_87[20] = _zz_86;
-    _zz_87[19] = _zz_86;
-    _zz_87[18] = _zz_86;
-    _zz_87[17] = _zz_86;
-    _zz_87[16] = _zz_86;
-    _zz_87[15] = _zz_86;
-    _zz_87[14] = _zz_86;
-    _zz_87[13] = _zz_86;
-    _zz_87[12] = _zz_86;
-    _zz_87[11] = _zz_86;
-    _zz_87[10] = _zz_86;
-    _zz_87[9] = _zz_86;
-    _zz_87[8] = _zz_86;
-    _zz_87[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+    if(when_DBusCachedPlugin_l474) begin
+      writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
+    end
   end
 
-  assign _zz_88 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_89[31] = _zz_88;
-    _zz_89[30] = _zz_88;
-    _zz_89[29] = _zz_88;
-    _zz_89[28] = _zz_88;
-    _zz_89[27] = _zz_88;
-    _zz_89[26] = _zz_88;
-    _zz_89[25] = _zz_88;
-    _zz_89[24] = _zz_88;
-    _zz_89[23] = _zz_88;
-    _zz_89[22] = _zz_88;
-    _zz_89[21] = _zz_88;
-    _zz_89[20] = _zz_88;
-    _zz_89[19] = _zz_88;
-    _zz_89[18] = _zz_88;
-    _zz_89[17] = _zz_88;
-    _zz_89[16] = _zz_88;
-    _zz_89[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign when_DBusCachedPlugin_l474 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_327)
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_87;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_89;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  always @(*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
-        if(_zz_287)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        if(when_DBusCachedPlugin_l499) begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_286)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l498 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign when_DBusCachedPlugin_l499 = (! dataCache_1_io_cpu_execute_refilling);
   assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
-  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1_io_cpu_writeBack_data;
+  assign MmuPlugin_dBusAccess_rsp_payload_data = writeBack_DBusCachedPlugin_rspRf;
   assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1_io_cpu_writeBack_unalignedAccess || dataCache_1_io_cpu_writeBack_accessError);
   assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1_io_cpu_redo;
   assign MmuPlugin_ports_0_dirty = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+    if(when_MmuPlugin_l125) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
-    if((CsrPlugin_privilege == 2'b11))begin
+    if(when_MmuPlugin_l126) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
   end
 
-  always @ (*) begin
-    MmuPlugin_ports_0_cacheHitsCalc[0] = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[1] = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[2] = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[3] = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-  end
-
+  assign when_MmuPlugin_l125 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l126 = (CsrPlugin_privilege == 2'b11);
+  assign MmuPlugin_ports_0_cacheHitsCalc = {((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_0_cacheHitsCalc)) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_0_cacheHitsCalc_1))),{((MmuPlugin_ports_0_cache_1_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_2) && (MmuPlugin_ports_0_cache_1_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_3)),((MmuPlugin_ports_0_cache_0_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_4) && (MmuPlugin_ports_0_cache_0_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_0_cacheHit = (MmuPlugin_ports_0_cacheHitsCalc != 4'b0000);
-  assign _zz_90 = MmuPlugin_ports_0_cacheHitsCalc[3];
-  assign _zz_91 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_90);
-  assign _zz_92 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_90);
-  assign _zz_93 = {_zz_92,_zz_91};
-  assign MmuPlugin_ports_0_cacheLine_valid = _zz_246;
-  assign MmuPlugin_ports_0_cacheLine_exception = _zz_247;
-  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_248;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_249;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_250;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_251;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_252;
-  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_253;
-  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_254;
-  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_255;
-  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_256;
-  always @ (*) begin
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_1 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_MmuPlugin_ports_0_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_2 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_MmuPlugin_ports_0_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_3 = {_zz_MmuPlugin_ports_0_cacheLine_valid_2,_zz_MmuPlugin_ports_0_cacheLine_valid_1};
+  assign MmuPlugin_ports_0_cacheLine_valid = _zz_MmuPlugin_ports_0_cacheLine_valid_4;
+  assign MmuPlugin_ports_0_cacheLine_exception = _zz_MmuPlugin_ports_0_cacheLine_exception;
+  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_MmuPlugin_ports_0_cacheLine_superPage;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1;
+  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_MmuPlugin_ports_0_cacheLine_allowRead;
+  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_MmuPlugin_ports_0_cacheLine_allowWrite;
+  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_MmuPlugin_ports_0_cacheLine_allowExecute;
+  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_MmuPlugin_ports_0_cacheLine_allowUser;
+  always @(*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(_zz_289)begin
-      if(_zz_290)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274) begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4439,63 +4531,63 @@ module VexRiscv (
   assign MmuPlugin_ports_0_entryToReplace_willClear = 1'b0;
   assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_0_entryToReplace_willOverflow = (MmuPlugin_ports_0_entryToReplace_willOverflowIfInc && MmuPlugin_ports_0_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_377);
-    if(MmuPlugin_ports_0_entryToReplace_willClear)begin
+  always @(*) begin
+    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_MmuPlugin_ports_0_entryToReplace_valueNext);
+    if(MmuPlugin_ports_0_entryToReplace_willClear) begin
       MmuPlugin_ports_0_entryToReplace_valueNext = 2'b00;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
       IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_0_dirty) && MmuPlugin_ports_0_cacheHit) && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_0_dirty || (! MmuPlugin_ports_0_cacheHit));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
@@ -4513,45 +4605,42 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_0_cacheHitsCalc[3];
   assign IBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_0_cache_3_physicalAddress_1,(MmuPlugin_ports_0_cache_3_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_3_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
   assign MmuPlugin_ports_1_dirty = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+    if(when_MmuPlugin_l125_1) begin
       MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
     end
-    if((CsrPlugin_privilege == 2'b11))begin
-      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11)))begin
+    if(when_MmuPlugin_l126_1) begin
+      if(when_MmuPlugin_l128) begin
         MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
       end
     end
   end
 
-  always @ (*) begin
-    MmuPlugin_ports_1_cacheHitsCalc[0] = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[1] = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[2] = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[3] = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-  end
-
+  assign when_MmuPlugin_l125_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l126_1 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l128 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
+  assign MmuPlugin_ports_1_cacheHitsCalc = {((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_1_cacheHitsCalc)) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_1_cacheHitsCalc_1))),{((MmuPlugin_ports_1_cache_1_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_2) && (MmuPlugin_ports_1_cache_1_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_3)),((MmuPlugin_ports_1_cache_0_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_4) && (MmuPlugin_ports_1_cache_0_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_1_cacheHit = (MmuPlugin_ports_1_cacheHitsCalc != 4'b0000);
-  assign _zz_94 = MmuPlugin_ports_1_cacheHitsCalc[3];
-  assign _zz_95 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_94);
-  assign _zz_96 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_94);
-  assign _zz_97 = {_zz_96,_zz_95};
-  assign MmuPlugin_ports_1_cacheLine_valid = _zz_257;
-  assign MmuPlugin_ports_1_cacheLine_exception = _zz_258;
-  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_259;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_260;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_261;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_262;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_263;
-  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_264;
-  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_265;
-  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_266;
-  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_267;
-  always @ (*) begin
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_1 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_MmuPlugin_ports_1_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_2 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_MmuPlugin_ports_1_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_3 = {_zz_MmuPlugin_ports_1_cacheLine_valid_2,_zz_MmuPlugin_ports_1_cacheLine_valid_1};
+  assign MmuPlugin_ports_1_cacheLine_valid = _zz_MmuPlugin_ports_1_cacheLine_valid_4;
+  assign MmuPlugin_ports_1_cacheLine_exception = _zz_MmuPlugin_ports_1_cacheLine_exception;
+  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_MmuPlugin_ports_1_cacheLine_superPage;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1;
+  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_MmuPlugin_ports_1_cacheLine_allowRead;
+  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_MmuPlugin_ports_1_cacheLine_allowWrite;
+  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_MmuPlugin_ports_1_cacheLine_allowExecute;
+  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_MmuPlugin_ports_1_cacheLine_allowUser;
+  always @(*) begin
     MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(_zz_289)begin
-      if(_zz_291)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274_1) begin
         MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4560,63 +4649,63 @@ module VexRiscv (
   assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
   assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_379);
-    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
+  always @(*) begin
+    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_MmuPlugin_ports_1_entryToReplace_valueNext);
+    if(MmuPlugin_ports_1_entryToReplace_willClear) begin
       MmuPlugin_ports_1_entryToReplace_valueNext = 2'b00;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
       DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_1_dirty) && MmuPlugin_ports_1_cacheHit) && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_1_dirty || (! MmuPlugin_ports_1_cacheHit));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
@@ -4633,20 +4722,21 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_1_cache_2_physicalAddress_1,(MmuPlugin_ports_1_cache_2_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_2_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
   assign DBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_1_cacheHitsCalc[3];
   assign DBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_1_cache_3_physicalAddress_1,(MmuPlugin_ports_1_cache_3_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_3_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
-  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_380[0];
-  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_381[0];
-  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_382[0];
-  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_383[0];
-  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_384[0];
-  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_385[0];
-  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_386[0];
-  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_387[0];
+  assign MmuPlugin_shared_dBusRsp_pte_V = MmuPlugin_shared_dBusRspStaged_payload_data[0];
+  assign MmuPlugin_shared_dBusRsp_pte_R = MmuPlugin_shared_dBusRspStaged_payload_data[1];
+  assign MmuPlugin_shared_dBusRsp_pte_W = MmuPlugin_shared_dBusRspStaged_payload_data[2];
+  assign MmuPlugin_shared_dBusRsp_pte_X = MmuPlugin_shared_dBusRspStaged_payload_data[3];
+  assign MmuPlugin_shared_dBusRsp_pte_U = MmuPlugin_shared_dBusRspStaged_payload_data[4];
+  assign MmuPlugin_shared_dBusRsp_pte_G = MmuPlugin_shared_dBusRspStaged_payload_data[5];
+  assign MmuPlugin_shared_dBusRsp_pte_A = MmuPlugin_shared_dBusRspStaged_payload_data[6];
+  assign MmuPlugin_shared_dBusRsp_pte_D = MmuPlugin_shared_dBusRspStaged_payload_data[7];
   assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_shared_dBusRspStaged_payload_data[9 : 8];
   assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_shared_dBusRspStaged_payload_data[19 : 10];
   assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
   assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
-  always @ (*) begin
+  assign when_MmuPlugin_l205 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
+  always @(*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
@@ -4666,8 +4756,8 @@ module VexRiscv (
 
   assign MmuPlugin_dBusAccess_cmd_payload_write = 1'b0;
   assign MmuPlugin_dBusAccess_cmd_payload_size = 2'b10;
-  always @ (*) begin
-    MmuPlugin_dBusAccess_cmd_payload_address = 32'h0;
+  always @(*) begin
+    MmuPlugin_dBusAccess_cmd_payload_address = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
@@ -4684,84 +4774,95 @@ module VexRiscv (
     endcase
   end
 
-  assign MmuPlugin_dBusAccess_cmd_payload_data = 32'h0;
+  assign MmuPlugin_dBusAccess_cmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
   assign MmuPlugin_dBusAccess_cmd_payload_writeMask = 4'bxxxx;
-  always @ (*) begin
-    _zz_98[0] = (((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit));
-    _zz_98[1] = (((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit));
+  assign _zz_MmuPlugin_shared_refills = {(((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit)),(((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit))};
+  always @(*) begin
+    _zz_MmuPlugin_shared_refills_1[0] = _zz_MmuPlugin_shared_refills[1];
+    _zz_MmuPlugin_shared_refills_1[1] = _zz_MmuPlugin_shared_refills[0];
   end
 
-  assign _zz_99 = _zz_98;
-  always @ (*) begin
-    _zz_100[0] = _zz_99[1];
-    _zz_100[1] = _zz_99[0];
+  assign _zz_MmuPlugin_shared_refills_2 = (_zz_MmuPlugin_shared_refills_1 & (~ _zz__zz_MmuPlugin_shared_refills_2));
+  always @(*) begin
+    _zz_MmuPlugin_shared_refills_3[0] = _zz_MmuPlugin_shared_refills_2[1];
+    _zz_MmuPlugin_shared_refills_3[1] = _zz_MmuPlugin_shared_refills_2[0];
   end
 
-  assign _zz_101 = (_zz_100 & (~ _zz_388));
-  always @ (*) begin
-    _zz_102[0] = _zz_101[1];
-    _zz_102[1] = _zz_101[0];
-  end
-
-  assign MmuPlugin_shared_refills = _zz_102;
-  assign _zz_103 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign MmuPlugin_shared_refills = _zz_MmuPlugin_shared_refills_3;
+  assign when_MmuPlugin_l217 = (MmuPlugin_shared_refills != 2'b00);
+  assign _zz_MmuPlugin_shared_vpn_0 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign when_MmuPlugin_l243 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
   assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[0]);
   assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[1]);
-  assign _zz_105 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_106 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_107 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_108 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_109 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_110 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_104 = {(((decode_INSTRUCTION & _zz_507) == 32'h00100050) != 1'b0),{(_zz_110 != 1'b0),{(_zz_110 != 1'b0),{(_zz_508 != _zz_509),{_zz_510,{_zz_511,_zz_512}}}}}};
-  assign _zz_111 = _zz_104[2 : 1];
-  assign _zz_49 = _zz_111;
-  assign _zz_112 = _zz_104[7 : 6];
-  assign _zz_48 = _zz_112;
-  assign _zz_113 = _zz_104[9 : 8];
-  assign _zz_47 = _zz_113;
-  assign _zz_114 = _zz_104[23 : 22];
-  assign _zz_46 = _zz_114;
-  assign _zz_115 = _zz_104[25 : 24];
-  assign _zz_45 = _zz_115;
-  assign _zz_116 = _zz_104[27 : 26];
-  assign _zz_44 = _zz_116;
-  assign _zz_117 = _zz_104[30 : 29];
-  assign _zz_43 = _zz_117;
+  assign when_MmuPlugin_l272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign when_MmuPlugin_l274 = MmuPlugin_shared_portSortedOh[0];
+  assign when_MmuPlugin_l280 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l280_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l280_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l280_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l274_1 = MmuPlugin_shared_portSortedOh[1];
+  assign when_MmuPlugin_l280_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l280_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l280_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l280_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l304 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED) == 32'h00100050) != 1'b0),{(_zz_decode_IS_RS2_SIGNED_7 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_7 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_1 != _zz__zz_decode_IS_RS2_SIGNED_2),{_zz__zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_8}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[26 : 25];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[28 : 27];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[31 : 30];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_243;
-  assign decode_RegFilePlugin_rs2Data = _zz_244;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_118)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_118)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_118)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -4770,353 +4871,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_119 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_119 = {31'd0, _zz_389};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_119 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_120 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_120 = {29'd0, _zz_390};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_120 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_120 = {27'd0, _zz_391};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_121 = _zz_392[11];
-  always @ (*) begin
-    _zz_122[19] = _zz_121;
-    _zz_122[18] = _zz_121;
-    _zz_122[17] = _zz_121;
-    _zz_122[16] = _zz_121;
-    _zz_122[15] = _zz_121;
-    _zz_122[14] = _zz_121;
-    _zz_122[13] = _zz_121;
-    _zz_122[12] = _zz_121;
-    _zz_122[11] = _zz_121;
-    _zz_122[10] = _zz_121;
-    _zz_122[9] = _zz_121;
-    _zz_122[8] = _zz_121;
-    _zz_122[7] = _zz_121;
-    _zz_122[6] = _zz_121;
-    _zz_122[5] = _zz_121;
-    _zz_122[4] = _zz_121;
-    _zz_122[3] = _zz_121;
-    _zz_122[2] = _zz_121;
-    _zz_122[1] = _zz_121;
-    _zz_122[0] = _zz_121;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_123 = _zz_393[11];
-  always @ (*) begin
-    _zz_124[19] = _zz_123;
-    _zz_124[18] = _zz_123;
-    _zz_124[17] = _zz_123;
-    _zz_124[16] = _zz_123;
-    _zz_124[15] = _zz_123;
-    _zz_124[14] = _zz_123;
-    _zz_124[13] = _zz_123;
-    _zz_124[12] = _zz_123;
-    _zz_124[11] = _zz_123;
-    _zz_124[10] = _zz_123;
-    _zz_124[9] = _zz_123;
-    _zz_124[8] = _zz_123;
-    _zz_124[7] = _zz_123;
-    _zz_124[6] = _zz_123;
-    _zz_124[5] = _zz_123;
-    _zz_124[4] = _zz_123;
-    _zz_124[3] = _zz_123;
-    _zz_124[2] = _zz_123;
-    _zz_124[1] = _zz_123;
-    _zz_124[0] = _zz_123;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_125 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_125 = {_zz_122,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_125 = {_zz_124,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_125 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_394;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_126[0] = execute_SRC1[31];
-    _zz_126[1] = execute_SRC1[30];
-    _zz_126[2] = execute_SRC1[29];
-    _zz_126[3] = execute_SRC1[28];
-    _zz_126[4] = execute_SRC1[27];
-    _zz_126[5] = execute_SRC1[26];
-    _zz_126[6] = execute_SRC1[25];
-    _zz_126[7] = execute_SRC1[24];
-    _zz_126[8] = execute_SRC1[23];
-    _zz_126[9] = execute_SRC1[22];
-    _zz_126[10] = execute_SRC1[21];
-    _zz_126[11] = execute_SRC1[20];
-    _zz_126[12] = execute_SRC1[19];
-    _zz_126[13] = execute_SRC1[18];
-    _zz_126[14] = execute_SRC1[17];
-    _zz_126[15] = execute_SRC1[16];
-    _zz_126[16] = execute_SRC1[15];
-    _zz_126[17] = execute_SRC1[14];
-    _zz_126[18] = execute_SRC1[13];
-    _zz_126[19] = execute_SRC1[12];
-    _zz_126[20] = execute_SRC1[11];
-    _zz_126[21] = execute_SRC1[10];
-    _zz_126[22] = execute_SRC1[9];
-    _zz_126[23] = execute_SRC1[8];
-    _zz_126[24] = execute_SRC1[7];
-    _zz_126[25] = execute_SRC1[6];
-    _zz_126[26] = execute_SRC1[5];
-    _zz_126[27] = execute_SRC1[4];
-    _zz_126[28] = execute_SRC1[3];
-    _zz_126[29] = execute_SRC1[2];
-    _zz_126[30] = execute_SRC1[1];
-    _zz_126[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_126 : execute_SRC1);
-  always @ (*) begin
-    _zz_127[0] = memory_SHIFT_RIGHT[31];
-    _zz_127[1] = memory_SHIFT_RIGHT[30];
-    _zz_127[2] = memory_SHIFT_RIGHT[29];
-    _zz_127[3] = memory_SHIFT_RIGHT[28];
-    _zz_127[4] = memory_SHIFT_RIGHT[27];
-    _zz_127[5] = memory_SHIFT_RIGHT[26];
-    _zz_127[6] = memory_SHIFT_RIGHT[25];
-    _zz_127[7] = memory_SHIFT_RIGHT[24];
-    _zz_127[8] = memory_SHIFT_RIGHT[23];
-    _zz_127[9] = memory_SHIFT_RIGHT[22];
-    _zz_127[10] = memory_SHIFT_RIGHT[21];
-    _zz_127[11] = memory_SHIFT_RIGHT[20];
-    _zz_127[12] = memory_SHIFT_RIGHT[19];
-    _zz_127[13] = memory_SHIFT_RIGHT[18];
-    _zz_127[14] = memory_SHIFT_RIGHT[17];
-    _zz_127[15] = memory_SHIFT_RIGHT[16];
-    _zz_127[16] = memory_SHIFT_RIGHT[15];
-    _zz_127[17] = memory_SHIFT_RIGHT[14];
-    _zz_127[18] = memory_SHIFT_RIGHT[13];
-    _zz_127[19] = memory_SHIFT_RIGHT[12];
-    _zz_127[20] = memory_SHIFT_RIGHT[11];
-    _zz_127[21] = memory_SHIFT_RIGHT[10];
-    _zz_127[22] = memory_SHIFT_RIGHT[9];
-    _zz_127[23] = memory_SHIFT_RIGHT[8];
-    _zz_127[24] = memory_SHIFT_RIGHT[7];
-    _zz_127[25] = memory_SHIFT_RIGHT[6];
-    _zz_127[26] = memory_SHIFT_RIGHT[5];
-    _zz_127[27] = memory_SHIFT_RIGHT[4];
-    _zz_127[28] = memory_SHIFT_RIGHT[3];
-    _zz_127[29] = memory_SHIFT_RIGHT[2];
-    _zz_127[30] = memory_SHIFT_RIGHT[1];
-    _zz_127[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_128 = 1'b0;
-    if(_zz_292)begin
-      if(_zz_293)begin
-        if(_zz_133)begin
-          _zz_128 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_294)begin
-      if(_zz_295)begin
-        if(_zz_135)begin
-          _zz_128 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_296)begin
-      if(_zz_297)begin
-        if(_zz_137)begin
-          _zz_128 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_128 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_129 = 1'b0;
-    if(_zz_292)begin
-      if(_zz_293)begin
-        if(_zz_134)begin
-          _zz_129 = 1'b1;
-        end
-      end
-    end
-    if(_zz_294)begin
-      if(_zz_295)begin
-        if(_zz_136)begin
-          _zz_129 = 1'b1;
-        end
-      end
-    end
-    if(_zz_296)begin
-      if(_zz_297)begin
-        if(_zz_138)begin
-          _zz_129 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_129 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_133 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_134 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_135 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_136 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_137 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_138 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_139 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_139 == 3'b000)) begin
-        _zz_140 = execute_BranchPlugin_eq;
-    end else if((_zz_139 == 3'b001)) begin
-        _zz_140 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_139 & 3'b101) == 3'b101))) begin
-        _zz_140 = (! execute_SRC_LESS);
-    end else begin
-        _zz_140 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_141 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_141 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_141 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_141 = _zz_140;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_142 = _zz_401[11];
-  always @ (*) begin
-    _zz_143[19] = _zz_142;
-    _zz_143[18] = _zz_142;
-    _zz_143[17] = _zz_142;
-    _zz_143[16] = _zz_142;
-    _zz_143[15] = _zz_142;
-    _zz_143[14] = _zz_142;
-    _zz_143[13] = _zz_142;
-    _zz_143[12] = _zz_142;
-    _zz_143[11] = _zz_142;
-    _zz_143[10] = _zz_142;
-    _zz_143[9] = _zz_142;
-    _zz_143[8] = _zz_142;
-    _zz_143[7] = _zz_142;
-    _zz_143[6] = _zz_142;
-    _zz_143[5] = _zz_142;
-    _zz_143[4] = _zz_142;
-    _zz_143[3] = _zz_142;
-    _zz_143[2] = _zz_142;
-    _zz_143[1] = _zz_142;
-    _zz_143[0] = _zz_142;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_144 = _zz_402[19];
-  always @ (*) begin
-    _zz_145[10] = _zz_144;
-    _zz_145[9] = _zz_144;
-    _zz_145[8] = _zz_144;
-    _zz_145[7] = _zz_144;
-    _zz_145[6] = _zz_144;
-    _zz_145[5] = _zz_144;
-    _zz_145[4] = _zz_144;
-    _zz_145[3] = _zz_144;
-    _zz_145[2] = _zz_144;
-    _zz_145[1] = _zz_144;
-    _zz_145[0] = _zz_144;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_146 = _zz_403[11];
-  always @ (*) begin
-    _zz_147[18] = _zz_146;
-    _zz_147[17] = _zz_146;
-    _zz_147[16] = _zz_146;
-    _zz_147[15] = _zz_146;
-    _zz_147[14] = _zz_146;
-    _zz_147[13] = _zz_146;
-    _zz_147[12] = _zz_146;
-    _zz_147[11] = _zz_146;
-    _zz_147[10] = _zz_146;
-    _zz_147[9] = _zz_146;
-    _zz_147[8] = _zz_146;
-    _zz_147[7] = _zz_146;
-    _zz_147[6] = _zz_146;
-    _zz_147[5] = _zz_146;
-    _zz_147[4] = _zz_146;
-    _zz_147[3] = _zz_146;
-    _zz_147[2] = _zz_146;
-    _zz_147[1] = _zz_146;
-    _zz_147[0] = _zz_146;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_148 = (_zz_404[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_148 = _zz_405[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_148 = _zz_406[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_148);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -5127,80 +5251,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_149 = _zz_407[11];
-  always @ (*) begin
-    _zz_150[19] = _zz_149;
-    _zz_150[18] = _zz_149;
-    _zz_150[17] = _zz_149;
-    _zz_150[16] = _zz_149;
-    _zz_150[15] = _zz_149;
-    _zz_150[14] = _zz_149;
-    _zz_150[13] = _zz_149;
-    _zz_150[12] = _zz_149;
-    _zz_150[11] = _zz_149;
-    _zz_150[10] = _zz_149;
-    _zz_150[9] = _zz_149;
-    _zz_150[8] = _zz_149;
-    _zz_150[7] = _zz_149;
-    _zz_150[6] = _zz_149;
-    _zz_150[5] = _zz_149;
-    _zz_150[4] = _zz_149;
-    _zz_150[3] = _zz_149;
-    _zz_150[2] = _zz_149;
-    _zz_150[1] = _zz_149;
-    _zz_150[0] = _zz_149;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_150,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_152,{{{_zz_713,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_154,{{{_zz_714,_zz_715},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_410};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_151 = _zz_408[19];
-  always @ (*) begin
-    _zz_152[10] = _zz_151;
-    _zz_152[9] = _zz_151;
-    _zz_152[8] = _zz_151;
-    _zz_152[7] = _zz_151;
-    _zz_152[6] = _zz_151;
-    _zz_152[5] = _zz_151;
-    _zz_152[4] = _zz_151;
-    _zz_152[3] = _zz_151;
-    _zz_152[2] = _zz_151;
-    _zz_152[1] = _zz_151;
-    _zz_152[0] = _zz_151;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_153 = _zz_409[11];
-  always @ (*) begin
-    _zz_154[18] = _zz_153;
-    _zz_154[17] = _zz_153;
-    _zz_154[16] = _zz_153;
-    _zz_154[15] = _zz_153;
-    _zz_154[14] = _zz_153;
-    _zz_154[13] = _zz_153;
-    _zz_154[12] = _zz_153;
-    _zz_154[11] = _zz_153;
-    _zz_154[10] = _zz_153;
-    _zz_154[9] = _zz_153;
-    _zz_154[8] = _zz_153;
-    _zz_154[7] = _zz_153;
-    _zz_154[6] = _zz_153;
-    _zz_154[5] = _zz_153;
-    _zz_154[4] = _zz_153;
-    _zz_154[3] = _zz_153;
-    _zz_154[2] = _zz_153;
-    _zz_154[1] = _zz_153;
-    _zz_154[0] = _zz_153;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -5210,9 +5334,9 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
-    CsrPlugin_privilege = _zz_155;
-    if(CsrPlugin_forceMachineWire)begin
+  always @(*) begin
+    CsrPlugin_privilege = _zz_CsrPlugin_privilege;
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
@@ -5220,82 +5344,93 @@ module VexRiscv (
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeInstruction)begin
-        CsrPlugin_redoInterface_valid = 1'b1;
-      end
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
+      CsrPlugin_redoInterface_valid = 1'b1;
     end
   end
 
   assign CsrPlugin_redoInterface_payload = decode_PC;
-  assign _zz_156 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_157 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_158 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_159 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_160 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_161 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  always @ (*) begin
+  always @(*) begin
+    CsrPlugin_rescheduleLogic_rescheduleNext = 1'b0;
+    if(when_CsrPlugin_l803) begin
+      CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
+    end
+    if(execute_CsrPlugin_csr_384) begin
+      if(execute_CsrPlugin_writeInstruction) begin
+        CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
+      end
+    end
+  end
+
+  assign when_CsrPlugin_l803 = (execute_arbitration_isValid && execute_IS_SFENCE_VMA);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_when_CsrPlugin_l952_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
       4'b0000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_1) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0010 : begin
-        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_2) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_3) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_4) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_5) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_6) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_7) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_8) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_9) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_10) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_11) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
@@ -5304,81 +5439,114 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l866 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
+  assign when_CsrPlugin_l866_3 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_4 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_5 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_6 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_7 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
+  assign when_CsrPlugin_l866_8 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
+  assign when_CsrPlugin_l866_9 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
+  assign when_CsrPlugin_l866_10 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
+  assign when_CsrPlugin_l866_11 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_162 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_163 = _zz_411[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_278)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign when_CsrPlugin_l946_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign when_CsrPlugin_l952_3 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign when_CsrPlugin_l952_4 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign when_CsrPlugin_l952_5 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign when_CsrPlugin_l952_6 = ((_zz_when_CsrPlugin_l952_3 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_7 = ((_zz_when_CsrPlugin_l952_4 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_8 = ((_zz_when_CsrPlugin_l952_5 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
@@ -5392,8 +5560,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
         CsrPlugin_xtvec_base = CsrPlugin_stvec_base;
@@ -5406,151 +5574,160 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_256)begin
+    if(execute_CsrPlugin_csr_256) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_384)begin
+    if(execute_CsrPlugin_csr_384) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_770)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_770) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_771)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_771) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_324)begin
+    if(execute_CsrPlugin_csr_324) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_260)begin
+    if(execute_CsrPlugin_csr_260) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_261)begin
+    if(execute_CsrPlugin_csr_261) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_321)begin
+    if(execute_CsrPlugin_csr_321) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_320)begin
+    if(execute_CsrPlugin_csr_320) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_322)begin
+    if(execute_CsrPlugin_csr_322) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_323)begin
+    if(execute_CsrPlugin_csr_323) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_2496)begin
+    if(execute_CsrPlugin_csr_2496) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3520)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3520) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_298)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_299)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_300)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_299)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_300)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5566,48 +5743,58 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_298)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_298)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  always @ (*) begin
-    execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-    if(execute_CsrPlugin_csr_836)begin
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  always @(*) begin
+    execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_readToWriteData[9 : 9] = CsrPlugin_sip_SEIP_SOFT;
     end
-    if(execute_CsrPlugin_csr_324)begin
+    if(execute_CsrPlugin_csr_324) begin
       execute_CsrPlugin_readToWriteData[9 : 9] = CsrPlugin_sip_SEIP_SOFT;
     end
   end
 
-  always @ (*) begin
-    case(_zz_328)
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || execute_IS_SFENCE_VMA));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_301)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5620,8 +5807,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_301)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5640,60 +5827,71 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_413) + $signed(_zz_414));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_273)begin
-      if(_zz_302)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_303)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_418);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_164 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_164[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_419);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_420 : _zz_421);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_422[31:0];
-  assign _zz_165 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_166 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_167 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_168[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_168[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_170 = (_zz_169 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_170 != 32'h0);
-  assign _zz_172 = (_zz_171 & externalInterruptArray_regNext);
-  assign externalInterruptS = (_zz_172 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_3 = (_zz_CsrPlugin_csrMapping_readDataInit_2 & externalInterruptArray_regNext);
+  assign externalInterruptS = (_zz_CsrPlugin_csrMapping_readDataInit_3 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_304)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -5703,9 +5901,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_173))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -5714,12 +5912,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_304)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -5730,35 +5929,118 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_52 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_36 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_68 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_69 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_70 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5779,9 +6061,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_174)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -5790,267 +6078,300 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_175[12 : 0] = 13'h1000;
-      _zz_175[25 : 20] = 6'h20;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_176[19 : 19] = MmuPlugin_status_mxr;
-      _zz_176[18 : 18] = MmuPlugin_status_sum;
-      _zz_176[17 : 17] = MmuPlugin_status_mprv;
-      _zz_176[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_176[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_176[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_176[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_176[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_176[1 : 1] = CsrPlugin_sstatus_SIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_256)begin
-      _zz_177[19 : 19] = MmuPlugin_status_mxr;
-      _zz_177[18 : 18] = MmuPlugin_status_sum;
-      _zz_177[17 : 17] = MmuPlugin_status_mprv;
-      _zz_177[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_177[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_177[1 : 1] = CsrPlugin_sstatus_SIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_256) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_384)begin
-      _zz_178[31 : 31] = MmuPlugin_satp_mode;
-      _zz_178[30 : 22] = MmuPlugin_satp_asid;
-      _zz_178[19 : 0] = MmuPlugin_satp_ppn;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_384) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = MmuPlugin_satp_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[30 : 22] = MmuPlugin_satp_asid;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[19 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_179[0 : 0] = 1'b1;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[0 : 0] = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_180[1 : 0] = 2'b10;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 0] = 2'b10;
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_181[1 : 0] = 2'b11;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = 2'b11;
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_182[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_182[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_182[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_182[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_182[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_182[9 : 9] = CsrPlugin_sip_SEIP_OR;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
-  always @ (*) begin
-    _zz_183 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_183[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_183[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_183[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_183[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_183[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_183[1 : 1] = CsrPlugin_sie_SSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_184 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_184[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_185 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_185[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_186 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_186[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_186[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_187 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_187[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_188 = 32'h0;
-    if(execute_CsrPlugin_csr_324)begin
-      _zz_188[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_188[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_188[9 : 9] = CsrPlugin_sip_SEIP_OR;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_324) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
-  always @ (*) begin
-    _zz_189 = 32'h0;
-    if(execute_CsrPlugin_csr_260)begin
-      _zz_189[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_189[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_189[1 : 1] = CsrPlugin_sie_SSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_260) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_190 = 32'h0;
-    if(execute_CsrPlugin_csr_261)begin
-      _zz_190[31 : 2] = CsrPlugin_stvec_base;
-      _zz_190[1 : 0] = CsrPlugin_stvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_261) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 2] = CsrPlugin_stvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_19[1 : 0] = CsrPlugin_stvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_191 = 32'h0;
-    if(execute_CsrPlugin_csr_321)begin
-      _zz_191[31 : 0] = CsrPlugin_sepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_321) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_sepc;
     end
   end
 
-  always @ (*) begin
-    _zz_192 = 32'h0;
-    if(execute_CsrPlugin_csr_320)begin
-      _zz_192[31 : 0] = CsrPlugin_sscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_320) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_193 = 32'h0;
-    if(execute_CsrPlugin_csr_322)begin
-      _zz_193[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_193[3 : 0] = CsrPlugin_scause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_322) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_194 = 32'h0;
-    if(execute_CsrPlugin_csr_323)begin
-      _zz_194[31 : 0] = CsrPlugin_stval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_323) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = CsrPlugin_stval;
     end
   end
 
-  always @ (*) begin
-    _zz_195 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_195[31 : 0] = _zz_169;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_196 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_196[31 : 0] = _zz_170;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  always @ (*) begin
-    _zz_197 = 32'h0;
-    if(execute_CsrPlugin_csr_2496)begin
-      _zz_197[31 : 0] = _zz_171;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h0;
+    if(execute_CsrPlugin_csr_2496) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_26[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_2;
     end
   end
 
-  always @ (*) begin
-    _zz_198 = 32'h0;
-    if(execute_CsrPlugin_csr_3520)begin
-      _zz_198[31 : 0] = _zz_172;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_27 = 32'h0;
+    if(execute_CsrPlugin_csr_3520) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_27[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_3;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_175 | _zz_176) | (_zz_177 | _zz_178)) | ((_zz_179 | _zz_180) | (_zz_181 | _zz_716))) | (((_zz_182 | _zz_183) | (_zz_184 | _zz_185)) | ((_zz_186 | _zz_187) | (_zz_188 | _zz_189)))) | ((((_zz_190 | _zz_191) | (_zz_192 | _zz_193)) | ((_zz_194 | _zz_195) | (_zz_196 | _zz_197))) | _zz_198));
-  assign iBusWishbone_ADR = {_zz_477,_zz_199};
-  assign iBusWishbone_CTI = ((_zz_199 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7)) | ((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_28))) | (((_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12) | (_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14)) | ((_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16) | (_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20) | (_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22)) | ((_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24) | (_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | _zz_CsrPlugin_csrMapping_readDataInit_27));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_305)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_305)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_200;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_206 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_202 = dBus_cmd_valid;
-  assign _zz_204 = dBus_cmd_payload_wr;
-  assign _zz_205 = (_zz_201 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_203 && (_zz_204 || _zz_205));
-  assign dBusWishbone_ADR = ((_zz_206 ? {{dBus_cmd_payload_address[31 : 5],_zz_201},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_206 ? (_zz_205 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_204 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_204;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_203 = (_zz_202 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_202;
-  assign dBusWishbone_STB = _zz_202;
-  assign dBus_rsp_valid = _zz_207;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_68 <= 1'b0;
-      _zz_70 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_83;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_84;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
@@ -6068,9 +6389,9 @@ module VexRiscv (
       MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
       MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
       MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
-      _zz_118 <= 1'b1;
-      _zz_130 <= 1'b0;
-      _zz_155 <= 2'b11;
+      _zz_7 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
+      _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -6113,205 +6434,205 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_169 <= 32'h0;
-      _zz_171 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit_2 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_174 <= 3'b000;
+      switch_Fetcher_l362 <= 3'b000;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
-      _zz_199 <= 3'b000;
-      _zz_200 <= 1'b0;
-      _zz_201 <= 3'b000;
-      _zz_207 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_68 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_66)begin
-        _zz_68 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_70 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_70 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_306)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
       MmuPlugin_ports_0_entryToReplace_value <= MmuPlugin_ports_0_entryToReplace_valueNext;
-      if(contextSwitching)begin
-        if(MmuPlugin_ports_0_cache_0_exception)begin
+      if(contextSwitching) begin
+        if(MmuPlugin_ports_0_cache_0_exception) begin
           MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_1_exception)begin
+        if(MmuPlugin_ports_0_cache_1_exception) begin
           MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_2_exception)begin
+        if(MmuPlugin_ports_0_cache_2_exception) begin
           MmuPlugin_ports_0_cache_2_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_3_exception)begin
+        if(MmuPlugin_ports_0_cache_3_exception) begin
           MmuPlugin_ports_0_cache_3_valid <= 1'b0;
         end
       end
       MmuPlugin_ports_1_entryToReplace_value <= MmuPlugin_ports_1_entryToReplace_valueNext;
-      if(contextSwitching)begin
-        if(MmuPlugin_ports_1_cache_0_exception)begin
+      if(contextSwitching) begin
+        if(MmuPlugin_ports_1_cache_0_exception) begin
           MmuPlugin_ports_1_cache_0_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_1_exception)begin
+        if(MmuPlugin_ports_1_cache_1_exception) begin
           MmuPlugin_ports_1_cache_1_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_2_exception)begin
+        if(MmuPlugin_ports_1_cache_2_exception) begin
           MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_3_exception)begin
+        if(MmuPlugin_ports_1_cache_3_exception) begin
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
       end
       MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
       case(MmuPlugin_shared_state_1)
         `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-          if(_zz_307)begin
+          if(when_MmuPlugin_l217) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
-          if(MmuPlugin_dBusAccess_cmd_ready)begin
+          if(MmuPlugin_dBusAccess_cmd_ready) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
-          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+          if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
-            if((MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception))begin
+            if(when_MmuPlugin_l243) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
             end
-            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
             end
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
-          if(MmuPlugin_dBusAccess_cmd_ready)begin
+          if(MmuPlugin_dBusAccess_cmd_ready) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
           end
         end
         default : begin
-          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+          if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             end
           end
         end
       endcase
-      if(_zz_289)begin
-        if(_zz_290)begin
-          if(_zz_308)begin
+      if(when_MmuPlugin_l272) begin
+        if(when_MmuPlugin_l274) begin
+          if(when_MmuPlugin_l280) begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(_zz_309)begin
+          if(when_MmuPlugin_l280_1) begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(_zz_310)begin
+          if(when_MmuPlugin_l280_2) begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(_zz_311)begin
+          if(when_MmuPlugin_l280_3) begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(_zz_291)begin
-          if(_zz_312)begin
+        if(when_MmuPlugin_l274_1) begin
+          if(when_MmuPlugin_l280_4) begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(_zz_313)begin
+          if(when_MmuPlugin_l280_5) begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(_zz_314)begin
+          if(when_MmuPlugin_l280_6) begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(_zz_315)begin
+          if(when_MmuPlugin_l280_7) begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
       end
-      if((writeBack_arbitration_isValid && writeBack_IS_SFENCE_VMA))begin
+      if(when_MmuPlugin_l304) begin
         MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6321,83 +6642,83 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_118 <= 1'b0;
-      _zz_130 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_7 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_316)begin
-        if(_zz_317)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_318)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_319)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(_zz_320)begin
-        if(_zz_321)begin
+      if(when_CsrPlugin_l946_1) begin
+        if(when_CsrPlugin_l952_3) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_322)begin
+        if(when_CsrPlugin_l952_4) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_323)begin
+        if(when_CsrPlugin_l952_5) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_324)begin
+        if(when_CsrPlugin_l952_6) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_325)begin
+        if(when_CsrPlugin_l952_7) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_326)begin
+        if(when_CsrPlugin_l952_8) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_282)begin
-        _zz_155 <= CsrPlugin_targetPrivilege;
+      if(when_CsrPlugin_l1019) begin
+        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b01 : begin
             CsrPlugin_sstatus_SIE <= 1'b0;
@@ -6413,101 +6734,105 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_283)begin
-        case(_zz_285)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_155 <= CsrPlugin_mstatus_MPP;
+            _zz_CsrPlugin_privilege <= CsrPlugin_mstatus_MPP;
           end
           2'b01 : begin
             CsrPlugin_sstatus_SPP <= 1'b0;
             CsrPlugin_sstatus_SIE <= CsrPlugin_sstatus_SPIE;
             CsrPlugin_sstatus_SPIE <= 1'b1;
-            _zz_155 <= {1'b0,CsrPlugin_sstatus_SPP};
+            _zz_CsrPlugin_privilege <= {1'b0,CsrPlugin_sstatus_SPP};
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_161,{_zz_160,{_zz_159,{_zz_158,{_zz_157,_zz_156}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_5,{_zz_when_CsrPlugin_l952_4,{_zz_when_CsrPlugin_l952_3,{_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! memory_arbitration_isStuck))begin
+      if(when_Pipeline_l124_58) begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Pipeline_l124_59) begin
         memory_to_writeBack_IS_DBUS_SHARING <= memory_IS_DBUS_SHARING;
       end
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_174)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_174 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_174 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_174 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_174 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_174 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(MmuPlugin_dBusAccess_rsp_valid)begin
+      if(MmuPlugin_dBusAccess_rsp_valid) begin
         memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_432[0];
-          MmuPlugin_status_sum <= _zz_433[0];
-          MmuPlugin_status_mprv <= _zz_434[0];
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_435[0];
-          CsrPlugin_mstatus_MIE <= _zz_436[0];
-          CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_437[0];
-          CsrPlugin_sstatus_SIE <= _zz_438[0];
+      if(MmuPlugin_dBusAccess_rsp_valid) begin
+        memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
+      end
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_status_mxr <= CsrPlugin_csrMapping_writeDataSignal[19];
+          MmuPlugin_status_sum <= CsrPlugin_csrMapping_writeDataSignal[18];
+          MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          CsrPlugin_sstatus_SPP <= CsrPlugin_csrMapping_writeDataSignal[8 : 8];
+          CsrPlugin_sstatus_SPIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sstatus_SIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_256)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_439[0];
-          MmuPlugin_status_sum <= _zz_440[0];
-          MmuPlugin_status_mprv <= _zz_441[0];
-          CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_442[0];
-          CsrPlugin_sstatus_SIE <= _zz_443[0];
+      if(execute_CsrPlugin_csr_256) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_status_mxr <= CsrPlugin_csrMapping_writeDataSignal[19];
+          MmuPlugin_status_sum <= CsrPlugin_csrMapping_writeDataSignal[18];
+          MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
+          CsrPlugin_sstatus_SPP <= CsrPlugin_csrMapping_writeDataSignal[8 : 8];
+          CsrPlugin_sstatus_SPIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sstatus_SIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_384)begin
-        if(execute_CsrPlugin_writeInstruction)begin
+      if(execute_CsrPlugin_csr_384) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_satp_mode <= CsrPlugin_csrMapping_writeDataSignal[31];
           MmuPlugin_ports_0_cache_0_valid <= 1'b0;
           MmuPlugin_ports_0_cache_1_valid <= 1'b0;
           MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -6517,122 +6842,119 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_valid <= 1'b0;
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_satp_mode <= _zz_444[0];
+      end
+      if(execute_CsrPlugin_csr_836) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sip_STIP <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sip_SSIP <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_sip_SEIP_SOFT <= CsrPlugin_csrMapping_writeDataSignal[9];
         end
       end
-      if(execute_CsrPlugin_csr_836)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_446[0];
-          CsrPlugin_sip_SSIP <= _zz_447[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_448[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          CsrPlugin_sie_SEIE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_sie_STIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sie_SSIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_449[0];
-          CsrPlugin_mie_MTIE <= _zz_450[0];
-          CsrPlugin_mie_MSIE <= _zz_451[0];
-          CsrPlugin_sie_SEIE <= _zz_452[0];
-          CsrPlugin_sie_STIE <= _zz_453[0];
-          CsrPlugin_sie_SSIE <= _zz_454[0];
+      if(execute_CsrPlugin_csr_770) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_medeleg_IAM <= CsrPlugin_csrMapping_writeDataSignal[0];
+          CsrPlugin_medeleg_IAF <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_medeleg_II <= CsrPlugin_csrMapping_writeDataSignal[2];
+          CsrPlugin_medeleg_LAM <= CsrPlugin_csrMapping_writeDataSignal[4];
+          CsrPlugin_medeleg_LAF <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_medeleg_SAM <= CsrPlugin_csrMapping_writeDataSignal[6];
+          CsrPlugin_medeleg_SAF <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_medeleg_EU <= CsrPlugin_csrMapping_writeDataSignal[8];
+          CsrPlugin_medeleg_ES <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_medeleg_IPF <= CsrPlugin_csrMapping_writeDataSignal[12];
+          CsrPlugin_medeleg_LPF <= CsrPlugin_csrMapping_writeDataSignal[13];
+          CsrPlugin_medeleg_SPF <= CsrPlugin_csrMapping_writeDataSignal[15];
         end
       end
-      if(execute_CsrPlugin_csr_770)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_medeleg_IAM <= _zz_455[0];
-          CsrPlugin_medeleg_IAF <= _zz_456[0];
-          CsrPlugin_medeleg_II <= _zz_457[0];
-          CsrPlugin_medeleg_LAM <= _zz_458[0];
-          CsrPlugin_medeleg_LAF <= _zz_459[0];
-          CsrPlugin_medeleg_SAM <= _zz_460[0];
-          CsrPlugin_medeleg_SAF <= _zz_461[0];
-          CsrPlugin_medeleg_EU <= _zz_462[0];
-          CsrPlugin_medeleg_ES <= _zz_463[0];
-          CsrPlugin_medeleg_IPF <= _zz_464[0];
-          CsrPlugin_medeleg_LPF <= _zz_465[0];
-          CsrPlugin_medeleg_SPF <= _zz_466[0];
+      if(execute_CsrPlugin_csr_771) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mideleg_SE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_mideleg_ST <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_mideleg_SS <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_771)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mideleg_SE <= _zz_467[0];
-          CsrPlugin_mideleg_ST <= _zz_468[0];
-          CsrPlugin_mideleg_SS <= _zz_469[0];
+      if(execute_CsrPlugin_csr_324) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sip_STIP <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sip_SSIP <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_sip_SEIP_SOFT <= CsrPlugin_csrMapping_writeDataSignal[9];
         end
       end
-      if(execute_CsrPlugin_csr_324)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_470[0];
-          CsrPlugin_sip_SSIP <= _zz_471[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_472[0];
+      if(execute_CsrPlugin_csr_260) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sie_SEIE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_sie_STIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sie_SSIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_260)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sie_SEIE <= _zz_473[0];
-          CsrPlugin_sie_STIE <= _zz_474[0];
-          CsrPlugin_sie_SSIE <= _zz_475[0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_169 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_2496) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_2496)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_171 <= execute_CsrPlugin_writeData[31 : 0];
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      if(_zz_305)begin
-        if(iBusWishbone_ACK)begin
-          _zz_199 <= (_zz_199 + 3'b001);
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_200 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_202 && _zz_203))begin
-        _zz_201 <= (_zz_201 + 3'b001);
-        if(_zz_205)begin
-          _zz_201 <= 3'b000;
-        end
-      end
-      _zz_207 <= ((_zz_202 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_71 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_306)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
     MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
     MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
-    if((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)))begin
+    if(when_MmuPlugin_l205) begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -6647,10 +6969,10 @@ module VexRiscv (
     end
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-        if(_zz_307)begin
+        if(when_MmuPlugin_l217) begin
           MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
-          MmuPlugin_shared_vpn_1 <= _zz_103[31 : 22];
-          MmuPlugin_shared_vpn_0 <= _zz_103[21 : 12];
+          MmuPlugin_shared_vpn_1 <= _zz_MmuPlugin_shared_vpn_0[31 : 22];
+          MmuPlugin_shared_vpn_0 <= _zz_MmuPlugin_shared_vpn_0[21 : 12];
         end
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -6662,9 +6984,9 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(_zz_289)begin
-      if(_zz_290)begin
-        if(_zz_308)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274) begin
+        if(when_MmuPlugin_l280) begin
           MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6676,7 +6998,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_309)begin
+        if(when_MmuPlugin_l280_1) begin
           MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6688,7 +7010,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_310)begin
+        if(when_MmuPlugin_l280_2) begin
           MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6700,7 +7022,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_311)begin
+        if(when_MmuPlugin_l280_3) begin
           MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6713,8 +7035,8 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
-      if(_zz_291)begin
-        if(_zz_312)begin
+      if(when_MmuPlugin_l274_1) begin
+        if(when_MmuPlugin_l280_4) begin
           MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6726,7 +7048,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_313)begin
+        if(when_MmuPlugin_l280_5) begin
           MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6738,7 +7060,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_314)begin
+        if(when_MmuPlugin_l280_6) begin
           MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6750,7 +7072,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_315)begin
+        if(when_MmuPlugin_l280_7) begin
           MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6764,79 +7086,79 @@ module VexRiscv (
         end
       end
     end
-    _zz_131 <= _zz_40[11 : 7];
-    _zz_132 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_sip_SEIP_INPUT <= externalInterruptS;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_278)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_163 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_163 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_316)begin
-      if(_zz_317)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_318)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_319)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(_zz_320)begin
-      if(_zz_321)begin
+    if(when_CsrPlugin_l946_1) begin
+      if(when_CsrPlugin_l952_3) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_322)begin
+      if(when_CsrPlugin_l952_4) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_323)begin
+      if(when_CsrPlugin_l952_5) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_324)begin
+      if(when_CsrPlugin_l952_6) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_325)begin
+      if(when_CsrPlugin_l952_7) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_326)begin
+      if(when_CsrPlugin_l952_8) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_282)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b01 : begin
           CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_sepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -6844,7 +7166,7 @@ module VexRiscv (
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -6852,424 +7174,438 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_273)begin
-      if(_zz_302)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_423[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_303)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_167 ? (~ _zz_168) : _zz_168) + _zz_429);
-      memory_DivPlugin_rs2 <= ((_zz_166 ? (~ execute_RS2) : execute_RS2) + _zz_431);
-      memory_DivPlugin_div_needRevert <= ((_zz_167 ^ (_zz_166 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_55;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_execute_to_memory_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_28) begin
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_30) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
+    end
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_34) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_35) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_36) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_39) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_40) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_41) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_56) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_57) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_60) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_61) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_63) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_64) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_65) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_66) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_67) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_68) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_69) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_70) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_384 <= (decode_INSTRUCTION[31 : 20] == 12'h180);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_770 <= (decode_INSTRUCTION[31 : 20] == 12'h302);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_771 <= (decode_INSTRUCTION[31 : 20] == 12'h303);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_324 <= (decode_INSTRUCTION[31 : 20] == 12'h144);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_260 <= (decode_INSTRUCTION[31 : 20] == 12'h104);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_261 <= (decode_INSTRUCTION[31 : 20] == 12'h105);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_321 <= (decode_INSTRUCTION[31 : 20] == 12'h141);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_320 <= (decode_INSTRUCTION[31 : 20] == 12'h140);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_322 <= (decode_INSTRUCTION[31 : 20] == 12'h142);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_323 <= (decode_INSTRUCTION[31 : 20] == 12'h143);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_24) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_25) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_26) begin
       execute_CsrPlugin_csr_2496 <= (decode_INSTRUCTION[31 : 20] == 12'h9c0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_27) begin
       execute_CsrPlugin_csr_3520 <= (decode_INSTRUCTION[31 : 20] == 12'hdc0);
     end
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        MmuPlugin_satp_asid <= execute_CsrPlugin_writeData[30 : 22];
-        MmuPlugin_satp_ppn <= execute_CsrPlugin_writeData[19 : 0];
+    if(execute_CsrPlugin_csr_384) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        MmuPlugin_satp_asid <= CsrPlugin_csrMapping_writeDataSignal[30 : 22];
+        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[19 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_445[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_261)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_stvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_stvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_261) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_stvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_stvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_321)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_sepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_321) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_sepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_320)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_sscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_320) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_sscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_322)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_scause_interrupt <= _zz_476[0];
-        CsrPlugin_scause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_322) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_scause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_scause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_323)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_stval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_323) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_stval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_173 <= debug_bus_cmd_payload_address[2];
-    if(_zz_280)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_304)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -7277,14 +7613,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_280)begin
-        if(_zz_281)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_284)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -7297,9 +7633,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_isLrsc,
   input               io_cpu_execute_args_isAmo,
@@ -7333,6 +7668,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -7348,9 +7684,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -7358,7 +7695,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -7367,38 +7704,23 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire                _zz_19;
-  wire                _zz_20;
-  wire                _zz_21;
-  wire                _zz_22;
-  wire       [2:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [0:0]    _zz_25;
-  wire       [9:0]    _zz_26;
-  wire       [9:0]    _zz_27;
-  wire       [31:0]   _zz_28;
-  wire       [31:0]   _zz_29;
-  wire       [31:0]   _zz_30;
-  wire       [31:0]   _zz_31;
-  wire       [1:0]    _zz_32;
-  wire       [31:0]   _zz_33;
-  wire       [1:0]    _zz_34;
-  wire       [1:0]    _zz_35;
-  wire       [0:0]    _zz_36;
-  wire       [0:0]    _zz_37;
-  wire       [0:0]    _zz_38;
-  wire       [2:0]    _zz_39;
-  wire       [1:0]    _zz_40;
-  wire       [21:0]   _zz_41;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [31:0]   _zz_stageB_amo_addSub;
+  wire       [31:0]   _zz_stageB_amo_addSub_1;
+  wire       [31:0]   _zz_stageB_amo_addSub_2;
+  wire       [31:0]   _zz_stageB_amo_addSub_3;
+  wire       [31:0]   _zz_stageB_amo_addSub_4;
+  wire       [1:0]    _zz_stageB_amo_addSub_5;
+  wire       [1:0]    _zz_stageB_amo_addSub_6;
+  wire       [1:0]    _zz_stageB_amo_addSub_7;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -7423,38 +7745,45 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
   reg                 stageA_request_isAmo;
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
   reg                 stageB_request_isAmo;
@@ -7462,6 +7791,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -7479,25 +7809,36 @@ module DataCache (
   reg        [31:0]   stageB_mmuRsp_ways_2_physical;
   reg                 stageB_mmuRsp_ways_3_sel;
   reg        [31:0]   stageB_mmuRsp_ways_3_physical;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   reg                 stageB_lrSc_reserved;
+  wire                when_DataCache_l866;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -7506,14 +7847,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
+  wire       [2:0]    switch_Misc_l199;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l984;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l997;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1010;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -7525,73 +7878,62 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_42;
-  reg [7:0] _zz_43;
-  reg [7:0] _zz_44;
-  reg [7:0] _zz_45;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign _zz_16 = (! stageB_amo_internal_resultRegValid);
-  assign _zz_17 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_18 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_19 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_20 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign _zz_21 = (! stageB_flusher_hold);
-  assign _zz_22 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_23 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
-  assign _zz_24 = _zz_4[0 : 0];
-  assign _zz_25 = _zz_4[1 : 1];
-  assign _zz_26 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_27 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_28 = ($signed(_zz_29) + $signed(_zz_33));
-  assign _zz_29 = ($signed(_zz_30) + $signed(_zz_31));
-  assign _zz_30 = stageB_request_data;
-  assign _zz_31 = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_32 = (stageB_amo_compare ? _zz_34 : _zz_35);
-  assign _zz_33 = {{30{_zz_32[1]}}, _zz_32};
-  assign _zz_34 = 2'b01;
-  assign _zz_35 = 2'b00;
-  assign _zz_36 = 1'b1;
-  assign _zz_37 = (! stageB_lrSc_reserved);
-  assign _zz_38 = loader_counter_willIncrement;
-  assign _zz_39 = {2'd0, _zz_38};
-  assign _zz_40 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_41 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
+  assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
+  assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
+  assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
+  assign _zz_stageB_amo_addSub_6 = 2'b01;
+  assign _zz_stageB_amo_addSub_7 = 2'b00;
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_41;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_45, _zz_44, _zz_43, _zz_42};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_42 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_43 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_44 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_45 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -7606,327 +7948,348 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_24[0];
-  assign ways_0_tagsReadRsp_error = _zz_25[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_36[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_26)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_27)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(_zz_19)begin
+          if(when_DataCache_l984) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l866 = ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_request_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
+  always @(*) begin
+    stageB_requestDataBypass = io_cpu_writeBack_storeData;
+    if(stageB_request_isAmo) begin
+      stageB_requestDataBypass[31 : 0] = stageB_amo_resultReg;
     end
   end
 
   assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
   assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
-  assign stageB_amo_addSub = _zz_28;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
+  assign stageB_amo_addSub = _zz_stageB_amo_addSub;
+  assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_23)
+  assign switch_Misc_l199 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  always @(*) begin
+    case(switch_Misc_l199)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
       3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] ^ stageB_dataMux[31 : 0]);
       end
       3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] | stageB_dataMux[31 : 0]);
       end
       3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] & stageB_dataMux[31 : 0]);
       end
       default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
+        stageB_amo_result = (stageB_amo_selectRf ? io_cpu_writeBack_storeData[31 : 0] : stageB_dataMux[31 : 0]);
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7934,103 +8297,87 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(_zz_20)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(_zz_19)begin
+          if(when_DataCache_l984) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 io_mem_cmd_valid = 1'b0;
               end
             end
-            if(_zz_20)begin
+            if(when_DataCache_l1005) begin
               io_mem_cmd_valid = 1'b0;
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               io_mem_cmd_valid = 1'b0;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -8038,12 +8385,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -8054,23 +8401,44 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l984 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l997 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1010 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_37};
-    end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -8078,26 +8446,29 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_39);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
       stageA_request_isAmo <= io_cpu_execute_args_isAmo;
@@ -8105,18 +8476,17 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
       stageB_request_isAmo <= stageA_request_isAmo;
@@ -8124,7 +8494,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -8143,48 +8513,39 @@ module DataCache (
       stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
       stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_21)begin
-        if(_zz_22)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
     stageB_amo_resultReg <= stageB_amo_result;
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -8193,27 +8554,29 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_21)begin
-          if(! _zz_22) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
-      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+      if(when_DataCache_l866) begin
         stageB_lrSc_reserved <= (! stageB_request_wr);
       end
-      if(_zz_13)begin
+      if(when_DataCache_l1051) begin
         stageB_lrSc_reserved <= stageB_lrSc_reserved;
       end
       `ifndef SYNTHESIS
@@ -8221,28 +8584,27 @@ module DataCache (
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_18)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_40[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -8297,18 +8659,14 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
+  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [21:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [21:0]   _zz_17;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -8317,8 +8675,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -8332,22 +8695,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -8365,82 +8731,86 @@ module InstructionCache (
   reg        [31:0]   decodeStage_mmuRsp_ways_2_physical;
   reg                 decodeStage_mmuRsp_ways_3_sel;
   reg        [31:0]   decodeStage_mmuRsp_ways_3_physical;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
+  wire                when_Fetcher_l398;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_13 = (! lineLoader_flushCounter[7]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -8456,30 +8826,36 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -8487,51 +8863,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_14)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -8550,14 +8926,14 @@ module InstructionCache (
       decodeStage_mmuRsp_ways_3_sel <= io_cpu_fetch_mmuRsp_ways_3_sel;
       decodeStage_mmuRsp_ways_3_physical <= io_cpu_fetch_mmuRsp_ways_3_physical;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
+    if(when_Fetcher_l398) begin
+      io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxNoDspFmax.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxNoDspFmax.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -81,66 +81,42 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_192;
-  wire                _zz_193;
-  wire                _zz_194;
-  wire                _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  reg                 _zz_200;
-  reg                 _zz_201;
-  reg        [31:0]   _zz_202;
-  reg                 _zz_203;
-  reg        [31:0]   _zz_204;
-  reg        [1:0]    _zz_205;
-  reg                 _zz_206;
-  reg                 _zz_207;
-  wire                _zz_208;
-  wire       [2:0]    _zz_209;
-  reg                 _zz_210;
-  wire       [31:0]   _zz_211;
-  reg                 _zz_212;
-  reg                 _zz_213;
-  wire                _zz_214;
-  wire       [31:0]   _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire       [3:0]    _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
-  reg        [31:0]   _zz_227;
-  reg        [31:0]   _zz_228;
-  reg        [31:0]   _zz_229;
-  reg                 _zz_230;
-  reg                 _zz_231;
-  reg                 _zz_232;
-  reg        [9:0]    _zz_233;
-  reg        [9:0]    _zz_234;
-  reg        [9:0]    _zz_235;
-  reg        [9:0]    _zz_236;
-  reg                 _zz_237;
-  reg                 _zz_238;
-  reg                 _zz_239;
-  reg                 _zz_240;
-  reg                 _zz_241;
-  reg                 _zz_242;
-  reg                 _zz_243;
-  reg        [9:0]    _zz_244;
-  reg        [9:0]    _zz_245;
-  reg        [9:0]    _zz_246;
-  reg        [9:0]    _zz_247;
-  reg                 _zz_248;
-  reg                 _zz_249;
-  reg                 _zz_250;
-  reg                 _zz_251;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  reg                 dataCache_1_io_cpu_execute_isValid;
+  reg        [31:0]   dataCache_1_io_cpu_execute_address;
+  reg                 dataCache_1_io_cpu_execute_args_wr;
+  reg        [1:0]    dataCache_1_io_cpu_execute_args_size;
+  reg                 dataCache_1_io_cpu_execute_args_isLrsc;
+  wire                dataCache_1_io_cpu_execute_args_amoCtrl_swap;
+  wire       [2:0]    dataCache_1_io_cpu_execute_args_amoCtrl_alu;
+  reg                 dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -163,6 +139,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -171,417 +148,323 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_252;
-  wire                _zz_253;
-  wire                _zz_254;
-  wire                _zz_255;
-  wire                _zz_256;
-  wire                _zz_257;
-  wire                _zz_258;
-  wire                _zz_259;
-  wire                _zz_260;
-  wire                _zz_261;
-  wire                _zz_262;
-  wire                _zz_263;
-  wire                _zz_264;
-  wire                _zz_265;
-  wire                _zz_266;
-  wire                _zz_267;
-  wire       [1:0]    _zz_268;
-  wire                _zz_269;
-  wire                _zz_270;
-  wire                _zz_271;
-  wire                _zz_272;
-  wire                _zz_273;
-  wire                _zz_274;
-  wire                _zz_275;
-  wire                _zz_276;
-  wire                _zz_277;
-  wire                _zz_278;
-  wire                _zz_279;
-  wire                _zz_280;
-  wire                _zz_281;
-  wire                _zz_282;
-  wire                _zz_283;
-  wire                _zz_284;
-  wire                _zz_285;
-  wire                _zz_286;
-  wire                _zz_287;
-  wire                _zz_288;
-  wire                _zz_289;
-  wire                _zz_290;
-  wire                _zz_291;
-  wire                _zz_292;
-  wire                _zz_293;
-  wire                _zz_294;
-  wire                _zz_295;
-  wire                _zz_296;
-  wire                _zz_297;
-  wire                _zz_298;
-  wire                _zz_299;
-  wire                _zz_300;
-  wire                _zz_301;
-  wire                _zz_302;
-  wire                _zz_303;
-  wire                _zz_304;
-  wire                _zz_305;
-  wire                _zz_306;
-  wire                _zz_307;
-  wire       [1:0]    _zz_308;
-  wire                _zz_309;
-  wire       [32:0]   _zz_310;
-  wire       [31:0]   _zz_311;
-  wire       [32:0]   _zz_312;
-  wire       [0:0]    _zz_313;
-  wire       [0:0]    _zz_314;
-  wire       [0:0]    _zz_315;
-  wire       [0:0]    _zz_316;
-  wire       [0:0]    _zz_317;
-  wire       [0:0]    _zz_318;
-  wire       [0:0]    _zz_319;
-  wire       [0:0]    _zz_320;
-  wire       [0:0]    _zz_321;
-  wire       [0:0]    _zz_322;
-  wire       [0:0]    _zz_323;
-  wire       [0:0]    _zz_324;
-  wire       [0:0]    _zz_325;
-  wire       [0:0]    _zz_326;
-  wire       [0:0]    _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [0:0]    _zz_329;
-  wire       [0:0]    _zz_330;
-  wire       [0:0]    _zz_331;
-  wire       [0:0]    _zz_332;
-  wire       [3:0]    _zz_333;
-  wire       [2:0]    _zz_334;
-  wire       [31:0]   _zz_335;
-  wire       [2:0]    _zz_336;
-  wire       [2:0]    _zz_337;
-  wire       [0:0]    _zz_338;
-  wire       [1:0]    _zz_339;
-  wire       [0:0]    _zz_340;
-  wire       [1:0]    _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [0:0]    _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [0:0]    _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [0:0]    _zz_348;
-  wire       [0:0]    _zz_349;
-  wire       [1:0]    _zz_350;
-  wire       [0:0]    _zz_351;
-  wire       [2:0]    _zz_352;
-  wire       [4:0]    _zz_353;
-  wire       [11:0]   _zz_354;
-  wire       [11:0]   _zz_355;
-  wire       [31:0]   _zz_356;
-  wire       [31:0]   _zz_357;
-  wire       [31:0]   _zz_358;
-  wire       [31:0]   _zz_359;
-  wire       [31:0]   _zz_360;
-  wire       [31:0]   _zz_361;
-  wire       [31:0]   _zz_362;
-  wire       [19:0]   _zz_363;
-  wire       [11:0]   _zz_364;
-  wire       [11:0]   _zz_365;
-  wire       [1:0]    _zz_366;
-  wire       [1:0]    _zz_367;
-  wire       [0:0]    _zz_368;
-  wire       [5:0]    _zz_369;
-  wire       [33:0]   _zz_370;
-  wire       [32:0]   _zz_371;
-  wire       [33:0]   _zz_372;
-  wire       [32:0]   _zz_373;
-  wire       [33:0]   _zz_374;
-  wire       [32:0]   _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [5:0]    _zz_377;
-  wire       [32:0]   _zz_378;
-  wire       [31:0]   _zz_379;
-  wire       [31:0]   _zz_380;
-  wire       [32:0]   _zz_381;
-  wire       [32:0]   _zz_382;
-  wire       [32:0]   _zz_383;
-  wire       [32:0]   _zz_384;
-  wire       [0:0]    _zz_385;
-  wire       [32:0]   _zz_386;
-  wire       [0:0]    _zz_387;
-  wire       [32:0]   _zz_388;
-  wire       [0:0]    _zz_389;
-  wire       [31:0]   _zz_390;
-  wire       [0:0]    _zz_391;
-  wire       [0:0]    _zz_392;
-  wire       [0:0]    _zz_393;
-  wire       [0:0]    _zz_394;
-  wire       [0:0]    _zz_395;
-  wire       [0:0]    _zz_396;
-  wire       [0:0]    _zz_397;
-  wire       [0:0]    _zz_398;
-  wire       [0:0]    _zz_399;
-  wire       [0:0]    _zz_400;
-  wire       [0:0]    _zz_401;
-  wire       [0:0]    _zz_402;
-  wire       [0:0]    _zz_403;
-  wire       [0:0]    _zz_404;
-  wire       [0:0]    _zz_405;
-  wire       [0:0]    _zz_406;
-  wire       [0:0]    _zz_407;
-  wire       [0:0]    _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [0:0]    _zz_410;
-  wire       [0:0]    _zz_411;
-  wire       [0:0]    _zz_412;
-  wire       [0:0]    _zz_413;
-  wire       [0:0]    _zz_414;
-  wire       [0:0]    _zz_415;
-  wire       [0:0]    _zz_416;
-  wire       [0:0]    _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [0:0]    _zz_419;
-  wire       [0:0]    _zz_420;
-  wire       [0:0]    _zz_421;
-  wire       [0:0]    _zz_422;
-  wire       [0:0]    _zz_423;
-  wire       [0:0]    _zz_424;
-  wire       [0:0]    _zz_425;
-  wire       [0:0]    _zz_426;
-  wire       [0:0]    _zz_427;
-  wire       [0:0]    _zz_428;
-  wire       [0:0]    _zz_429;
-  wire       [0:0]    _zz_430;
-  wire       [0:0]    _zz_431;
-  wire       [0:0]    _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [0:0]    _zz_434;
-  wire       [0:0]    _zz_435;
-  wire       [26:0]   _zz_436;
-  wire                _zz_437;
-  wire                _zz_438;
-  wire       [1:0]    _zz_439;
-  wire       [31:0]   _zz_440;
-  wire       [31:0]   _zz_441;
-  wire       [31:0]   _zz_442;
-  wire                _zz_443;
-  wire       [0:0]    _zz_444;
-  wire       [17:0]   _zz_445;
-  wire       [31:0]   _zz_446;
-  wire       [31:0]   _zz_447;
-  wire       [31:0]   _zz_448;
-  wire                _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [11:0]   _zz_451;
-  wire       [31:0]   _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
-  wire                _zz_455;
-  wire       [0:0]    _zz_456;
-  wire       [5:0]    _zz_457;
-  wire       [31:0]   _zz_458;
-  wire       [31:0]   _zz_459;
-  wire       [31:0]   _zz_460;
-  wire                _zz_461;
-  wire                _zz_462;
-  wire       [31:0]   _zz_463;
-  wire       [0:0]    _zz_464;
-  wire       [1:0]    _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [0:0]    _zz_467;
-  wire                _zz_468;
-  wire       [0:0]    _zz_469;
-  wire       [28:0]   _zz_470;
-  wire       [31:0]   _zz_471;
-  wire       [31:0]   _zz_472;
-  wire       [31:0]   _zz_473;
-  wire       [0:0]    _zz_474;
-  wire       [0:0]    _zz_475;
-  wire       [1:0]    _zz_476;
-  wire       [1:0]    _zz_477;
-  wire                _zz_478;
-  wire       [0:0]    _zz_479;
-  wire       [24:0]   _zz_480;
-  wire       [31:0]   _zz_481;
-  wire       [31:0]   _zz_482;
-  wire       [31:0]   _zz_483;
-  wire       [31:0]   _zz_484;
-  wire       [31:0]   _zz_485;
-  wire       [31:0]   _zz_486;
-  wire       [0:0]    _zz_487;
-  wire       [0:0]    _zz_488;
-  wire       [2:0]    _zz_489;
-  wire       [2:0]    _zz_490;
-  wire                _zz_491;
-  wire       [0:0]    _zz_492;
-  wire       [21:0]   _zz_493;
-  wire       [31:0]   _zz_494;
-  wire       [31:0]   _zz_495;
-  wire       [31:0]   _zz_496;
-  wire       [31:0]   _zz_497;
-  wire                _zz_498;
-  wire                _zz_499;
-  wire       [31:0]   _zz_500;
-  wire       [31:0]   _zz_501;
-  wire       [1:0]    _zz_502;
-  wire       [1:0]    _zz_503;
-  wire                _zz_504;
-  wire       [0:0]    _zz_505;
-  wire       [18:0]   _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [31:0]   _zz_508;
-  wire       [31:0]   _zz_509;
-  wire       [31:0]   _zz_510;
-  wire       [31:0]   _zz_511;
-  wire       [31:0]   _zz_512;
-  wire                _zz_513;
-  wire       [0:0]    _zz_514;
-  wire       [0:0]    _zz_515;
-  wire                _zz_516;
-  wire       [0:0]    _zz_517;
-  wire       [15:0]   _zz_518;
-  wire       [31:0]   _zz_519;
-  wire       [31:0]   _zz_520;
-  wire                _zz_521;
-  wire       [0:0]    _zz_522;
-  wire       [0:0]    _zz_523;
-  wire       [31:0]   _zz_524;
-  wire       [31:0]   _zz_525;
-  wire                _zz_526;
-  wire       [5:0]    _zz_527;
-  wire       [5:0]    _zz_528;
-  wire                _zz_529;
-  wire       [0:0]    _zz_530;
-  wire       [11:0]   _zz_531;
-  wire       [31:0]   _zz_532;
-  wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire                _zz_536;
-  wire       [0:0]    _zz_537;
-  wire       [2:0]    _zz_538;
-  wire                _zz_539;
-  wire       [0:0]    _zz_540;
-  wire       [0:0]    _zz_541;
-  wire                _zz_542;
-  wire       [4:0]    _zz_543;
-  wire       [4:0]    _zz_544;
-  wire                _zz_545;
-  wire       [0:0]    _zz_546;
-  wire       [8:0]    _zz_547;
-  wire       [31:0]   _zz_548;
-  wire       [31:0]   _zz_549;
-  wire       [31:0]   _zz_550;
-  wire                _zz_551;
-  wire       [0:0]    _zz_552;
-  wire       [0:0]    _zz_553;
-  wire       [31:0]   _zz_554;
-  wire       [31:0]   _zz_555;
-  wire       [31:0]   _zz_556;
-  wire       [31:0]   _zz_557;
-  wire       [31:0]   _zz_558;
-  wire       [31:0]   _zz_559;
-  wire       [0:0]    _zz_560;
-  wire       [2:0]    _zz_561;
-  wire       [0:0]    _zz_562;
-  wire       [5:0]    _zz_563;
-  wire       [1:0]    _zz_564;
-  wire       [1:0]    _zz_565;
-  wire                _zz_566;
-  wire       [0:0]    _zz_567;
-  wire       [6:0]    _zz_568;
-  wire       [31:0]   _zz_569;
-  wire       [31:0]   _zz_570;
-  wire       [31:0]   _zz_571;
-  wire       [31:0]   _zz_572;
-  wire       [31:0]   _zz_573;
-  wire       [31:0]   _zz_574;
-  wire       [31:0]   _zz_575;
-  wire                _zz_576;
-  wire       [0:0]    _zz_577;
-  wire       [0:0]    _zz_578;
-  wire                _zz_579;
-  wire       [0:0]    _zz_580;
-  wire       [3:0]    _zz_581;
-  wire                _zz_582;
-  wire       [0:0]    _zz_583;
-  wire       [0:0]    _zz_584;
-  wire       [0:0]    _zz_585;
-  wire       [0:0]    _zz_586;
-  wire                _zz_587;
-  wire       [0:0]    _zz_588;
-  wire       [4:0]    _zz_589;
-  wire       [31:0]   _zz_590;
-  wire       [31:0]   _zz_591;
-  wire       [31:0]   _zz_592;
-  wire       [31:0]   _zz_593;
-  wire       [31:0]   _zz_594;
-  wire       [31:0]   _zz_595;
-  wire       [31:0]   _zz_596;
-  wire       [31:0]   _zz_597;
-  wire                _zz_598;
-  wire       [0:0]    _zz_599;
-  wire       [1:0]    _zz_600;
-  wire       [31:0]   _zz_601;
-  wire       [31:0]   _zz_602;
-  wire       [31:0]   _zz_603;
-  wire       [31:0]   _zz_604;
-  wire       [31:0]   _zz_605;
-  wire                _zz_606;
-  wire       [4:0]    _zz_607;
-  wire       [4:0]    _zz_608;
-  wire                _zz_609;
-  wire       [0:0]    _zz_610;
-  wire       [2:0]    _zz_611;
-  wire       [31:0]   _zz_612;
-  wire       [31:0]   _zz_613;
-  wire       [31:0]   _zz_614;
-  wire                _zz_615;
-  wire       [31:0]   _zz_616;
-  wire                _zz_617;
-  wire       [0:0]    _zz_618;
-  wire       [2:0]    _zz_619;
-  wire       [0:0]    _zz_620;
-  wire       [0:0]    _zz_621;
-  wire       [2:0]    _zz_622;
-  wire       [2:0]    _zz_623;
-  wire                _zz_624;
-  wire       [0:0]    _zz_625;
-  wire       [0:0]    _zz_626;
-  wire       [31:0]   _zz_627;
-  wire       [31:0]   _zz_628;
-  wire       [31:0]   _zz_629;
-  wire       [31:0]   _zz_630;
-  wire                _zz_631;
-  wire       [0:0]    _zz_632;
-  wire       [0:0]    _zz_633;
-  wire       [31:0]   _zz_634;
-  wire       [31:0]   _zz_635;
-  wire                _zz_636;
-  wire       [0:0]    _zz_637;
-  wire       [0:0]    _zz_638;
-  wire       [0:0]    _zz_639;
-  wire       [1:0]    _zz_640;
-  wire       [1:0]    _zz_641;
-  wire       [1:0]    _zz_642;
-  wire       [0:0]    _zz_643;
-  wire       [0:0]    _zz_644;
-  wire       [31:0]   _zz_645;
-  wire       [31:0]   _zz_646;
-  wire       [31:0]   _zz_647;
-  wire       [31:0]   _zz_648;
-  wire       [31:0]   _zz_649;
-  wire       [31:0]   _zz_650;
-  wire       [31:0]   _zz_651;
-  wire       [31:0]   _zz_652;
-  wire       [31:0]   _zz_653;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [17:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [11:0]   _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [5:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_18;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_19;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
+  wire                _zz_decode_LEGAL_INSTRUCTION_21;
+  wire                _zz_decode_LEGAL_INSTRUCTION_22;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspRf;
+  wire       [9:0]    _zz_MmuPlugin_ports_0_cacheHitsCalc;
+  wire       [9:0]    _zz_MmuPlugin_ports_0_cacheHitsCalc_1;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_2;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_3;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_4;
+  wire                _zz_MmuPlugin_ports_0_cacheHitsCalc_5;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_valid_4;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_exception;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_superPage;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowRead;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowWrite;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowExecute;
+  reg                 _zz_MmuPlugin_ports_0_cacheLine_allowUser;
+  wire       [1:0]    _zz_MmuPlugin_ports_0_entryToReplace_valueNext;
+  wire       [0:0]    _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1;
+  wire       [9:0]    _zz_MmuPlugin_ports_1_cacheHitsCalc;
+  wire       [9:0]    _zz_MmuPlugin_ports_1_cacheHitsCalc_1;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_2;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_3;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_4;
+  wire                _zz_MmuPlugin_ports_1_cacheHitsCalc_5;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_valid_4;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_exception;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_superPage;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0;
+  reg        [9:0]    _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowRead;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowWrite;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowExecute;
+  reg                 _zz_MmuPlugin_ports_1_cacheLine_allowUser;
+  wire       [1:0]    _zz_MmuPlugin_ports_1_entryToReplace_valueNext;
+  wire       [0:0]    _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1;
+  wire       [1:0]    _zz__zz_MmuPlugin_shared_refills_2;
+  wire       [31:0]   _zz__zz_decode_IS_DIV;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_1;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_2;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_3;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_4;
+  wire                _zz__zz_decode_IS_DIV_5;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_6;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_7;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_8;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_9;
+  wire       [29:0]   _zz__zz_decode_IS_DIV_10;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_11;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_12;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_13;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_14;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_15;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_18;
+  wire                _zz__zz_decode_IS_DIV_19;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_20;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_21;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_23;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_24;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_25;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_26;
+  wire       [25:0]   _zz__zz_decode_IS_DIV_27;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_28;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_29;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_30;
+  wire                _zz__zz_decode_IS_DIV_31;
+  wire                _zz__zz_decode_IS_DIV_32;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_33;
+  wire                _zz__zz_decode_IS_DIV_34;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_35;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_36;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_37;
+  wire       [22:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_39;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_40;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_41;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_42;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_43;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_44;
+  wire                _zz__zz_decode_IS_DIV_45;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_46;
+  wire       [19:0]   _zz__zz_decode_IS_DIV_47;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_48;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_49;
+  wire                _zz__zz_decode_IS_DIV_50;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_51;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_52;
+  wire                _zz__zz_decode_IS_DIV_53;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_54;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_55;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_56;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_57;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_58;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_59;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_60;
+  wire       [16:0]   _zz__zz_decode_IS_DIV_61;
+  wire                _zz__zz_decode_IS_DIV_62;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_63;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_64;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_65;
+  wire                _zz__zz_decode_IS_DIV_66;
+  wire                _zz__zz_decode_IS_DIV_67;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_68;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_69;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_70;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_71;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_72;
+  wire                _zz__zz_decode_IS_DIV_73;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_75;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_76;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_77;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_78;
+  wire                _zz__zz_decode_IS_DIV_79;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_80;
+  wire                _zz__zz_decode_IS_DIV_81;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_82;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_83;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_84;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_85;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_86;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_87;
+  wire                _zz__zz_decode_IS_DIV_88;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_89;
+  wire                _zz__zz_decode_IS_DIV_90;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_91;
+  wire       [12:0]   _zz__zz_decode_IS_DIV_92;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_93;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_94;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_95;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_96;
+  wire                _zz__zz_decode_IS_DIV_97;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_98;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_99;
+  wire                _zz__zz_decode_IS_DIV_100;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_101;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_102;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_103;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_104;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_105;
+  wire                _zz__zz_decode_IS_DIV_106;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_107;
+  wire                _zz__zz_decode_IS_DIV_108;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_109;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_110;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_111;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_112;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_113;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_114;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_115;
+  wire                _zz__zz_decode_IS_DIV_116;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_117;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_118;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_119;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_120;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_121;
+  wire                _zz__zz_decode_IS_DIV_122;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_123;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_124;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_125;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_126;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_127;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_128;
+  wire       [9:0]    _zz__zz_decode_IS_DIV_129;
+  wire                _zz__zz_decode_IS_DIV_130;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_131;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_132;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_133;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_134;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_135;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_136;
+  wire                _zz__zz_decode_IS_DIV_137;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_138;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_139;
+  wire       [7:0]    _zz__zz_decode_IS_DIV_140;
+  wire                _zz__zz_decode_IS_DIV_141;
+  wire                _zz__zz_decode_IS_DIV_142;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_143;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_144;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_145;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_146;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_147;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_148;
+  wire       [5:0]    _zz__zz_decode_IS_DIV_149;
+  wire                _zz__zz_decode_IS_DIV_150;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_151;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_152;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_153;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_154;
+  wire                _zz__zz_decode_IS_DIV_155;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_156;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_157;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_158;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_159;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_160;
+  wire                _zz__zz_decode_IS_DIV_161;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_162;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_163;
+  wire                _zz__zz_decode_IS_DIV_164;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_165;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_166;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_167;
+  wire                _zz__zz_decode_IS_DIV_168;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_169;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_170;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_171;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_172;
+  wire                _zz__zz_decode_IS_DIV_173;
+  wire                _zz__zz_decode_IS_DIV_174;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_175;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_176;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_177;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_178;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_179;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_180;
+  wire                _zz__zz_decode_IS_DIV_181;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_182;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_183;
+  wire                _zz__zz_decode_IS_DIV_184;
+  wire                _zz__zz_decode_IS_DIV_185;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [5:0]    _zz_memory_MulDivIterativePlugin_mul_counter_valueNext;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_2;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator_3;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_4;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_5;
+  wire       [5:0]    _zz_memory_MulDivIterativePlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_2;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire                execute_IS_DBUS_SHARING;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_SRC2_FORCE_ZERO;
@@ -589,51 +472,51 @@ module VexRiscv (
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire                memory_IS_SFENCE_VMA;
-  wire                execute_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA;
+  wire                decode_IS_SFENCE_VMA2;
   wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_LRSC;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -650,20 +533,21 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
+  wire                execute_IS_SFENCE_VMA;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_31;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -673,54 +557,55 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_33;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_36;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_38;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_39;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_40;
-  wire       [31:0]   _zz_41;
-  wire                _zz_42;
-  reg                 _zz_43;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_47;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_48;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_49;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_50;
-  wire                writeBack_IS_SFENCE_VMA;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  wire                execute_IS_SFENCE_VMA2;
   wire                writeBack_IS_DBUS_SHARING;
   wire                memory_IS_DBUS_SHARING;
-  reg        [31:0]   _zz_51;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   _zz_decode_RS2_2;
+  wire                writeBack_MEMORY_LRSC;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MEMORY_AMO;
-  wire                execute_MEMORY_LRSC;
+  reg                 execute_MEMORY_AMO;
+  reg                 execute_MEMORY_LRSC;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   wire       [31:0]   execute_RS2;
@@ -730,7 +615,7 @@ module VexRiscv (
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_AMO;
   wire                decode_MEMORY_LRSC;
-  reg                 _zz_52;
+  reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
   reg                 IBusCachedPlugin_rsp_issueDetected_4;
@@ -738,8 +623,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53;
-  reg        [31:0]   _zz_54;
+  reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -830,7 +715,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -883,6 +768,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -903,28 +793,34 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -954,20 +850,24 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_3_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_3_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_3_halt;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
-  wire                _zz_63;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_3_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_64;
-  wire                _zz_65;
-  reg                 _zz_66;
-  wire                _zz_67;
-  reg                 _zz_68;
-  reg        [31:0]   _zz_69;
-  wire                _zz_70;
-  reg                 _zz_71;
-  reg        [31:0]   _zz_72;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  wire                IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -975,12 +875,20 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
+  wire                when_Fetcher_l329_4;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_5;
+  wire                when_Fetcher_l329_5;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -988,7 +896,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_73;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -996,6 +904,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -1003,7 +916,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -1011,8 +924,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -1020,27 +934,44 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_74;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l311;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_75;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_76;
-  reg        [31:0]   _zz_77;
-  wire                _zz_78;
-  reg        [31:0]   _zz_79;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire                when_DBusCachedPlugin_l474;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
+  wire                when_DBusCachedPlugin_l484;
   reg                 DBusCachedPlugin_forceDatapath;
+  wire                when_DBusCachedPlugin_l498;
+  wire                when_DBusCachedPlugin_l499;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
@@ -1093,12 +1024,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
   wire                MmuPlugin_ports_0_dirty;
   reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
-  reg        [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
+  wire                when_MmuPlugin_l125;
+  wire                when_MmuPlugin_l126;
+  wire       [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
-  wire                _zz_80;
-  wire                _zz_81;
-  wire                _zz_82;
-  wire       [1:0]    _zz_83;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid_1;
+  wire                _zz_MmuPlugin_ports_0_cacheLine_valid_2;
+  wire       [1:0]    _zz_MmuPlugin_ports_0_cacheLine_valid_3;
   wire                MmuPlugin_ports_0_cacheLine_valid;
   wire                MmuPlugin_ports_0_cacheLine_exception;
   wire                MmuPlugin_ports_0_cacheLine_superPage;
@@ -1162,12 +1095,15 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
   wire                MmuPlugin_ports_1_dirty;
   reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
-  reg        [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
+  wire                when_MmuPlugin_l125_1;
+  wire                when_MmuPlugin_l126_1;
+  wire                when_MmuPlugin_l128;
+  wire       [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
-  wire                _zz_84;
-  wire                _zz_85;
-  wire                _zz_86;
-  wire       [1:0]    _zz_87;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid_1;
+  wire                _zz_MmuPlugin_ports_1_cacheLine_valid_2;
+  wire       [1:0]    _zz_MmuPlugin_ports_1_cacheLine_valid_3;
   wire                MmuPlugin_ports_1_cacheLine_valid;
   wire                MmuPlugin_ports_1_cacheLine_exception;
   wire                MmuPlugin_ports_1_cacheLine_superPage;
@@ -1206,6 +1142,7 @@ module VexRiscv (
   wire       [11:0]   MmuPlugin_shared_dBusRsp_pte_PPN1;
   wire                MmuPlugin_shared_dBusRsp_exception;
   wire                MmuPlugin_shared_dBusRsp_leaf;
+  wire                when_MmuPlugin_l205;
   reg                 MmuPlugin_shared_pteBuffer_V;
   reg                 MmuPlugin_shared_pteBuffer_R;
   reg                 MmuPlugin_shared_pteBuffer_W;
@@ -1217,29 +1154,44 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_shared_pteBuffer_RSW;
   reg        [9:0]    MmuPlugin_shared_pteBuffer_PPN0;
   reg        [11:0]   MmuPlugin_shared_pteBuffer_PPN1;
-  reg        [1:0]    _zz_88;
-  wire       [1:0]    _zz_89;
-  reg        [1:0]    _zz_90;
+  wire       [1:0]    _zz_MmuPlugin_shared_refills;
+  reg        [1:0]    _zz_MmuPlugin_shared_refills_1;
   wire       [1:0]    MmuPlugin_shared_refills;
-  wire       [1:0]    _zz_91;
-  reg        [1:0]    _zz_92;
-  wire       [31:0]   _zz_93;
-  wire       [34:0]   _zz_94;
-  wire                _zz_95;
-  wire                _zz_96;
-  wire                _zz_97;
-  wire                _zz_98;
-  wire                _zz_99;
-  wire                _zz_100;
-  wire                _zz_101;
-  wire                _zz_102;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_103;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_104;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_105;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_106;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_107;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_108;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_109;
+  wire       [1:0]    _zz_MmuPlugin_shared_refills_2;
+  reg        [1:0]    _zz_MmuPlugin_shared_refills_3;
+  wire                when_MmuPlugin_l217;
+  wire       [31:0]   _zz_MmuPlugin_shared_vpn_0;
+  wire                when_MmuPlugin_l243;
+  wire                when_MmuPlugin_l272;
+  wire                when_MmuPlugin_l274;
+  wire                when_MmuPlugin_l280;
+  wire                when_MmuPlugin_l280_1;
+  wire                when_MmuPlugin_l280_2;
+  wire                when_MmuPlugin_l280_3;
+  wire                when_MmuPlugin_l274_1;
+  wire                when_MmuPlugin_l280_4;
+  wire                when_MmuPlugin_l280_5;
+  wire                when_MmuPlugin_l280_6;
+  wire                when_MmuPlugin_l280_7;
+  wire                when_MmuPlugin_l304;
+  wire       [35:0]   _zz_decode_IS_DIV;
+  wire                _zz_decode_IS_DIV_1;
+  wire                _zz_decode_IS_DIV_2;
+  wire                _zz_decode_IS_DIV_3;
+  wire                _zz_decode_IS_DIV_4;
+  wire                _zz_decode_IS_DIV_5;
+  wire                _zz_decode_IS_DIV_6;
+  wire                _zz_decode_IS_DIV_7;
+  wire                _zz_decode_IS_DIV_8;
+  wire                _zz_decode_IS_DIV_9;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1247,47 +1199,65 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_110;
+  reg                 _zz_2;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_111;
-  reg        [31:0]   _zz_112;
-  wire                _zz_113;
-  reg        [19:0]   _zz_114;
-  wire                _zz_115;
-  reg        [19:0]   _zz_116;
-  reg        [31:0]   _zz_117;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_118;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_119;
-  reg                 _zz_120;
-  reg                 _zz_121;
-  reg                 _zz_122;
-  reg        [4:0]    _zz_123;
-  reg        [31:0]   _zz_124;
-  wire                _zz_125;
-  wire                _zz_126;
-  wire                _zz_127;
-  wire                _zz_128;
-  wire                _zz_129;
-  wire                _zz_130;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_131;
-  reg                 _zz_132;
-  reg                 _zz_133;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_DO;
+  reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_134;
-  reg        [10:0]   _zz_135;
-  wire                _zz_136;
-  reg        [19:0]   _zz_137;
-  wire                _zz_138;
-  reg        [18:0]   _zz_139;
-  reg        [31:0]   _zz_140;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
+  reg        [31:0]   _zz_execute_BranchPlugin_branch_src2_6;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_141;
+  reg        [1:0]    _zz_CsrPlugin_privilege;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1344,12 +1314,14 @@ module VexRiscv (
   reg        [21:0]   CsrPlugin_satp_PPN;
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
-  wire                _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
-  wire                _zz_145;
-  wire                _zz_146;
-  wire                _zz_147;
+  reg                 CsrPlugin_rescheduleLogic_rescheduleNext;
+  wire                when_CsrPlugin_l803;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
+  wire                _zz_when_CsrPlugin_l952_3;
+  wire                _zz_when_CsrPlugin_l952_4;
+  wire                _zz_when_CsrPlugin_l952_5;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1361,36 +1333,81 @@ module VexRiscv (
   reg        [3:0]    CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
+  wire                when_CsrPlugin_l866;
+  wire                when_CsrPlugin_l866_1;
+  wire                when_CsrPlugin_l866_2;
+  wire                when_CsrPlugin_l866_3;
+  wire                when_CsrPlugin_l866_4;
+  wire                when_CsrPlugin_l866_5;
+  wire                when_CsrPlugin_l866_6;
+  wire                when_CsrPlugin_l866_7;
+  wire                when_CsrPlugin_l866_8;
+  wire                when_CsrPlugin_l866_9;
+  wire                when_CsrPlugin_l866_10;
+  wire                when_CsrPlugin_l866_11;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_148;
-  wire                _zz_149;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l946_1;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l952_3;
+  wire                when_CsrPlugin_l952_4;
+  wire                when_CsrPlugin_l952_5;
+  wire                when_CsrPlugin_l952_6;
+  wire                when_CsrPlugin_l952_7;
+  wire                when_CsrPlugin_l952_8;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   reg        [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -1402,6 +1419,10 @@ module VexRiscv (
   reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
   wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
   wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
+  wire                when_MulDivIterativePlugin_l96;
+  wire                when_MulDivIterativePlugin_l97;
+  wire                when_MulDivIterativePlugin_l100;
+  wire                when_MulDivIterativePlugin_l110;
   reg                 memory_MulDivIterativePlugin_div_needRevert;
   reg                 memory_MulDivIterativePlugin_div_counter_willIncrement;
   reg                 memory_MulDivIterativePlugin_div_counter_willClear;
@@ -1410,221 +1431,329 @@ module VexRiscv (
   wire                memory_MulDivIterativePlugin_div_counter_willOverflowIfInc;
   wire                memory_MulDivIterativePlugin_div_counter_willOverflow;
   reg                 memory_MulDivIterativePlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_MulDivIterativePlugin_div_result;
-  wire       [31:0]   _zz_150;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_151;
-  wire                _zz_152;
-  wire                _zz_153;
-  reg        [32:0]   _zz_154;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs1;
+  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_155;
-  wire       [31:0]   _zz_156;
-  reg        [31:0]   _zz_157;
-  wire       [31:0]   _zz_158;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_LRSC;
+  wire                when_Pipeline_l124_27;
+  reg                 execute_to_memory_MEMORY_LRSC;
+  wire                when_Pipeline_l124_28;
+  reg                 memory_to_writeBack_MEMORY_LRSC;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_MEMORY_AMO;
+  wire                when_Pipeline_l124_30;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_31;
+  reg                 decode_to_execute_IS_SFENCE_VMA2;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_SFENCE_VMA;
-  reg                 execute_to_memory_IS_SFENCE_VMA;
-  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_34;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_36;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_37;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_38;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_39;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_40;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_41;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_43;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_44;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_47;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_48;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_49;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_50;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_51;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_52;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_53;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_54;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_55;
   reg                 execute_to_memory_IS_DBUS_SHARING;
+  wire                when_Pipeline_l124_56;
   reg                 memory_to_writeBack_IS_DBUS_SHARING;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_58;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_59;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_60;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_61;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_256;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_384;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_770;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_771;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_324;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_260;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_261;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_321;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_320;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_322;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_323;
+  wire                when_CsrPlugin_l1264_24;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_25;
   reg                 execute_CsrPlugin_csr_4032;
+  wire                when_CsrPlugin_l1264_26;
   reg                 execute_CsrPlugin_csr_2496;
+  wire                when_CsrPlugin_l1264_27;
   reg                 execute_CsrPlugin_csr_3520;
-  reg        [31:0]   _zz_159;
-  reg        [31:0]   _zz_160;
-  reg        [31:0]   _zz_161;
-  reg        [31:0]   _zz_162;
-  reg        [31:0]   _zz_163;
-  reg        [31:0]   _zz_164;
-  reg        [31:0]   _zz_165;
-  reg        [31:0]   _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
-  reg        [31:0]   _zz_172;
-  reg        [31:0]   _zz_173;
-  reg        [31:0]   _zz_174;
-  reg        [31:0]   _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  reg        [31:0]   _zz_179;
-  reg        [31:0]   _zz_180;
-  reg        [31:0]   _zz_181;
-  reg        [31:0]   _zz_182;
-  reg        [2:0]    _zz_183;
-  reg                 _zz_184;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_26;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  wire                _zz_190;
-  reg                 _zz_191;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [31:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [71:0] _zz_15_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
-  reg [39:0] _zz_18_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
-  reg [23:0] _zz_21_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
-  reg [63:0] _zz_24_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
-  reg [95:0] _zz_27_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_30_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_31_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_35_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_37_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_38_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_39_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_40_string;
-  reg [39:0] _zz_44_string;
-  reg [31:0] _zz_45_string;
-  reg [71:0] _zz_46_string;
-  reg [39:0] _zz_47_string;
-  reg [23:0] _zz_48_string;
-  reg [63:0] _zz_49_string;
-  reg [95:0] _zz_50_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [47:0] MmuPlugin_shared_state_1_string;
-  reg [95:0] _zz_103_string;
-  reg [63:0] _zz_104_string;
-  reg [23:0] _zz_105_string;
-  reg [39:0] _zz_106_string;
-  reg [71:0] _zz_107_string;
-  reg [31:0] _zz_108_string;
-  reg [39:0] _zz_109_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1633,715 +1762,623 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_252 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_253 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_254 = 1'b1;
-  assign _zz_255 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_256 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_257 = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_258 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_259 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_260 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_261 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_262 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_263 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_264 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_265 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_266 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_267 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_268 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_269 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
-  assign _zz_270 = (! dataCache_1_io_cpu_execute_refilling);
-  assign _zz_271 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign _zz_273 = MmuPlugin_shared_portSortedOh[0];
-  assign _zz_274 = MmuPlugin_shared_portSortedOh[1];
-  assign _zz_275 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_276 = (1'b0 || (! 1'b1));
-  assign _zz_277 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_278 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_279 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_280 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_281 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_282 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_283 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_284 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
-  assign _zz_285 = (! memory_arbitration_isStuck);
-  assign _zz_286 = (iBus_cmd_valid || (_zz_183 != 3'b000));
-  assign _zz_287 = (_zz_226 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_288 = (MmuPlugin_shared_refills != 2'b00);
-  assign _zz_289 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
-  assign _zz_290 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
-  assign _zz_291 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
-  assign _zz_292 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
-  assign _zz_293 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
-  assign _zz_294 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
-  assign _zz_295 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
-  assign _zz_296 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
-  assign _zz_297 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
-  assign _zz_298 = ((_zz_142 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign _zz_299 = ((_zz_143 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign _zz_300 = ((_zz_144 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign _zz_301 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_302 = ((_zz_142 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
-  assign _zz_303 = ((_zz_143 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
-  assign _zz_304 = ((_zz_144 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
-  assign _zz_305 = ((_zz_145 && 1'b1) && (! 1'b0));
-  assign _zz_306 = ((_zz_146 && 1'b1) && (! 1'b0));
-  assign _zz_307 = ((_zz_147 && 1'b1) && (! 1'b0));
-  assign _zz_308 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_309 = execute_INSTRUCTION[13];
-  assign _zz_310 = ($signed(_zz_312) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_311 = _zz_310[31 : 0];
-  assign _zz_312 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_313 = _zz_94[34 : 34];
-  assign _zz_314 = _zz_94[33 : 33];
-  assign _zz_315 = _zz_94[32 : 32];
-  assign _zz_316 = _zz_94[31 : 31];
-  assign _zz_317 = _zz_94[28 : 28];
-  assign _zz_318 = _zz_94[21 : 21];
-  assign _zz_319 = _zz_94[20 : 20];
-  assign _zz_320 = _zz_94[19 : 19];
-  assign _zz_321 = _zz_94[13 : 13];
-  assign _zz_322 = _zz_94[12 : 12];
-  assign _zz_323 = _zz_94[11 : 11];
-  assign _zz_324 = _zz_94[17 : 17];
-  assign _zz_325 = _zz_94[5 : 5];
-  assign _zz_326 = _zz_94[3 : 3];
-  assign _zz_327 = _zz_94[18 : 18];
-  assign _zz_328 = _zz_94[10 : 10];
-  assign _zz_329 = _zz_94[16 : 16];
-  assign _zz_330 = _zz_94[15 : 15];
-  assign _zz_331 = _zz_94[4 : 4];
-  assign _zz_332 = _zz_94[0 : 0];
-  assign _zz_333 = (_zz_55 - 4'b0001);
-  assign _zz_334 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_335 = {29'd0, _zz_334};
-  assign _zz_336 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_337 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_338 = MmuPlugin_ports_0_entryToReplace_willIncrement;
-  assign _zz_339 = {1'd0, _zz_338};
-  assign _zz_340 = MmuPlugin_ports_1_entryToReplace_willIncrement;
-  assign _zz_341 = {1'd0, _zz_340};
-  assign _zz_342 = MmuPlugin_shared_dBusRspStaged_payload_data[0 : 0];
-  assign _zz_343 = MmuPlugin_shared_dBusRspStaged_payload_data[1 : 1];
-  assign _zz_344 = MmuPlugin_shared_dBusRspStaged_payload_data[2 : 2];
-  assign _zz_345 = MmuPlugin_shared_dBusRspStaged_payload_data[3 : 3];
-  assign _zz_346 = MmuPlugin_shared_dBusRspStaged_payload_data[4 : 4];
-  assign _zz_347 = MmuPlugin_shared_dBusRspStaged_payload_data[5 : 5];
-  assign _zz_348 = MmuPlugin_shared_dBusRspStaged_payload_data[6 : 6];
-  assign _zz_349 = MmuPlugin_shared_dBusRspStaged_payload_data[7 : 7];
-  assign _zz_350 = (_zz_90 - 2'b01);
-  assign _zz_351 = execute_SRC_LESS;
-  assign _zz_352 = 3'b100;
-  assign _zz_353 = execute_INSTRUCTION[19 : 15];
-  assign _zz_354 = execute_INSTRUCTION[31 : 20];
-  assign _zz_355 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_356 = ($signed(_zz_357) + $signed(_zz_360));
-  assign _zz_357 = ($signed(_zz_358) + $signed(_zz_359));
-  assign _zz_358 = execute_SRC1;
-  assign _zz_359 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_360 = (execute_SRC_USE_SUB_LESS ? _zz_361 : _zz_362);
-  assign _zz_361 = 32'h00000001;
-  assign _zz_362 = 32'h0;
-  assign _zz_363 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_364 = execute_INSTRUCTION[31 : 20];
-  assign _zz_365 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_366 = (_zz_148 & (~ _zz_367));
-  assign _zz_367 = (_zz_148 - 2'b01);
-  assign _zz_368 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_369 = {5'd0, _zz_368};
-  assign _zz_370 = (_zz_372 + _zz_374);
-  assign _zz_371 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_372 = {{1{_zz_371[32]}}, _zz_371};
-  assign _zz_373 = _zz_375;
-  assign _zz_374 = {{1{_zz_373[32]}}, _zz_373};
-  assign _zz_375 = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_376 = memory_MulDivIterativePlugin_div_counter_willIncrement;
-  assign _zz_377 = {5'd0, _zz_376};
-  assign _zz_378 = {1'd0, memory_MulDivIterativePlugin_rs2};
-  assign _zz_379 = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_380 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_381 = {_zz_150,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_382 = _zz_383;
-  assign _zz_383 = _zz_384;
-  assign _zz_384 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_151) : _zz_151)} + _zz_386);
-  assign _zz_385 = memory_MulDivIterativePlugin_div_needRevert;
-  assign _zz_386 = {32'd0, _zz_385};
-  assign _zz_387 = _zz_153;
-  assign _zz_388 = {32'd0, _zz_387};
-  assign _zz_389 = _zz_152;
-  assign _zz_390 = {31'd0, _zz_389};
-  assign _zz_391 = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_392 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_393 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_394 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_395 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_396 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_397 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_398 = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_399 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_400 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_401 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_402 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_403 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_404 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_405 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_406 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_407 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_408 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_409 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_410 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_411 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_412 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_413 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_414 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_415 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_416 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_417 = execute_CsrPlugin_writeData[4 : 4];
-  assign _zz_418 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_419 = execute_CsrPlugin_writeData[6 : 6];
-  assign _zz_420 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_421 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_422 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_423 = execute_CsrPlugin_writeData[12 : 12];
-  assign _zz_424 = execute_CsrPlugin_writeData[13 : 13];
-  assign _zz_425 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_426 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_427 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_428 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_429 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_430 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_431 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_432 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_433 = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_434 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_435 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_436 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_437 = 1'b1;
-  assign _zz_438 = 1'b1;
-  assign _zz_439 = {_zz_59,_zz_58};
-  assign _zz_440 = 32'h0000107f;
-  assign _zz_441 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_442 = 32'h00002073;
-  assign _zz_443 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_444 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_445 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_446) == 32'h00000003),{(_zz_447 == _zz_448),{_zz_449,{_zz_450,_zz_451}}}}}};
-  assign _zz_446 = 32'h0000505f;
-  assign _zz_447 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_448 = 32'h00000063;
-  assign _zz_449 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_450 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_451 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_452) == 32'h00001013),{(_zz_453 == _zz_454),{_zz_455,{_zz_456,_zz_457}}}}}};
-  assign _zz_452 = 32'hfc00305f;
-  assign _zz_453 = (decode_INSTRUCTION & 32'h01f0707f);
-  assign _zz_454 = 32'h0000500f;
-  assign _zz_455 = ((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013);
-  assign _zz_456 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_457 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_458) == 32'h12000073),{(_zz_459 == _zz_460),{_zz_461,_zz_462}}}}};
-  assign _zz_458 = 32'hfe007fff;
-  assign _zz_459 = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_460 = 32'h10200073;
-  assign _zz_461 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_462 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_463 = 32'h02004064;
-  assign _zz_464 = _zz_102;
-  assign _zz_465 = {_zz_100,_zz_101};
-  assign _zz_466 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_467 = 1'b0;
-  assign _zz_468 = (((decode_INSTRUCTION & _zz_471) == 32'h00000050) != 1'b0);
-  assign _zz_469 = ((_zz_472 == _zz_473) != 1'b0);
-  assign _zz_470 = {({_zz_474,_zz_475} != 2'b00),{(_zz_476 != _zz_477),{_zz_478,{_zz_479,_zz_480}}}};
-  assign _zz_471 = 32'h02203050;
-  assign _zz_472 = (decode_INSTRUCTION & 32'h02403050);
-  assign _zz_473 = 32'h00000050;
-  assign _zz_474 = ((decode_INSTRUCTION & _zz_481) == 32'h00001050);
-  assign _zz_475 = ((decode_INSTRUCTION & _zz_482) == 32'h00002050);
-  assign _zz_476 = {_zz_96,(_zz_483 == _zz_484)};
-  assign _zz_477 = 2'b00;
-  assign _zz_478 = ((_zz_485 == _zz_486) != 1'b0);
-  assign _zz_479 = ({_zz_487,_zz_488} != 2'b00);
-  assign _zz_480 = {(_zz_489 != _zz_490),{_zz_491,{_zz_492,_zz_493}}};
-  assign _zz_481 = 32'h00001050;
-  assign _zz_482 = 32'h00002050;
-  assign _zz_483 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_484 = 32'h00000004;
-  assign _zz_485 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_486 = 32'h00000040;
-  assign _zz_487 = ((decode_INSTRUCTION & _zz_494) == 32'h00005010);
-  assign _zz_488 = ((decode_INSTRUCTION & _zz_495) == 32'h00005020);
-  assign _zz_489 = {(_zz_496 == _zz_497),{_zz_498,_zz_499}};
-  assign _zz_490 = 3'b000;
-  assign _zz_491 = ((_zz_500 == _zz_501) != 1'b0);
-  assign _zz_492 = (_zz_100 != 1'b0);
-  assign _zz_493 = {(_zz_502 != _zz_503),{_zz_504,{_zz_505,_zz_506}}};
-  assign _zz_494 = 32'h00007034;
-  assign _zz_495 = 32'h02007064;
-  assign _zz_496 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_497 = 32'h40001010;
-  assign _zz_498 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz_499 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz_500 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_501 = 32'h00001000;
-  assign _zz_502 = {(_zz_507 == _zz_508),(_zz_509 == _zz_510)};
-  assign _zz_503 = 2'b00;
-  assign _zz_504 = ((_zz_511 == _zz_512) != 1'b0);
-  assign _zz_505 = (_zz_513 != 1'b0);
-  assign _zz_506 = {(_zz_514 != _zz_515),{_zz_516,{_zz_517,_zz_518}}};
-  assign _zz_507 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_508 = 32'h00002000;
-  assign _zz_509 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_510 = 32'h00001000;
-  assign _zz_511 = (decode_INSTRUCTION & 32'h02003050);
-  assign _zz_512 = 32'h02000050;
-  assign _zz_513 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz_514 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_515 = 1'b0;
-  assign _zz_516 = ({(_zz_519 == _zz_520),{_zz_521,{_zz_522,_zz_523}}} != 4'b0000);
-  assign _zz_517 = ((_zz_524 == _zz_525) != 1'b0);
-  assign _zz_518 = {(_zz_526 != 1'b0),{(_zz_527 != _zz_528),{_zz_529,{_zz_530,_zz_531}}}};
-  assign _zz_519 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_520 = 32'h00000020;
-  assign _zz_521 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_522 = ((decode_INSTRUCTION & _zz_532) == 32'h08000020);
-  assign _zz_523 = ((decode_INSTRUCTION & _zz_533) == 32'h00000020);
-  assign _zz_524 = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_525 = 32'h00000008;
-  assign _zz_526 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
-  assign _zz_527 = {(_zz_534 == _zz_535),{_zz_536,{_zz_537,_zz_538}}};
-  assign _zz_528 = 6'h0;
-  assign _zz_529 = ({_zz_539,{_zz_540,_zz_541}} != 3'b000);
-  assign _zz_530 = (_zz_542 != 1'b0);
-  assign _zz_531 = {(_zz_543 != _zz_544),{_zz_545,{_zz_546,_zz_547}}};
-  assign _zz_532 = 32'h08000070;
-  assign _zz_533 = 32'h10000070;
-  assign _zz_534 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_535 = 32'h00002040;
-  assign _zz_536 = ((decode_INSTRUCTION & _zz_548) == 32'h00001040);
-  assign _zz_537 = (_zz_549 == _zz_550);
-  assign _zz_538 = {_zz_551,{_zz_552,_zz_553}};
-  assign _zz_539 = ((decode_INSTRUCTION & _zz_554) == 32'h08000020);
-  assign _zz_540 = (_zz_555 == _zz_556);
-  assign _zz_541 = (_zz_557 == _zz_558);
-  assign _zz_542 = ((decode_INSTRUCTION & _zz_559) == 32'h00000010);
-  assign _zz_543 = {_zz_99,{_zz_560,_zz_561}};
-  assign _zz_544 = 5'h0;
-  assign _zz_545 = ({_zz_562,_zz_563} != 7'h0);
-  assign _zz_546 = (_zz_564 != _zz_565);
-  assign _zz_547 = {_zz_566,{_zz_567,_zz_568}};
-  assign _zz_548 = 32'h00001040;
-  assign _zz_549 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_550 = 32'h00000040;
-  assign _zz_551 = ((decode_INSTRUCTION & _zz_569) == 32'h00000040);
-  assign _zz_552 = (_zz_570 == _zz_571);
-  assign _zz_553 = (_zz_572 == _zz_573);
-  assign _zz_554 = 32'h08000020;
-  assign _zz_555 = (decode_INSTRUCTION & 32'h10000020);
-  assign _zz_556 = 32'h00000020;
-  assign _zz_557 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_558 = 32'h00000020;
-  assign _zz_559 = 32'h00000010;
-  assign _zz_560 = (_zz_574 == _zz_575);
-  assign _zz_561 = {_zz_576,{_zz_577,_zz_578}};
-  assign _zz_562 = _zz_96;
-  assign _zz_563 = {_zz_579,{_zz_580,_zz_581}};
-  assign _zz_564 = {_zz_98,_zz_582};
-  assign _zz_565 = 2'b00;
-  assign _zz_566 = ({_zz_583,_zz_584} != 2'b00);
-  assign _zz_567 = (_zz_585 != _zz_586);
-  assign _zz_568 = {_zz_587,{_zz_588,_zz_589}};
-  assign _zz_569 = 32'h02400040;
-  assign _zz_570 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_571 = 32'h0;
-  assign _zz_572 = (decode_INSTRUCTION & 32'h18002008);
-  assign _zz_573 = 32'h10002008;
-  assign _zz_574 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_575 = 32'h00002010;
-  assign _zz_576 = ((decode_INSTRUCTION & _zz_590) == 32'h00000010);
-  assign _zz_577 = (_zz_591 == _zz_592);
-  assign _zz_578 = (_zz_593 == _zz_594);
-  assign _zz_579 = ((decode_INSTRUCTION & _zz_595) == 32'h00001010);
-  assign _zz_580 = (_zz_596 == _zz_597);
-  assign _zz_581 = {_zz_598,{_zz_599,_zz_600}};
-  assign _zz_582 = ((decode_INSTRUCTION & _zz_601) == 32'h00000020);
-  assign _zz_583 = _zz_98;
-  assign _zz_584 = (_zz_602 == _zz_603);
-  assign _zz_585 = (_zz_604 == _zz_605);
-  assign _zz_586 = 1'b0;
-  assign _zz_587 = (_zz_606 != 1'b0);
-  assign _zz_588 = (_zz_607 != _zz_608);
-  assign _zz_589 = {_zz_609,{_zz_610,_zz_611}};
-  assign _zz_590 = 32'h00001030;
-  assign _zz_591 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_592 = 32'h00000020;
-  assign _zz_593 = (decode_INSTRUCTION & 32'h02002068);
-  assign _zz_594 = 32'h00002020;
-  assign _zz_595 = 32'h00001010;
-  assign _zz_596 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_597 = 32'h00002010;
-  assign _zz_598 = ((decode_INSTRUCTION & _zz_612) == 32'h00002008);
-  assign _zz_599 = (_zz_613 == _zz_614);
-  assign _zz_600 = {_zz_99,_zz_615};
-  assign _zz_601 = 32'h00000070;
-  assign _zz_602 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_603 = 32'h0;
-  assign _zz_604 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_605 = 32'h00004010;
-  assign _zz_606 = ((decode_INSTRUCTION & _zz_616) == 32'h00002010);
-  assign _zz_607 = {_zz_617,{_zz_618,_zz_619}};
-  assign _zz_608 = 5'h0;
-  assign _zz_609 = ({_zz_620,_zz_621} != 2'b00);
-  assign _zz_610 = (_zz_622 != _zz_623);
-  assign _zz_611 = {_zz_624,{_zz_625,_zz_626}};
-  assign _zz_612 = 32'h00002008;
-  assign _zz_613 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_614 = 32'h00000010;
-  assign _zz_615 = ((decode_INSTRUCTION & _zz_627) == 32'h0);
-  assign _zz_616 = 32'h00006014;
-  assign _zz_617 = ((decode_INSTRUCTION & _zz_628) == 32'h0);
-  assign _zz_618 = (_zz_629 == _zz_630);
-  assign _zz_619 = {_zz_631,{_zz_632,_zz_633}};
-  assign _zz_620 = _zz_97;
-  assign _zz_621 = (_zz_634 == _zz_635);
-  assign _zz_622 = {_zz_636,{_zz_637,_zz_638}};
-  assign _zz_623 = 3'b000;
-  assign _zz_624 = ({_zz_639,_zz_640} != 3'b000);
-  assign _zz_625 = (_zz_641 != _zz_642);
-  assign _zz_626 = (_zz_643 != _zz_644);
-  assign _zz_627 = 32'h00000028;
-  assign _zz_628 = 32'h00000044;
-  assign _zz_629 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_630 = 32'h0;
-  assign _zz_631 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_632 = ((decode_INSTRUCTION & _zz_645) == 32'h00001000);
-  assign _zz_633 = _zz_97;
-  assign _zz_634 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_635 = 32'h0;
-  assign _zz_636 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_637 = ((decode_INSTRUCTION & _zz_646) == 32'h00002010);
-  assign _zz_638 = ((decode_INSTRUCTION & _zz_647) == 32'h40000030);
-  assign _zz_639 = _zz_96;
-  assign _zz_640 = {_zz_95,(_zz_648 == _zz_649)};
-  assign _zz_641 = {_zz_95,(_zz_650 == _zz_651)};
-  assign _zz_642 = 2'b00;
-  assign _zz_643 = ((decode_INSTRUCTION & _zz_652) == 32'h00001008);
-  assign _zz_644 = 1'b0;
-  assign _zz_645 = 32'h00005004;
-  assign _zz_646 = 32'h00002014;
-  assign _zz_647 = 32'h40000034;
-  assign _zz_648 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_649 = 32'h00000004;
-  assign _zz_650 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz_651 = 32'h00000004;
-  assign _zz_652 = 32'h00005048;
-  assign _zz_653 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_437) begin
-      _zz_227 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_writeBack_DBusCachedPlugin_rspRf = (! dataCache_1_io_cpu_writeBack_exclusiveOk);
+  assign _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1 = MmuPlugin_ports_0_entryToReplace_willIncrement;
+  assign _zz_MmuPlugin_ports_0_entryToReplace_valueNext = {1'd0, _zz_MmuPlugin_ports_0_entryToReplace_valueNext_1};
+  assign _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1 = MmuPlugin_ports_1_entryToReplace_willIncrement;
+  assign _zz_MmuPlugin_ports_1_entryToReplace_valueNext = {1'd0, _zz_MmuPlugin_ports_1_entryToReplace_valueNext_1};
+  assign _zz__zz_MmuPlugin_shared_refills_2 = (_zz_MmuPlugin_shared_refills_1 - 2'b01);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
+  assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
+  assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
+  assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
+  assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator = {_zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_MulDivIterativePlugin_div_result_1 = _zz_memory_MulDivIterativePlugin_div_result_2;
+  assign _zz_memory_MulDivIterativePlugin_div_result_2 = _zz_memory_MulDivIterativePlugin_div_result_3;
+  assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
+  assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
+  assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
+  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00305f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'h01f0707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h0000500f;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_18) == 32'h12000073),{(_zz_decode_LEGAL_INSTRUCTION_19 == _zz_decode_LEGAL_INSTRUCTION_20),{_zz_decode_LEGAL_INSTRUCTION_21,_zz_decode_LEGAL_INSTRUCTION_22}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_18 = 32'hfe007fff;
+  assign _zz_decode_LEGAL_INSTRUCTION_19 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h10200073;
+  assign _zz_decode_LEGAL_INSTRUCTION_21 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_22 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_1 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_2 = (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_3 = (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_4 = (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_0_cacheHitsCalc_5 = (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22];
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_1 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12];
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_2 = (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_3 = (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_4 = (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22]);
+  assign _zz_MmuPlugin_ports_1_cacheHitsCalc_5 = (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]);
+  assign _zz__zz_decode_IS_DIV = 32'h02004064;
+  assign _zz__zz_decode_IS_DIV_1 = _zz_decode_IS_DIV_9;
+  assign _zz__zz_decode_IS_DIV_2 = {_zz_decode_IS_DIV_7,_zz_decode_IS_DIV_8};
+  assign _zz__zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_DIV_4 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_6) == 32'h00000050) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_7 = ((_zz__zz_decode_IS_DIV_8 == _zz__zz_decode_IS_DIV_9) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_10 = {({_zz__zz_decode_IS_DIV_11,_zz__zz_decode_IS_DIV_13} != 2'b00),{(_zz__zz_decode_IS_DIV_15 != _zz__zz_decode_IS_DIV_18),{_zz__zz_decode_IS_DIV_19,{_zz__zz_decode_IS_DIV_22,_zz__zz_decode_IS_DIV_27}}}};
+  assign _zz__zz_decode_IS_DIV_6 = 32'h02203050;
+  assign _zz__zz_decode_IS_DIV_8 = (decode_INSTRUCTION & 32'h02403050);
+  assign _zz__zz_decode_IS_DIV_9 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_12) == 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_14) == 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_15 = {_zz_decode_IS_DIV_2,(_zz__zz_decode_IS_DIV_16 == _zz__zz_decode_IS_DIV_17)};
+  assign _zz__zz_decode_IS_DIV_18 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_19 = ((_zz__zz_decode_IS_DIV_20 == _zz__zz_decode_IS_DIV_21) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_22 = ({_zz__zz_decode_IS_DIV_23,_zz__zz_decode_IS_DIV_25} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_27 = {(_zz__zz_decode_IS_DIV_28 != _zz__zz_decode_IS_DIV_33),{_zz__zz_decode_IS_DIV_34,{_zz__zz_decode_IS_DIV_37,_zz__zz_decode_IS_DIV_38}}};
+  assign _zz__zz_decode_IS_DIV_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_DIV_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_DIV_16 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_IS_DIV_17 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_20 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_DIV_21 = 32'h00000040;
+  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_24) == 32'h00005010);
+  assign _zz__zz_decode_IS_DIV_25 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_26) == 32'h00005020);
+  assign _zz__zz_decode_IS_DIV_28 = {(_zz__zz_decode_IS_DIV_29 == _zz__zz_decode_IS_DIV_30),{_zz__zz_decode_IS_DIV_31,_zz__zz_decode_IS_DIV_32}};
+  assign _zz__zz_decode_IS_DIV_33 = 3'b000;
+  assign _zz__zz_decode_IS_DIV_34 = ((_zz__zz_decode_IS_DIV_35 == _zz__zz_decode_IS_DIV_36) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_37 = (_zz_decode_IS_DIV_7 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_38 = {(_zz__zz_decode_IS_DIV_39 != _zz__zz_decode_IS_DIV_44),{_zz__zz_decode_IS_DIV_45,{_zz__zz_decode_IS_DIV_46,_zz__zz_decode_IS_DIV_47}}};
+  assign _zz__zz_decode_IS_DIV_24 = 32'h00007034;
+  assign _zz__zz_decode_IS_DIV_26 = 32'h02007064;
+  assign _zz__zz_decode_IS_DIV_29 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_IS_DIV_30 = 32'h40001010;
+  assign _zz__zz_decode_IS_DIV_31 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_32 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_35 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_36 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_39 = {(_zz__zz_decode_IS_DIV_40 == _zz__zz_decode_IS_DIV_41),(_zz__zz_decode_IS_DIV_42 == _zz__zz_decode_IS_DIV_43)};
+  assign _zz__zz_decode_IS_DIV_44 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_45 = (_zz_decode_IS_DIV_6 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_46 = (_zz_decode_IS_DIV_6 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_47 = {(_zz__zz_decode_IS_DIV_48 != _zz__zz_decode_IS_DIV_49),{_zz__zz_decode_IS_DIV_50,{_zz__zz_decode_IS_DIV_52,_zz__zz_decode_IS_DIV_61}}};
+  assign _zz__zz_decode_IS_DIV_40 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_41 = 32'h00002000;
+  assign _zz__zz_decode_IS_DIV_42 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_DIV_43 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_48 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_IS_DIV_49 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_50 = (((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_51) == 32'h00000024) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_52 = ({_zz__zz_decode_IS_DIV_53,{_zz__zz_decode_IS_DIV_54,_zz__zz_decode_IS_DIV_56}} != 4'b0000);
+  assign _zz__zz_decode_IS_DIV_61 = {(_zz__zz_decode_IS_DIV_62 != 1'b0),{(_zz__zz_decode_IS_DIV_63 != _zz__zz_decode_IS_DIV_65),{_zz__zz_decode_IS_DIV_66,{_zz__zz_decode_IS_DIV_83,_zz__zz_decode_IS_DIV_92}}}};
+  assign _zz__zz_decode_IS_DIV_51 = 32'h00000064;
+  assign _zz__zz_decode_IS_DIV_53 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_55) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_56 = {(_zz__zz_decode_IS_DIV_57 == _zz__zz_decode_IS_DIV_58),(_zz__zz_decode_IS_DIV_59 == _zz__zz_decode_IS_DIV_60)};
+  assign _zz__zz_decode_IS_DIV_62 = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
+  assign _zz__zz_decode_IS_DIV_63 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_64) == 32'h10000008);
+  assign _zz__zz_decode_IS_DIV_65 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_66 = ({_zz__zz_decode_IS_DIV_67,{_zz__zz_decode_IS_DIV_69,_zz__zz_decode_IS_DIV_72}} != 6'h0);
+  assign _zz__zz_decode_IS_DIV_83 = ({_zz__zz_decode_IS_DIV_84,_zz__zz_decode_IS_DIV_87} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_92 = {(_zz__zz_decode_IS_DIV_93 != _zz__zz_decode_IS_DIV_96),{_zz__zz_decode_IS_DIV_97,{_zz__zz_decode_IS_DIV_110,_zz__zz_decode_IS_DIV_129}}};
+  assign _zz__zz_decode_IS_DIV_55 = 32'h00000064;
+  assign _zz__zz_decode_IS_DIV_57 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz__zz_decode_IS_DIV_58 = 32'h08000020;
+  assign _zz__zz_decode_IS_DIV_59 = (decode_INSTRUCTION & 32'h10000070);
+  assign _zz__zz_decode_IS_DIV_60 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_64 = 32'h10000008;
+  assign _zz__zz_decode_IS_DIV_67 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_68) == 32'h00002040);
+  assign _zz__zz_decode_IS_DIV_69 = (_zz__zz_decode_IS_DIV_70 == _zz__zz_decode_IS_DIV_71);
+  assign _zz__zz_decode_IS_DIV_72 = {_zz__zz_decode_IS_DIV_73,{_zz__zz_decode_IS_DIV_75,_zz__zz_decode_IS_DIV_78}};
+  assign _zz__zz_decode_IS_DIV_84 = (_zz__zz_decode_IS_DIV_85 == _zz__zz_decode_IS_DIV_86);
+  assign _zz__zz_decode_IS_DIV_87 = {_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_90};
+  assign _zz__zz_decode_IS_DIV_93 = (_zz__zz_decode_IS_DIV_94 == _zz__zz_decode_IS_DIV_95);
+  assign _zz__zz_decode_IS_DIV_96 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_97 = ({_zz__zz_decode_IS_DIV_98,_zz__zz_decode_IS_DIV_99} != 5'h0);
+  assign _zz__zz_decode_IS_DIV_110 = (_zz__zz_decode_IS_DIV_111 != _zz__zz_decode_IS_DIV_128);
+  assign _zz__zz_decode_IS_DIV_129 = {_zz__zz_decode_IS_DIV_130,{_zz__zz_decode_IS_DIV_135,_zz__zz_decode_IS_DIV_140}};
+  assign _zz__zz_decode_IS_DIV_68 = 32'h00002040;
+  assign _zz__zz_decode_IS_DIV_70 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_DIV_71 = 32'h00001040;
+  assign _zz__zz_decode_IS_DIV_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_74) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_75 = (_zz__zz_decode_IS_DIV_76 == _zz__zz_decode_IS_DIV_77);
+  assign _zz__zz_decode_IS_DIV_78 = {_zz__zz_decode_IS_DIV_79,_zz__zz_decode_IS_DIV_81};
+  assign _zz__zz_decode_IS_DIV_85 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz__zz_decode_IS_DIV_86 = 32'h08000020;
+  assign _zz__zz_decode_IS_DIV_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_89) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_91) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_94 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_95 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_98 = _zz_decode_IS_DIV_5;
+  assign _zz__zz_decode_IS_DIV_99 = {_zz__zz_decode_IS_DIV_100,{_zz__zz_decode_IS_DIV_102,_zz__zz_decode_IS_DIV_105}};
+  assign _zz__zz_decode_IS_DIV_111 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_112,_zz__zz_decode_IS_DIV_115}};
+  assign _zz__zz_decode_IS_DIV_128 = 7'h0;
+  assign _zz__zz_decode_IS_DIV_130 = ({_zz__zz_decode_IS_DIV_131,_zz__zz_decode_IS_DIV_132} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_135 = (_zz__zz_decode_IS_DIV_136 != _zz__zz_decode_IS_DIV_139);
+  assign _zz__zz_decode_IS_DIV_140 = {_zz__zz_decode_IS_DIV_141,{_zz__zz_decode_IS_DIV_144,_zz__zz_decode_IS_DIV_149}};
+  assign _zz__zz_decode_IS_DIV_74 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_76 = (decode_INSTRUCTION & 32'h02400040);
+  assign _zz__zz_decode_IS_DIV_77 = 32'h00000040;
+  assign _zz__zz_decode_IS_DIV_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_80) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_82) == 32'h10002008);
+  assign _zz__zz_decode_IS_DIV_89 = 32'h10000020;
+  assign _zz__zz_decode_IS_DIV_91 = 32'h00000028;
+  assign _zz__zz_decode_IS_DIV_100 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_101) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_102 = (_zz__zz_decode_IS_DIV_103 == _zz__zz_decode_IS_DIV_104);
+  assign _zz__zz_decode_IS_DIV_105 = {_zz__zz_decode_IS_DIV_106,_zz__zz_decode_IS_DIV_108};
+  assign _zz__zz_decode_IS_DIV_112 = (_zz__zz_decode_IS_DIV_113 == _zz__zz_decode_IS_DIV_114);
+  assign _zz__zz_decode_IS_DIV_115 = {_zz__zz_decode_IS_DIV_116,{_zz__zz_decode_IS_DIV_118,_zz__zz_decode_IS_DIV_121}};
+  assign _zz__zz_decode_IS_DIV_131 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_132 = (_zz__zz_decode_IS_DIV_133 == _zz__zz_decode_IS_DIV_134);
+  assign _zz__zz_decode_IS_DIV_136 = {_zz_decode_IS_DIV_4,_zz__zz_decode_IS_DIV_137};
+  assign _zz__zz_decode_IS_DIV_139 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_141 = (_zz__zz_decode_IS_DIV_142 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_144 = (_zz__zz_decode_IS_DIV_145 != _zz__zz_decode_IS_DIV_148);
+  assign _zz__zz_decode_IS_DIV_149 = {_zz__zz_decode_IS_DIV_150,{_zz__zz_decode_IS_DIV_162,_zz__zz_decode_IS_DIV_167}};
+  assign _zz__zz_decode_IS_DIV_80 = 32'h00000038;
+  assign _zz__zz_decode_IS_DIV_82 = 32'h18002008;
+  assign _zz__zz_decode_IS_DIV_101 = 32'h00002030;
+  assign _zz__zz_decode_IS_DIV_103 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_DIV_104 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_107) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_108 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_109) == 32'h00002020);
+  assign _zz__zz_decode_IS_DIV_113 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_114 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_117) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_118 = (_zz__zz_decode_IS_DIV_119 == _zz__zz_decode_IS_DIV_120);
+  assign _zz__zz_decode_IS_DIV_121 = {_zz__zz_decode_IS_DIV_122,{_zz__zz_decode_IS_DIV_124,_zz__zz_decode_IS_DIV_125}};
+  assign _zz__zz_decode_IS_DIV_133 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_DIV_134 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_137 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_138) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_143) == 32'h00004010);
+  assign _zz__zz_decode_IS_DIV_145 = (_zz__zz_decode_IS_DIV_146 == _zz__zz_decode_IS_DIV_147);
+  assign _zz__zz_decode_IS_DIV_148 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_150 = ({_zz__zz_decode_IS_DIV_151,_zz__zz_decode_IS_DIV_154} != 5'h0);
+  assign _zz__zz_decode_IS_DIV_162 = (_zz__zz_decode_IS_DIV_163 != _zz__zz_decode_IS_DIV_166);
+  assign _zz__zz_decode_IS_DIV_167 = {_zz__zz_decode_IS_DIV_168,{_zz__zz_decode_IS_DIV_175,_zz__zz_decode_IS_DIV_180}};
+  assign _zz__zz_decode_IS_DIV_107 = 32'h02003020;
+  assign _zz__zz_decode_IS_DIV_109 = 32'h02002068;
+  assign _zz__zz_decode_IS_DIV_117 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_119 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz__zz_decode_IS_DIV_120 = 32'h00002008;
+  assign _zz__zz_decode_IS_DIV_122 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_123) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_124 = _zz_decode_IS_DIV_5;
+  assign _zz__zz_decode_IS_DIV_125 = (_zz__zz_decode_IS_DIV_126 == _zz__zz_decode_IS_DIV_127);
+  assign _zz__zz_decode_IS_DIV_138 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_143 = 32'h00004014;
+  assign _zz__zz_decode_IS_DIV_146 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_147 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_151 = (_zz__zz_decode_IS_DIV_152 == _zz__zz_decode_IS_DIV_153);
+  assign _zz__zz_decode_IS_DIV_154 = {_zz__zz_decode_IS_DIV_155,{_zz__zz_decode_IS_DIV_157,_zz__zz_decode_IS_DIV_160}};
+  assign _zz__zz_decode_IS_DIV_163 = {_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_164};
+  assign _zz__zz_decode_IS_DIV_166 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_168 = ({_zz__zz_decode_IS_DIV_169,_zz__zz_decode_IS_DIV_172} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_175 = (_zz__zz_decode_IS_DIV_176 != _zz__zz_decode_IS_DIV_179);
+  assign _zz__zz_decode_IS_DIV_180 = {_zz__zz_decode_IS_DIV_181,_zz__zz_decode_IS_DIV_184};
+  assign _zz__zz_decode_IS_DIV_123 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_126 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_DIV_127 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_152 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_153 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_155 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_156) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_157 = (_zz__zz_decode_IS_DIV_158 == _zz__zz_decode_IS_DIV_159);
+  assign _zz__zz_decode_IS_DIV_160 = {_zz__zz_decode_IS_DIV_161,_zz_decode_IS_DIV_3};
+  assign _zz__zz_decode_IS_DIV_164 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_165) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_169 = (_zz__zz_decode_IS_DIV_170 == _zz__zz_decode_IS_DIV_171);
+  assign _zz__zz_decode_IS_DIV_172 = {_zz__zz_decode_IS_DIV_173,_zz__zz_decode_IS_DIV_174};
+  assign _zz__zz_decode_IS_DIV_176 = {_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_177,_zz__zz_decode_IS_DIV_178}};
+  assign _zz__zz_decode_IS_DIV_179 = 3'b000;
+  assign _zz__zz_decode_IS_DIV_181 = ({_zz__zz_decode_IS_DIV_182,_zz__zz_decode_IS_DIV_183} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_184 = (_zz__zz_decode_IS_DIV_185 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_156 = 32'h00000018;
+  assign _zz__zz_decode_IS_DIV_158 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_DIV_159 = 32'h00002000;
+  assign _zz__zz_decode_IS_DIV_161 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_165 = 32'h00000058;
+  assign _zz__zz_decode_IS_DIV_170 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_171 = 32'h00000040;
+  assign _zz__zz_decode_IS_DIV_173 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_174 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_DIV_177 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_178 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_182 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_183 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_185 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_28 = 32'h0;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_438) begin
-      _zz_228 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_43) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_192                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_193                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_194                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_195                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_196                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                      ), //i
-    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]           ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_197                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_198                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_3_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_199                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_200                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical           ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical           ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_3_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_201                                            ), //i
-    .io_cpu_execute_address                    (_zz_202[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (_zz_203                                            ), //i
-    .io_cpu_execute_args_data                  (_zz_204[31:0]                                      ), //i
-    .io_cpu_execute_args_size                  (_zz_205[1:0]                                       ), //i
-    .io_cpu_execute_args_isLrsc                (_zz_206                                            ), //i
-    .io_cpu_execute_args_isAmo                 (_zz_207                                            ), //i
-    .io_cpu_execute_args_amoCtrl_swap          (_zz_208                                            ), //i
-    .io_cpu_execute_args_amoCtrl_alu           (_zz_209[2:0]                                       ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_210                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_211[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_212                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel             ), //i
-    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]  ), //i
-    .io_cpu_writeBack_isValid                  (_zz_213                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_214                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_215[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_216                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_217                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_218                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_219                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_220                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_221                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_222                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_223                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_224[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_225                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_226                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (dataCache_1_io_cpu_execute_args_wr             ), //i
+    .io_cpu_execute_args_size                  (dataCache_1_io_cpu_execute_args_size           ), //i
+    .io_cpu_execute_args_isLrsc                (dataCache_1_io_cpu_execute_args_isLrsc         ), //i
+    .io_cpu_execute_args_isAmo                 (execute_MEMORY_AMO                             ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (dataCache_1_io_cpu_execute_args_amoCtrl_swap   ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (dataCache_1_io_cpu_execute_args_amoCtrl_alu    ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical    ), //i
+    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel         ), //i
+    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical    ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_439)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_229 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_229 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_229 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_229 = CsrPlugin_redoInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_redoInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_83)
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
       2'b00 : begin
-        _zz_230 = MmuPlugin_ports_0_cache_0_valid;
-        _zz_231 = MmuPlugin_ports_0_cache_0_exception;
-        _zz_232 = MmuPlugin_ports_0_cache_0_superPage;
-        _zz_233 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
-        _zz_234 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
-        _zz_235 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
-        _zz_236 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
-        _zz_237 = MmuPlugin_ports_0_cache_0_allowRead;
-        _zz_238 = MmuPlugin_ports_0_cache_0_allowWrite;
-        _zz_239 = MmuPlugin_ports_0_cache_0_allowExecute;
-        _zz_240 = MmuPlugin_ports_0_cache_0_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
       end
       2'b01 : begin
-        _zz_230 = MmuPlugin_ports_0_cache_1_valid;
-        _zz_231 = MmuPlugin_ports_0_cache_1_exception;
-        _zz_232 = MmuPlugin_ports_0_cache_1_superPage;
-        _zz_233 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
-        _zz_234 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
-        _zz_235 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
-        _zz_236 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
-        _zz_237 = MmuPlugin_ports_0_cache_1_allowRead;
-        _zz_238 = MmuPlugin_ports_0_cache_1_allowWrite;
-        _zz_239 = MmuPlugin_ports_0_cache_1_allowExecute;
-        _zz_240 = MmuPlugin_ports_0_cache_1_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       2'b10 : begin
-        _zz_230 = MmuPlugin_ports_0_cache_2_valid;
-        _zz_231 = MmuPlugin_ports_0_cache_2_exception;
-        _zz_232 = MmuPlugin_ports_0_cache_2_superPage;
-        _zz_233 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
-        _zz_234 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
-        _zz_235 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
-        _zz_236 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
-        _zz_237 = MmuPlugin_ports_0_cache_2_allowRead;
-        _zz_238 = MmuPlugin_ports_0_cache_2_allowWrite;
-        _zz_239 = MmuPlugin_ports_0_cache_2_allowExecute;
-        _zz_240 = MmuPlugin_ports_0_cache_2_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
       end
       default : begin
-        _zz_230 = MmuPlugin_ports_0_cache_3_valid;
-        _zz_231 = MmuPlugin_ports_0_cache_3_exception;
-        _zz_232 = MmuPlugin_ports_0_cache_3_superPage;
-        _zz_233 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
-        _zz_234 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
-        _zz_235 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
-        _zz_236 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
-        _zz_237 = MmuPlugin_ports_0_cache_3_allowRead;
-        _zz_238 = MmuPlugin_ports_0_cache_3_allowWrite;
-        _zz_239 = MmuPlugin_ports_0_cache_3_allowExecute;
-        _zz_240 = MmuPlugin_ports_0_cache_3_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_87)
-      2'b00 : begin
-        _zz_241 = MmuPlugin_ports_1_cache_0_valid;
-        _zz_242 = MmuPlugin_ports_1_cache_0_exception;
-        _zz_243 = MmuPlugin_ports_1_cache_0_superPage;
-        _zz_244 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
-        _zz_245 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
-        _zz_246 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
-        _zz_247 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
-        _zz_248 = MmuPlugin_ports_1_cache_0_allowRead;
-        _zz_249 = MmuPlugin_ports_1_cache_0_allowWrite;
-        _zz_250 = MmuPlugin_ports_1_cache_0_allowExecute;
-        _zz_251 = MmuPlugin_ports_1_cache_0_allowUser;
-      end
-      2'b01 : begin
-        _zz_241 = MmuPlugin_ports_1_cache_1_valid;
-        _zz_242 = MmuPlugin_ports_1_cache_1_exception;
-        _zz_243 = MmuPlugin_ports_1_cache_1_superPage;
-        _zz_244 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
-        _zz_245 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
-        _zz_246 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
-        _zz_247 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
-        _zz_248 = MmuPlugin_ports_1_cache_1_allowRead;
-        _zz_249 = MmuPlugin_ports_1_cache_1_allowWrite;
-        _zz_250 = MmuPlugin_ports_1_cache_1_allowExecute;
-        _zz_251 = MmuPlugin_ports_1_cache_1_allowUser;
-      end
-      2'b10 : begin
-        _zz_241 = MmuPlugin_ports_1_cache_2_valid;
-        _zz_242 = MmuPlugin_ports_1_cache_2_exception;
-        _zz_243 = MmuPlugin_ports_1_cache_2_superPage;
-        _zz_244 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
-        _zz_245 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
-        _zz_246 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
-        _zz_247 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
-        _zz_248 = MmuPlugin_ports_1_cache_2_allowRead;
-        _zz_249 = MmuPlugin_ports_1_cache_2_allowWrite;
-        _zz_250 = MmuPlugin_ports_1_cache_2_allowExecute;
-        _zz_251 = MmuPlugin_ports_1_cache_2_allowUser;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       default : begin
-        _zz_241 = MmuPlugin_ports_1_cache_3_valid;
-        _zz_242 = MmuPlugin_ports_1_cache_3_exception;
-        _zz_243 = MmuPlugin_ports_1_cache_3_superPage;
-        _zz_244 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
-        _zz_245 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
-        _zz_246 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
-        _zz_247 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
-        _zz_248 = MmuPlugin_ports_1_cache_3_allowRead;
-        _zz_249 = MmuPlugin_ports_1_cache_3_allowWrite;
-        _zz_250 = MmuPlugin_ports_1_cache_3_allowExecute;
-        _zz_251 = MmuPlugin_ports_1_cache_3_allowUser;
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_MmuPlugin_ports_0_cacheLine_valid_3)
+      2'b00 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_0_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_0_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_0_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_0_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_0_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_0_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_0_allowUser;
+      end
+      2'b01 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_1_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_1_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_1_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_1_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_1_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_1_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_1_allowUser;
+      end
+      2'b10 : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_2_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_2_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_2_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_2_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_2_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_2_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_2_allowUser;
+      end
+      default : begin
+        _zz_MmuPlugin_ports_0_cacheLine_valid_4 = MmuPlugin_ports_0_cache_3_valid;
+        _zz_MmuPlugin_ports_0_cacheLine_exception = MmuPlugin_ports_0_cache_3_exception;
+        _zz_MmuPlugin_ports_0_cacheLine_superPage = MmuPlugin_ports_0_cache_3_superPage;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
+        _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
+        _zz_MmuPlugin_ports_0_cacheLine_allowRead = MmuPlugin_ports_0_cache_3_allowRead;
+        _zz_MmuPlugin_ports_0_cacheLine_allowWrite = MmuPlugin_ports_0_cache_3_allowWrite;
+        _zz_MmuPlugin_ports_0_cacheLine_allowExecute = MmuPlugin_ports_0_cache_3_allowExecute;
+        _zz_MmuPlugin_ports_0_cacheLine_allowUser = MmuPlugin_ports_0_cache_3_allowUser;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_MmuPlugin_ports_1_cacheLine_valid_3)
+      2'b00 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_0_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_0_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_0_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_0_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_0_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_0_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_0_allowUser;
+      end
+      2'b01 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_1_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_1_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_1_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_1_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_1_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_1_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_1_allowUser;
+      end
+      2'b10 : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_2_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_2_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_2_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_2_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_2_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_2_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_2_allowUser;
+      end
+      default : begin
+        _zz_MmuPlugin_ports_1_cacheLine_valid_4 = MmuPlugin_ports_1_cache_3_valid;
+        _zz_MmuPlugin_ports_1_cacheLine_exception = MmuPlugin_ports_1_cache_3_exception;
+        _zz_MmuPlugin_ports_1_cacheLine_superPage = MmuPlugin_ports_1_cache_3_superPage;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
+        _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
+        _zz_MmuPlugin_ports_1_cacheLine_allowRead = MmuPlugin_ports_1_cache_3_allowRead;
+        _zz_MmuPlugin_ports_1_cacheLine_allowWrite = MmuPlugin_ports_1_cache_3_allowWrite;
+        _zz_MmuPlugin_ports_1_cacheLine_allowExecute = MmuPlugin_ports_1_cache_3_allowExecute;
+        _zz_MmuPlugin_ports_1_cacheLine_allowUser = MmuPlugin_ports_1_cache_3_allowUser;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2354,30 +2391,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2390,116 +2427,116 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
-      default : _zz_10_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
-      default : _zz_15_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
-      default : _zz_18_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2512,30 +2549,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
-      default : _zz_21_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -2547,27 +2584,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
-      default : _zz_24_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2580,30 +2617,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
-      default : _zz_27_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2616,12 +2653,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2634,12 +2671,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2652,12 +2689,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_30_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_30_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_30_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_30_string = "ECALL";
-      default : _zz_30_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2670,48 +2707,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_31_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_31_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_31_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_31_string = "JALR";
-      default : _zz_31_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_35_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_35_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_35_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_35_string = "SRA_1    ";
-      default : _zz_35_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2724,12 +2761,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_37_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_37_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_37_string = "PC ";
-      default : _zz_37_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -2742,12 +2779,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_38_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_38_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_38_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_38_string = "URS1        ";
-      default : _zz_38_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2759,88 +2796,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_39_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_39_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_39_string = "BITWISE ";
-      default : _zz_39_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_40_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_40_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_40_string = "AND_1";
-      default : _zz_40_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_44_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44_string = "ECALL";
-      default : _zz_44_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_45_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_45_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_45_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_45_string = "JALR";
-      default : _zz_45_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46_string = "SRA_1    ";
-      default : _zz_46_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_47_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_47_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_47_string = "AND_1";
-      default : _zz_47_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_48_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_48_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_48_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_48_string = "PC ";
-      default : _zz_48_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_49_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_49_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_49_string = "BITWISE ";
-      default : _zz_49_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_50)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_50_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_50_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_50_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_50_string = "URS1        ";
-      default : _zz_50_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2854,64 +2891,64 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_103)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_103_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_103_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_103_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_103_string = "URS1        ";
-      default : _zz_103_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_104)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_104_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_104_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_104_string = "BITWISE ";
-      default : _zz_104_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_105)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_105_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_105_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_105_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_105_string = "PC ";
-      default : _zz_105_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_106)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_106_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_106_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_106_string = "AND_1";
-      default : _zz_106_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_107)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_107_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_107_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_107_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_107_string = "SRA_1    ";
-      default : _zz_107_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_108)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_108_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_108_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_108_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_108_string = "JALR";
-      default : _zz_108_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_109)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_109_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_109_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_109_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_109_string = "ECALL";
-      default : _zz_109_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2942,28 +2979,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -3005,48 +3042,48 @@ module VexRiscv (
   `endif
 
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_133;
-  assign execute_SHIFT_RIGHT = _zz_311;
-  assign execute_REGFILE_WRITE_DATA = _zz_111;
+  assign execute_BRANCH_DO = _zz_execute_BRANCH_DO_1;
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_202[1 : 0];
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_DIV = _zz_313[0];
-  assign decode_IS_RS2_SIGNED = _zz_314[0];
-  assign decode_IS_RS1_SIGNED = _zz_315[0];
-  assign decode_IS_MUL = _zz_316[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_317[0];
-  assign decode_BRANCH_CTRL = _zz_8;
-  assign _zz_9 = _zz_10;
-  assign _zz_11 = _zz_12;
-  assign decode_SHIFT_CTRL = _zz_13;
-  assign _zz_14 = _zz_15;
-  assign decode_ALU_BITWISE_CTRL = _zz_16;
-  assign _zz_17 = _zz_18;
-  assign decode_SRC_LESS_UNSIGNED = _zz_318[0];
-  assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
-  assign decode_IS_SFENCE_VMA = _zz_319[0];
-  assign decode_MEMORY_MANAGMENT = _zz_320[0];
+  assign decode_IS_DIV = _zz_decode_IS_DIV[35];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_DIV[34];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_DIV[33];
+  assign decode_IS_MUL = _zz_decode_IS_DIV[32];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_DIV[29];
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_DIV[22];
+  assign decode_IS_SFENCE_VMA = _zz_decode_IS_DIV[21];
+  assign decode_IS_SFENCE_VMA2 = _zz_decode_IS_DIV[20];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_DIV[19];
+  assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_321[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_DIV[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_322[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_323[0];
-  assign decode_SRC2_CTRL = _zz_19;
-  assign _zz_20 = _zz_21;
-  assign decode_ALU_CTRL = _zz_22;
-  assign _zz_23 = _zz_24;
-  assign decode_SRC1_CTRL = _zz_25;
-  assign _zz_26 = _zz_27;
-  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_52;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_DIV[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_DIV[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
@@ -3061,23 +3098,24 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_28;
-  assign execute_ENV_CTRL = _zz_29;
-  assign writeBack_ENV_CTRL = _zz_30;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
+  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_31;
-  assign decode_RS2_USE = _zz_324[0];
-  assign decode_RS1_USE = _zz_325[0];
-  always @ (*) begin
-    _zz_32 = execute_REGFILE_WRITE_DATA;
-    if(_zz_252)begin
-      _zz_32 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_DIV[17];
+  assign decode_RS1_USE = _zz_decode_IS_DIV[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
-    if(DBusCachedPlugin_forceDatapath)begin
-      _zz_32 = MmuPlugin_dBusAccess_cmd_payload_address;
+    if(DBusCachedPlugin_forceDatapath) begin
+      _zz_decode_RS2 = MmuPlugin_dBusAccess_cmd_payload_address;
     end
   end
 
@@ -3087,141 +3125,158 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_122)begin
-      if((_zz_123 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_124;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_253)begin
-      if(_zz_254)begin
-        if(_zz_126)begin
-          decode_RS2 = _zz_51;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_255)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_128)begin
-          decode_RS2 = _zz_33;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_256)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_130)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_122)begin
-      if((_zz_123 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_124;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_253)begin
-      if(_zz_254)begin
-        if(_zz_125)begin
-          decode_RS1 = _zz_51;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_255)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_127)begin
-          decode_RS1 = _zz_33;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_256)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_129)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_33 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_33 = _zz_119;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_33 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_257)begin
-      _zz_33 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    if(when_MulDivIterativePlugin_l96) begin
+      _zz_decode_RS2_1 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
     end
-    if(_zz_258)begin
-      _zz_33 = memory_MulDivIterativePlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_MulDivIterativePlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_34;
-  assign execute_SHIFT_CTRL = _zz_35;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_36 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_37;
-  assign execute_SRC1_CTRL = _zz_38;
-  assign decode_SRC_USE_SUB_LESS = _zz_326[0];
-  assign decode_SRC_ADD_ZERO = _zz_327[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_DIV[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_39;
-  assign execute_SRC2 = _zz_117;
-  assign execute_SRC1 = _zz_112;
-  assign execute_ALU_BITWISE_CTRL = _zz_40;
-  assign _zz_41 = writeBack_INSTRUCTION;
-  assign _zz_42 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_43 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_43 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_328[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_DIV[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_440) == 32'h00001073),{(_zz_441 == _zz_442),{_zz_443,{_zz_444,_zz_445}}}}}}} != 25'h0);
-  assign writeBack_IS_SFENCE_VMA = memory_to_writeBack_IS_SFENCE_VMA;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 25'h0);
+  assign execute_IS_SFENCE_VMA2 = decode_to_execute_IS_SFENCE_VMA2;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
-  always @ (*) begin
-    _zz_51 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_51 = writeBack_DBusCachedPlugin_rspFormated;
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  assign writeBack_MEMORY_LRSC = memory_to_writeBack_MEMORY_LRSC;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
-  assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  always @(*) begin
+    execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        execute_MEMORY_AMO = 1'b0;
+      end
+    end
+  end
+
+  always @(*) begin
+    execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        execute_MEMORY_LRSC = 1'b0;
+      end
+    end
+  end
+
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
@@ -3229,220 +3284,221 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_329[0];
-  assign decode_MEMORY_LRSC = _zz_330[0];
-  assign decode_MEMORY_ENABLE = _zz_331[0];
-  assign decode_FLUSH_ALL = _zz_332[0];
-  always @ (*) begin
+  assign decode_MEMORY_AMO = _zz_decode_IS_DIV[16];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_DIV[15];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_DIV[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_259)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_260)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_261)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_262)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_53 = execute_FORMAL_PC_NEXT;
-    if(CsrPlugin_redoInterface_valid)begin
-      _zz_53 = CsrPlugin_redoInterface_payload;
+  always @(*) begin
+    _zz_execute_to_memory_FORMAL_PC_NEXT = execute_FORMAL_PC_NEXT;
+    if(CsrPlugin_redoInterface_valid) begin
+      _zz_execute_to_memory_FORMAL_PC_NEXT = CsrPlugin_redoInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_54 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((decode_arbitration_isValid && (_zz_120 || _zz_121)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(CsrPlugin_pipelineLiberator_active) begin
+      decode_arbitration_haltByOther = 1'b1;
+    end
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_263)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(_zz_263)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_225 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_264)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_252)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeInstruction)begin
-        execute_arbitration_flushNext = 1'b1;
-      end
+    if(CsrPlugin_selfException_valid) begin
+      execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_257)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l97) begin
         memory_arbitration_haltItself = 1'b1;
       end
-      if(_zz_265)begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_258)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_266)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_267)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3451,51 +3507,53 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_266)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_267)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid) || IBusCachedPlugin_iBusRsp_stages_3_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_264)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_266)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_267)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_266)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_267)begin
-      case(_zz_268)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3511,59 +3569,65 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}} != 4'b0000);
-  assign _zz_55 = {CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_333));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_229;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_335);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -3572,66 +3636,78 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
   assign IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_3_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_3_halt = 1'b1;
     end
   end
 
-  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_3_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_3_input_ready = (IBusCachedPlugin_iBusRsp_stages_3_output_ready && _zz_63);
-  assign IBusCachedPlugin_iBusRsp_stages_3_output_valid = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && _zz_63);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_3_input_ready = (! IBusCachedPlugin_iBusRsp_stages_3_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_3_input_ready = (IBusCachedPlugin_iBusRsp_stages_3_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_3_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_3_output_valid = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_3_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_3_output_payload = IBusCachedPlugin_iBusRsp_stages_3_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_3_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_64;
-  assign _zz_64 = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_65 = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_67)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_67 = _zz_68;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_69;
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = ((1'b0 && (! _zz_70)) || IBusCachedPlugin_iBusRsp_stages_3_input_ready);
-  assign _zz_70 = _zz_71;
-  assign IBusCachedPlugin_iBusRsp_stages_3_input_valid = _zz_70;
-  assign IBusCachedPlugin_iBusRsp_stages_3_input_payload = _zz_72;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_3_input_valid = IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_3_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_3_input_payload = IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = ((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid) || IBusCachedPlugin_iBusRsp_stages_3_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! (! IBusCachedPlugin_iBusRsp_stages_3_input_ready));
+  assign when_Fetcher_l329_3 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_5 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
@@ -3639,87 +3715,93 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_193 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_194 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_195 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_194;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_2_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_197 = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_198 = (! IBusCachedPlugin_iBusRsp_stages_3_input_ready);
-  assign _zz_199 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_3_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_262)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_260)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_200 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_260)begin
-      _zz_200 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_261)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_259)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_261)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_259)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_3_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_3_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_3_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_3_output_payload;
-  assign _zz_192 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_226 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -3727,328 +3809,318 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  always @ (*) begin
-    _zz_52 = 1'b0;
-    if(decode_INSTRUCTION[25])begin
-      if(decode_MEMORY_LRSC)begin
-        _zz_52 = 1'b1;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  always @(*) begin
+    _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
+    if(when_DBusCachedPlugin_l311) begin
+      if(decode_MEMORY_LRSC) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
-      if(decode_MEMORY_AMO)begin
-        _zz_52 = 1'b1;
+      if(decode_MEMORY_AMO) begin
+        _zz_decode_MEMORY_FORCE_CONSTISTENCY = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l311 = decode_INSTRUCTION[25];
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
-    _zz_201 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        if(_zz_270)begin
-          _zz_201 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        if(when_DBusCachedPlugin_l499) begin
+          dataCache_1_io_cpu_execute_isValid = 1'b1;
         end
       end
     end
   end
 
-  always @ (*) begin
-    _zz_202 = execute_SRC_ADD;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        _zz_202 = MmuPlugin_dBusAccess_cmd_payload_address;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_address = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
   end
 
-  always @ (*) begin
-    _zz_203 = execute_MEMORY_WR;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        _zz_203 = MmuPlugin_dBusAccess_cmd_payload_write;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_wr = execute_MEMORY_WR;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_args_wr = 1'b0;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_75 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_75 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_75 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_204 = _zz_75;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        _zz_204 = MmuPlugin_dBusAccess_cmd_payload_data;
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_size = execute_DBusCachedPlugin_size;
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        dataCache_1_io_cpu_execute_args_size = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
-  always @ (*) begin
-    _zz_205 = execute_DBusCachedPlugin_size;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        _zz_205 = MmuPlugin_dBusAccess_cmd_payload_size;
-      end
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  always @(*) begin
+    dataCache_1_io_cpu_execute_args_isLrsc = 1'b0;
+    if(execute_MEMORY_LRSC) begin
+      dataCache_1_io_cpu_execute_args_isLrsc = 1'b1;
     end
   end
 
-  assign _zz_225 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  always @ (*) begin
-    _zz_206 = 1'b0;
-    if(execute_MEMORY_LRSC)begin
-      _zz_206 = 1'b1;
-    end
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        _zz_206 = 1'b0;
-      end
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_alu = execute_INSTRUCTION[31 : 29];
+  assign dataCache_1_io_cpu_execute_args_amoCtrl_swap = execute_INSTRUCTION[27];
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  always @(*) begin
+    dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+    if(memory_IS_DBUS_SHARING) begin
+      dataCache_1_io_cpu_memory_isValid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_207 = execute_MEMORY_AMO;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        _zz_207 = 1'b0;
-      end
-    end
-  end
-
-  assign _zz_209 = execute_INSTRUCTION[31 : 29];
-  assign _zz_208 = execute_INSTRUCTION[27];
-  always @ (*) begin
-    _zz_210 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-    if(memory_IS_DBUS_SHARING)begin
-      _zz_210 = 1'b1;
-    end
-  end
-
-  assign _zz_211 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_210;
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_211;
-  always @ (*) begin
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
+  always @(*) begin
     DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
-    if(memory_IS_DBUS_SHARING)begin
+    if(memory_IS_DBUS_SHARING) begin
       DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b1;
     end
   end
 
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_212 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_212 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_213 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-    if(writeBack_IS_DBUS_SHARING)begin
-      _zz_213 = 1'b1;
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_IS_DBUS_SHARING) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b1;
+    end
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
     end
   end
 
-  assign _zz_214 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_215 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_271)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_271)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_271)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_336};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_337};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_76 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_77[31] = _zz_76;
-    _zz_77[30] = _zz_76;
-    _zz_77[29] = _zz_76;
-    _zz_77[28] = _zz_76;
-    _zz_77[27] = _zz_76;
-    _zz_77[26] = _zz_76;
-    _zz_77[25] = _zz_76;
-    _zz_77[24] = _zz_76;
-    _zz_77[23] = _zz_76;
-    _zz_77[22] = _zz_76;
-    _zz_77[21] = _zz_76;
-    _zz_77[20] = _zz_76;
-    _zz_77[19] = _zz_76;
-    _zz_77[18] = _zz_76;
-    _zz_77[17] = _zz_76;
-    _zz_77[16] = _zz_76;
-    _zz_77[15] = _zz_76;
-    _zz_77[14] = _zz_76;
-    _zz_77[13] = _zz_76;
-    _zz_77[12] = _zz_76;
-    _zz_77[11] = _zz_76;
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+    if(when_DBusCachedPlugin_l474) begin
+      writeBack_DBusCachedPlugin_rspRf = {31'd0, _zz_writeBack_DBusCachedPlugin_rspRf};
+    end
   end
 
-  assign _zz_78 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_79[31] = _zz_78;
-    _zz_79[30] = _zz_78;
-    _zz_79[29] = _zz_78;
-    _zz_79[28] = _zz_78;
-    _zz_79[27] = _zz_78;
-    _zz_79[26] = _zz_78;
-    _zz_79[25] = _zz_78;
-    _zz_79[24] = _zz_78;
-    _zz_79[23] = _zz_78;
-    _zz_79[22] = _zz_78;
-    _zz_79[21] = _zz_78;
-    _zz_79[20] = _zz_78;
-    _zz_79[19] = _zz_78;
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign when_DBusCachedPlugin_l474 = (writeBack_MEMORY_LRSC && writeBack_MEMORY_WR);
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_308)
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
+  end
+
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_77;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_79;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  always @(*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
-        if(_zz_270)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
+        if(when_DBusCachedPlugin_l499) begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
-    if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_269)begin
+    if(MmuPlugin_dBusAccess_cmd_valid) begin
+      if(when_DBusCachedPlugin_l498) begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
+  assign when_DBusCachedPlugin_l498 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign when_DBusCachedPlugin_l499 = (! dataCache_1_io_cpu_execute_refilling);
   assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
-  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1_io_cpu_writeBack_data;
+  assign MmuPlugin_dBusAccess_rsp_payload_data = writeBack_DBusCachedPlugin_rspRf;
   assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1_io_cpu_writeBack_unalignedAccess || dataCache_1_io_cpu_writeBack_accessError);
   assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1_io_cpu_redo;
   assign MmuPlugin_ports_0_dirty = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+    if(when_MmuPlugin_l125) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
-    if((CsrPlugin_privilege == 2'b11))begin
+    if(when_MmuPlugin_l126) begin
       MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
     end
   end
 
-  always @ (*) begin
-    MmuPlugin_ports_0_cacheHitsCalc[0] = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[1] = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[2] = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_0_cacheHitsCalc[3] = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-  end
-
+  assign when_MmuPlugin_l125 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l126 = (CsrPlugin_privilege == 2'b11);
+  assign MmuPlugin_ports_0_cacheHitsCalc = {((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_0_cacheHitsCalc)) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_0_cacheHitsCalc_1))),{((MmuPlugin_ports_0_cache_1_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_2) && (MmuPlugin_ports_0_cache_1_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_3)),((MmuPlugin_ports_0_cache_0_valid && _zz_MmuPlugin_ports_0_cacheHitsCalc_4) && (MmuPlugin_ports_0_cache_0_superPage || _zz_MmuPlugin_ports_0_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_0_cacheHit = (MmuPlugin_ports_0_cacheHitsCalc != 4'b0000);
-  assign _zz_80 = MmuPlugin_ports_0_cacheHitsCalc[3];
-  assign _zz_81 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_80);
-  assign _zz_82 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_80);
-  assign _zz_83 = {_zz_82,_zz_81};
-  assign MmuPlugin_ports_0_cacheLine_valid = _zz_230;
-  assign MmuPlugin_ports_0_cacheLine_exception = _zz_231;
-  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_232;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_233;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_234;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_235;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_236;
-  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_237;
-  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_238;
-  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_239;
-  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_240;
-  always @ (*) begin
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_1 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_MmuPlugin_ports_0_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_2 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_MmuPlugin_ports_0_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_0_cacheLine_valid_3 = {_zz_MmuPlugin_ports_0_cacheLine_valid_2,_zz_MmuPlugin_ports_0_cacheLine_valid_1};
+  assign MmuPlugin_ports_0_cacheLine_valid = _zz_MmuPlugin_ports_0_cacheLine_valid_4;
+  assign MmuPlugin_ports_0_cacheLine_exception = _zz_MmuPlugin_ports_0_cacheLine_exception;
+  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_MmuPlugin_ports_0_cacheLine_superPage;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_0;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_MmuPlugin_ports_0_cacheLine_virtualAddress_1;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_0;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_MmuPlugin_ports_0_cacheLine_physicalAddress_1;
+  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_MmuPlugin_ports_0_cacheLine_allowRead;
+  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_MmuPlugin_ports_0_cacheLine_allowWrite;
+  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_MmuPlugin_ports_0_cacheLine_allowExecute;
+  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_MmuPlugin_ports_0_cacheLine_allowUser;
+  always @(*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(_zz_272)begin
-      if(_zz_273)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274) begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4057,63 +4129,63 @@ module VexRiscv (
   assign MmuPlugin_ports_0_entryToReplace_willClear = 1'b0;
   assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_0_entryToReplace_willOverflow = (MmuPlugin_ports_0_entryToReplace_willOverflowIfInc && MmuPlugin_ports_0_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_339);
-    if(MmuPlugin_ports_0_entryToReplace_willClear)begin
+  always @(*) begin
+    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_MmuPlugin_ports_0_entryToReplace_valueNext);
+    if(MmuPlugin_ports_0_entryToReplace_willClear) begin
       MmuPlugin_ports_0_entryToReplace_valueNext = 2'b00;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
       IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_0_dirty) && MmuPlugin_ports_0_cacheHit) && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_0_dirty || (! MmuPlugin_ports_0_cacheHit));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc) begin
       IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
@@ -4131,45 +4203,42 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_0_cacheHitsCalc[3];
   assign IBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_0_cache_3_physicalAddress_1,(MmuPlugin_ports_0_cache_3_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_3_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
   assign MmuPlugin_ports_1_dirty = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+    if(when_MmuPlugin_l125_1) begin
       MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
     end
-    if((CsrPlugin_privilege == 2'b11))begin
-      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11)))begin
+    if(when_MmuPlugin_l126_1) begin
+      if(when_MmuPlugin_l128) begin
         MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
       end
     end
   end
 
-  always @ (*) begin
-    MmuPlugin_ports_1_cacheHitsCalc[0] = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[1] = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[2] = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-    MmuPlugin_ports_1_cacheHitsCalc[3] = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
-  end
-
+  assign when_MmuPlugin_l125_1 = ((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11));
+  assign when_MmuPlugin_l126_1 = (CsrPlugin_privilege == 2'b11);
+  assign when_MmuPlugin_l128 = ((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11));
+  assign MmuPlugin_ports_1_cacheHitsCalc = {((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12]))),{((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == _zz_MmuPlugin_ports_1_cacheHitsCalc)) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == _zz_MmuPlugin_ports_1_cacheHitsCalc_1))),{((MmuPlugin_ports_1_cache_1_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_2) && (MmuPlugin_ports_1_cache_1_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_3)),((MmuPlugin_ports_1_cache_0_valid && _zz_MmuPlugin_ports_1_cacheHitsCalc_4) && (MmuPlugin_ports_1_cache_0_superPage || _zz_MmuPlugin_ports_1_cacheHitsCalc_5))}}};
   assign MmuPlugin_ports_1_cacheHit = (MmuPlugin_ports_1_cacheHitsCalc != 4'b0000);
-  assign _zz_84 = MmuPlugin_ports_1_cacheHitsCalc[3];
-  assign _zz_85 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_84);
-  assign _zz_86 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_84);
-  assign _zz_87 = {_zz_86,_zz_85};
-  assign MmuPlugin_ports_1_cacheLine_valid = _zz_241;
-  assign MmuPlugin_ports_1_cacheLine_exception = _zz_242;
-  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_243;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_244;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_245;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_246;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_247;
-  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_248;
-  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_249;
-  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_250;
-  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_251;
-  always @ (*) begin
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_1 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_MmuPlugin_ports_1_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_2 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_MmuPlugin_ports_1_cacheLine_valid);
+  assign _zz_MmuPlugin_ports_1_cacheLine_valid_3 = {_zz_MmuPlugin_ports_1_cacheLine_valid_2,_zz_MmuPlugin_ports_1_cacheLine_valid_1};
+  assign MmuPlugin_ports_1_cacheLine_valid = _zz_MmuPlugin_ports_1_cacheLine_valid_4;
+  assign MmuPlugin_ports_1_cacheLine_exception = _zz_MmuPlugin_ports_1_cacheLine_exception;
+  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_MmuPlugin_ports_1_cacheLine_superPage;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_0;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_MmuPlugin_ports_1_cacheLine_virtualAddress_1;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_0;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_MmuPlugin_ports_1_cacheLine_physicalAddress_1;
+  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_MmuPlugin_ports_1_cacheLine_allowRead;
+  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_MmuPlugin_ports_1_cacheLine_allowWrite;
+  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_MmuPlugin_ports_1_cacheLine_allowExecute;
+  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_MmuPlugin_ports_1_cacheLine_allowUser;
+  always @(*) begin
     MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(_zz_272)begin
-      if(_zz_274)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274_1) begin
         MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
       end
     end
@@ -4178,63 +4247,63 @@ module VexRiscv (
   assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
   assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_341);
-    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
+  always @(*) begin
+    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_MmuPlugin_ports_1_entryToReplace_valueNext);
+    if(MmuPlugin_ports_1_entryToReplace_willClear) begin
       MmuPlugin_ports_1_entryToReplace_valueNext = 2'b00;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
       DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_1_dirty) && MmuPlugin_ports_1_cacheHit) && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_1_dirty || (! MmuPlugin_ports_1_cacheHit));
     end else begin
       DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+  always @(*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc) begin
       DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
     end else begin
       DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
@@ -4251,20 +4320,21 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_1_cache_2_physicalAddress_1,(MmuPlugin_ports_1_cache_2_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_2_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
   assign DBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_1_cacheHitsCalc[3];
   assign DBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_1_cache_3_physicalAddress_1,(MmuPlugin_ports_1_cache_3_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_3_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
-  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_342[0];
-  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_343[0];
-  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_344[0];
-  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_345[0];
-  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_346[0];
-  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_347[0];
-  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_348[0];
-  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_349[0];
+  assign MmuPlugin_shared_dBusRsp_pte_V = MmuPlugin_shared_dBusRspStaged_payload_data[0];
+  assign MmuPlugin_shared_dBusRsp_pte_R = MmuPlugin_shared_dBusRspStaged_payload_data[1];
+  assign MmuPlugin_shared_dBusRsp_pte_W = MmuPlugin_shared_dBusRspStaged_payload_data[2];
+  assign MmuPlugin_shared_dBusRsp_pte_X = MmuPlugin_shared_dBusRspStaged_payload_data[3];
+  assign MmuPlugin_shared_dBusRsp_pte_U = MmuPlugin_shared_dBusRspStaged_payload_data[4];
+  assign MmuPlugin_shared_dBusRsp_pte_G = MmuPlugin_shared_dBusRspStaged_payload_data[5];
+  assign MmuPlugin_shared_dBusRsp_pte_A = MmuPlugin_shared_dBusRspStaged_payload_data[6];
+  assign MmuPlugin_shared_dBusRsp_pte_D = MmuPlugin_shared_dBusRspStaged_payload_data[7];
   assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_shared_dBusRspStaged_payload_data[9 : 8];
   assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_shared_dBusRspStaged_payload_data[19 : 10];
   assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
   assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
-  always @ (*) begin
+  assign when_MmuPlugin_l205 = (MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo));
+  always @(*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
@@ -4284,8 +4354,8 @@ module VexRiscv (
 
   assign MmuPlugin_dBusAccess_cmd_payload_write = 1'b0;
   assign MmuPlugin_dBusAccess_cmd_payload_size = 2'b10;
-  always @ (*) begin
-    MmuPlugin_dBusAccess_cmd_payload_address = 32'h0;
+  always @(*) begin
+    MmuPlugin_dBusAccess_cmd_payload_address = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
@@ -4302,86 +4372,97 @@ module VexRiscv (
     endcase
   end
 
-  assign MmuPlugin_dBusAccess_cmd_payload_data = 32'h0;
+  assign MmuPlugin_dBusAccess_cmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
   assign MmuPlugin_dBusAccess_cmd_payload_writeMask = 4'bxxxx;
-  always @ (*) begin
-    _zz_88[0] = (((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit));
-    _zz_88[1] = (((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit));
+  assign _zz_MmuPlugin_shared_refills = {(((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit)),(((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit))};
+  always @(*) begin
+    _zz_MmuPlugin_shared_refills_1[0] = _zz_MmuPlugin_shared_refills[1];
+    _zz_MmuPlugin_shared_refills_1[1] = _zz_MmuPlugin_shared_refills[0];
   end
 
-  assign _zz_89 = _zz_88;
-  always @ (*) begin
-    _zz_90[0] = _zz_89[1];
-    _zz_90[1] = _zz_89[0];
+  assign _zz_MmuPlugin_shared_refills_2 = (_zz_MmuPlugin_shared_refills_1 & (~ _zz__zz_MmuPlugin_shared_refills_2));
+  always @(*) begin
+    _zz_MmuPlugin_shared_refills_3[0] = _zz_MmuPlugin_shared_refills_2[1];
+    _zz_MmuPlugin_shared_refills_3[1] = _zz_MmuPlugin_shared_refills_2[0];
   end
 
-  assign _zz_91 = (_zz_90 & (~ _zz_350));
-  always @ (*) begin
-    _zz_92[0] = _zz_91[1];
-    _zz_92[1] = _zz_91[0];
-  end
-
-  assign MmuPlugin_shared_refills = _zz_92;
-  assign _zz_93 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign MmuPlugin_shared_refills = _zz_MmuPlugin_shared_refills_3;
+  assign when_MmuPlugin_l217 = (MmuPlugin_shared_refills != 2'b00);
+  assign _zz_MmuPlugin_shared_vpn_0 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign when_MmuPlugin_l243 = (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception);
   assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[0]);
   assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[1]);
-  assign _zz_95 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_96 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_97 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_98 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_99 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_100 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_101 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_102 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_94 = {(((decode_INSTRUCTION & _zz_463) == 32'h02004020) != 1'b0),{({_zz_102,_zz_101} != 2'b00),{({_zz_464,_zz_465} != 3'b000),{(_zz_466 != _zz_467),{_zz_468,{_zz_469,_zz_470}}}}}};
-  assign _zz_103 = _zz_94[2 : 1];
-  assign _zz_50 = _zz_103;
-  assign _zz_104 = _zz_94[7 : 6];
-  assign _zz_49 = _zz_104;
-  assign _zz_105 = _zz_94[9 : 8];
-  assign _zz_48 = _zz_105;
-  assign _zz_106 = _zz_94[23 : 22];
-  assign _zz_47 = _zz_106;
-  assign _zz_107 = _zz_94[25 : 24];
-  assign _zz_46 = _zz_107;
-  assign _zz_108 = _zz_94[27 : 26];
-  assign _zz_45 = _zz_108;
-  assign _zz_109 = _zz_94[30 : 29];
-  assign _zz_44 = _zz_109;
+  assign when_MmuPlugin_l272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign when_MmuPlugin_l274 = MmuPlugin_shared_portSortedOh[0];
+  assign when_MmuPlugin_l280 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l280_1 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l280_2 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l280_3 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l274_1 = MmuPlugin_shared_portSortedOh[1];
+  assign when_MmuPlugin_l280_4 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign when_MmuPlugin_l280_5 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign when_MmuPlugin_l280_6 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign when_MmuPlugin_l280_7 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign when_MmuPlugin_l304 = ((execute_arbitration_isValid && execute_arbitration_isFiring) && execute_IS_SFENCE_VMA2);
+  assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_decode_IS_DIV_6 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_decode_IS_DIV_7 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_decode_IS_DIV_8 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_decode_IS_DIV_9 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_decode_IS_DIV = {(((decode_INSTRUCTION & _zz__zz_decode_IS_DIV) == 32'h02004020) != 1'b0),{({_zz_decode_IS_DIV_9,_zz_decode_IS_DIV_8} != 2'b00),{({_zz__zz_decode_IS_DIV_1,_zz__zz_decode_IS_DIV_2} != 3'b000),{(_zz__zz_decode_IS_DIV_3 != _zz__zz_decode_IS_DIV_4),{_zz__zz_decode_IS_DIV_5,{_zz__zz_decode_IS_DIV_7,_zz__zz_decode_IS_DIV_10}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_DIV[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_DIV[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_DIV[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_DIV[24 : 23];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_DIV[26 : 25];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_DIV[28 : 27];
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_DIV[31 : 30];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_227;
-  assign decode_RegFilePlugin_rs2Data = _zz_228;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_42 && writeBack_arbitration_isFiring);
-    if(_zz_110)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_2) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_41[11 : 7];
-    if(_zz_110)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_51;
-    if(_zz_110)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -4390,362 +4471,385 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_111 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_111 = {31'd0, _zz_351};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_111 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_112 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_112 = {29'd0, _zz_352};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_112 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_112 = {27'd0, _zz_353};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_113 = _zz_354[11];
-  always @ (*) begin
-    _zz_114[19] = _zz_113;
-    _zz_114[18] = _zz_113;
-    _zz_114[17] = _zz_113;
-    _zz_114[16] = _zz_113;
-    _zz_114[15] = _zz_113;
-    _zz_114[14] = _zz_113;
-    _zz_114[13] = _zz_113;
-    _zz_114[12] = _zz_113;
-    _zz_114[11] = _zz_113;
-    _zz_114[10] = _zz_113;
-    _zz_114[9] = _zz_113;
-    _zz_114[8] = _zz_113;
-    _zz_114[7] = _zz_113;
-    _zz_114[6] = _zz_113;
-    _zz_114[5] = _zz_113;
-    _zz_114[4] = _zz_113;
-    _zz_114[3] = _zz_113;
-    _zz_114[2] = _zz_113;
-    _zz_114[1] = _zz_113;
-    _zz_114[0] = _zz_113;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_115 = _zz_355[11];
-  always @ (*) begin
-    _zz_116[19] = _zz_115;
-    _zz_116[18] = _zz_115;
-    _zz_116[17] = _zz_115;
-    _zz_116[16] = _zz_115;
-    _zz_116[15] = _zz_115;
-    _zz_116[14] = _zz_115;
-    _zz_116[13] = _zz_115;
-    _zz_116[12] = _zz_115;
-    _zz_116[11] = _zz_115;
-    _zz_116[10] = _zz_115;
-    _zz_116[9] = _zz_115;
-    _zz_116[8] = _zz_115;
-    _zz_116[7] = _zz_115;
-    _zz_116[6] = _zz_115;
-    _zz_116[5] = _zz_115;
-    _zz_116[4] = _zz_115;
-    _zz_116[3] = _zz_115;
-    _zz_116[2] = _zz_115;
-    _zz_116[1] = _zz_115;
-    _zz_116[0] = _zz_115;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_117 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_117 = {_zz_114,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_117 = {_zz_116,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_117 = _zz_36;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_356;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_118[0] = execute_SRC1[31];
-    _zz_118[1] = execute_SRC1[30];
-    _zz_118[2] = execute_SRC1[29];
-    _zz_118[3] = execute_SRC1[28];
-    _zz_118[4] = execute_SRC1[27];
-    _zz_118[5] = execute_SRC1[26];
-    _zz_118[6] = execute_SRC1[25];
-    _zz_118[7] = execute_SRC1[24];
-    _zz_118[8] = execute_SRC1[23];
-    _zz_118[9] = execute_SRC1[22];
-    _zz_118[10] = execute_SRC1[21];
-    _zz_118[11] = execute_SRC1[20];
-    _zz_118[12] = execute_SRC1[19];
-    _zz_118[13] = execute_SRC1[18];
-    _zz_118[14] = execute_SRC1[17];
-    _zz_118[15] = execute_SRC1[16];
-    _zz_118[16] = execute_SRC1[15];
-    _zz_118[17] = execute_SRC1[14];
-    _zz_118[18] = execute_SRC1[13];
-    _zz_118[19] = execute_SRC1[12];
-    _zz_118[20] = execute_SRC1[11];
-    _zz_118[21] = execute_SRC1[10];
-    _zz_118[22] = execute_SRC1[9];
-    _zz_118[23] = execute_SRC1[8];
-    _zz_118[24] = execute_SRC1[7];
-    _zz_118[25] = execute_SRC1[6];
-    _zz_118[26] = execute_SRC1[5];
-    _zz_118[27] = execute_SRC1[4];
-    _zz_118[28] = execute_SRC1[3];
-    _zz_118[29] = execute_SRC1[2];
-    _zz_118[30] = execute_SRC1[1];
-    _zz_118[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_118 : execute_SRC1);
-  always @ (*) begin
-    _zz_119[0] = memory_SHIFT_RIGHT[31];
-    _zz_119[1] = memory_SHIFT_RIGHT[30];
-    _zz_119[2] = memory_SHIFT_RIGHT[29];
-    _zz_119[3] = memory_SHIFT_RIGHT[28];
-    _zz_119[4] = memory_SHIFT_RIGHT[27];
-    _zz_119[5] = memory_SHIFT_RIGHT[26];
-    _zz_119[6] = memory_SHIFT_RIGHT[25];
-    _zz_119[7] = memory_SHIFT_RIGHT[24];
-    _zz_119[8] = memory_SHIFT_RIGHT[23];
-    _zz_119[9] = memory_SHIFT_RIGHT[22];
-    _zz_119[10] = memory_SHIFT_RIGHT[21];
-    _zz_119[11] = memory_SHIFT_RIGHT[20];
-    _zz_119[12] = memory_SHIFT_RIGHT[19];
-    _zz_119[13] = memory_SHIFT_RIGHT[18];
-    _zz_119[14] = memory_SHIFT_RIGHT[17];
-    _zz_119[15] = memory_SHIFT_RIGHT[16];
-    _zz_119[16] = memory_SHIFT_RIGHT[15];
-    _zz_119[17] = memory_SHIFT_RIGHT[14];
-    _zz_119[18] = memory_SHIFT_RIGHT[13];
-    _zz_119[19] = memory_SHIFT_RIGHT[12];
-    _zz_119[20] = memory_SHIFT_RIGHT[11];
-    _zz_119[21] = memory_SHIFT_RIGHT[10];
-    _zz_119[22] = memory_SHIFT_RIGHT[9];
-    _zz_119[23] = memory_SHIFT_RIGHT[8];
-    _zz_119[24] = memory_SHIFT_RIGHT[7];
-    _zz_119[25] = memory_SHIFT_RIGHT[6];
-    _zz_119[26] = memory_SHIFT_RIGHT[5];
-    _zz_119[27] = memory_SHIFT_RIGHT[4];
-    _zz_119[28] = memory_SHIFT_RIGHT[3];
-    _zz_119[29] = memory_SHIFT_RIGHT[2];
-    _zz_119[30] = memory_SHIFT_RIGHT[1];
-    _zz_119[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_120 = 1'b0;
-    if(_zz_275)begin
-      if(_zz_276)begin
-        if(_zz_125)begin
-          _zz_120 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_277)begin
-      if(_zz_278)begin
-        if(_zz_127)begin
-          _zz_120 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_279)begin
-      if(_zz_280)begin
-        if(_zz_129)begin
-          _zz_120 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_120 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_121 = 1'b0;
-    if(_zz_275)begin
-      if(_zz_276)begin
-        if(_zz_126)begin
-          _zz_121 = 1'b1;
-        end
-      end
-    end
-    if(_zz_277)begin
-      if(_zz_278)begin
-        if(_zz_128)begin
-          _zz_121 = 1'b1;
-        end
-      end
-    end
-    if(_zz_279)begin
-      if(_zz_280)begin
-        if(_zz_130)begin
-          _zz_121 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_121 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_125 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_126 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_127 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_128 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_129 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_130 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_131 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_131 == 3'b000)) begin
-        _zz_132 = execute_BranchPlugin_eq;
-    end else if((_zz_131 == 3'b001)) begin
-        _zz_132 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_131 & 3'b101) == 3'b101))) begin
-        _zz_132 = (! execute_SRC_LESS);
-    end else begin
-        _zz_132 = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_133 = 1'b0;
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_133 = 1'b1;
+      3'b001 : begin
+        _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_133 = 1'b1;
+      3'b1?1 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
-        _zz_133 = _zz_132;
+        _zz_execute_BRANCH_DO = execute_SRC_LESS;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : begin
+        _zz_execute_BRANCH_DO_1 = 1'b0;
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      default : begin
+        _zz_execute_BRANCH_DO_1 = _zz_execute_BRANCH_DO;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_134 = _zz_363[19];
-  always @ (*) begin
-    _zz_135[10] = _zz_134;
-    _zz_135[9] = _zz_134;
-    _zz_135[8] = _zz_134;
-    _zz_135[7] = _zz_134;
-    _zz_135[6] = _zz_134;
-    _zz_135[5] = _zz_134;
-    _zz_135[4] = _zz_134;
-    _zz_135[3] = _zz_134;
-    _zz_135[2] = _zz_134;
-    _zz_135[1] = _zz_134;
-    _zz_135[0] = _zz_134;
+  assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  assign _zz_136 = _zz_364[11];
-  always @ (*) begin
-    _zz_137[19] = _zz_136;
-    _zz_137[18] = _zz_136;
-    _zz_137[17] = _zz_136;
-    _zz_137[16] = _zz_136;
-    _zz_137[15] = _zz_136;
-    _zz_137[14] = _zz_136;
-    _zz_137[13] = _zz_136;
-    _zz_137[12] = _zz_136;
-    _zz_137[11] = _zz_136;
-    _zz_137[10] = _zz_136;
-    _zz_137[9] = _zz_136;
-    _zz_137[8] = _zz_136;
-    _zz_137[7] = _zz_136;
-    _zz_137[6] = _zz_136;
-    _zz_137[5] = _zz_136;
-    _zz_137[4] = _zz_136;
-    _zz_137[3] = _zz_136;
-    _zz_137[2] = _zz_136;
-    _zz_137[1] = _zz_136;
-    _zz_137[0] = _zz_136;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[19] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[18] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[17] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[16] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[15] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[14] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[13] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[12] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[11] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_138 = _zz_365[11];
-  always @ (*) begin
-    _zz_139[18] = _zz_138;
-    _zz_139[17] = _zz_138;
-    _zz_139[16] = _zz_138;
-    _zz_139[15] = _zz_138;
-    _zz_139[14] = _zz_138;
-    _zz_139[13] = _zz_138;
-    _zz_139[12] = _zz_138;
-    _zz_139[11] = _zz_138;
-    _zz_139[10] = _zz_138;
-    _zz_139[9] = _zz_138;
-    _zz_139[8] = _zz_138;
-    _zz_139[7] = _zz_138;
-    _zz_139[6] = _zz_138;
-    _zz_139[5] = _zz_138;
-    _zz_139[4] = _zz_138;
-    _zz_139[3] = _zz_138;
-    _zz_139[2] = _zz_138;
-    _zz_139[1] = _zz_138;
-    _zz_139[0] = _zz_138;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_140 = {{_zz_135,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_140 = {_zz_137,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_140 = {{_zz_139,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_140;
+  assign execute_BranchPlugin_branch_src2 = _zz_execute_BranchPlugin_branch_src2_6;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
-  always @ (*) begin
-    CsrPlugin_privilege = _zz_141;
-    if(CsrPlugin_forceMachineWire)begin
+  always @(*) begin
+    CsrPlugin_privilege = _zz_CsrPlugin_privilege;
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
@@ -4753,82 +4857,93 @@ module VexRiscv (
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeInstruction)begin
-        CsrPlugin_redoInterface_valid = 1'b1;
-      end
+    if(CsrPlugin_rescheduleLogic_rescheduleNext) begin
+      CsrPlugin_redoInterface_valid = 1'b1;
     end
   end
 
   assign CsrPlugin_redoInterface_payload = decode_PC;
-  assign _zz_142 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_143 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_144 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_145 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_146 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_147 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  always @ (*) begin
+  always @(*) begin
+    CsrPlugin_rescheduleLogic_rescheduleNext = 1'b0;
+    if(when_CsrPlugin_l803) begin
+      CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
+    end
+    if(execute_CsrPlugin_csr_384) begin
+      if(execute_CsrPlugin_writeInstruction) begin
+        CsrPlugin_rescheduleLogic_rescheduleNext = 1'b1;
+      end
+    end
+  end
+
+  assign when_CsrPlugin_l803 = (execute_arbitration_isValid && execute_IS_SFENCE_VMA);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_when_CsrPlugin_l952_3 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_4 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_5 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
       4'b0000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_1) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0010 : begin
-        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_2) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_3) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_4) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_5) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_6) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_7) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_8) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_9) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_10) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b1111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
+        if(when_CsrPlugin_l866_11) begin
           CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
@@ -4837,81 +4952,114 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l866 = ((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_1 = ((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_2 = ((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0));
+  assign when_CsrPlugin_l866_3 = ((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_4 = ((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_5 = ((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0));
+  assign when_CsrPlugin_l866_6 = ((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0));
+  assign when_CsrPlugin_l866_7 = ((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0));
+  assign when_CsrPlugin_l866_8 = ((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0));
+  assign when_CsrPlugin_l866_9 = ((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0));
+  assign when_CsrPlugin_l866_10 = ((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0));
+  assign when_CsrPlugin_l866_11 = ((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0));
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_148 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_149 = _zz_366[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_263)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign when_CsrPlugin_l946_1 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign when_CsrPlugin_l952_3 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign when_CsrPlugin_l952_4 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign when_CsrPlugin_l952_5 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign when_CsrPlugin_l952_6 = ((_zz_when_CsrPlugin_l952_3 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_7 = ((_zz_when_CsrPlugin_l952_4 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_8 = ((_zz_when_CsrPlugin_l952_5 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
@@ -4925,8 +5073,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
         CsrPlugin_xtvec_base = CsrPlugin_stvec_base;
@@ -4939,151 +5087,160 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_256)begin
+    if(execute_CsrPlugin_csr_256) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_384)begin
+    if(execute_CsrPlugin_csr_384) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_770)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_770) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_771)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_771) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_324)begin
+    if(execute_CsrPlugin_csr_324) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_260)begin
+    if(execute_CsrPlugin_csr_260) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_261)begin
+    if(execute_CsrPlugin_csr_261) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_321)begin
+    if(execute_CsrPlugin_csr_321) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_320)begin
+    if(execute_CsrPlugin_csr_320) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_322)begin
+    if(execute_CsrPlugin_csr_322) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_323)begin
+    if(execute_CsrPlugin_csr_323) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_2496)begin
+    if(execute_CsrPlugin_csr_2496) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3520)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3520) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_281)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_282)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_283)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_282)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_283)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5099,147 +5256,229 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_281)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_281)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  always @ (*) begin
-    execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-    if(execute_CsrPlugin_csr_836)begin
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  always @(*) begin
+    execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_readToWriteData[9 : 9] = CsrPlugin_sip_SEIP_SOFT;
     end
-    if(execute_CsrPlugin_csr_324)begin
+    if(execute_CsrPlugin_csr_324) begin
       execute_CsrPlugin_readToWriteData[9 : 9] = CsrPlugin_sip_SEIP_SOFT;
     end
   end
 
-  always @ (*) begin
-    case(_zz_309)
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || execute_IS_SFENCE_VMA));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_257)begin
-      if(_zz_265)begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l110) begin
       memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
     end
   end
 
   assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_369);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
-    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
+    if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end
   end
 
-  always @ (*) begin
+  assign when_MulDivIterativePlugin_l96 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign when_MulDivIterativePlugin_l97 = ((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign when_MulDivIterativePlugin_l100 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign when_MulDivIterativePlugin_l110 = (! memory_arbitration_isStuck);
+  always @(*) begin
     memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_258)begin
-      if(_zz_284)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_div_counter_willClear = 1'b0;
-    if(_zz_285)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_MulDivIterativePlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_MulDivIterativePlugin_div_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_div_counter_value == 6'h21);
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_377);
+      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
-    if(memory_MulDivIterativePlugin_div_counter_willClear)begin
+    if(memory_MulDivIterativePlugin_div_counter_willClear) begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_150 = memory_MulDivIterativePlugin_rs1[31 : 0];
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_150[31]};
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_378);
-  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_379 : _zz_380);
-  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_381[31:0];
-  assign _zz_151 = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
-  assign _zz_152 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_153 = ((execute_IS_MUL && _zz_152) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_154[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_154[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted = memory_MulDivIterativePlugin_rs1[31 : 0];
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31]};
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder : _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1);
+  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
+  assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
   end
 
-  assign _zz_156 = (_zz_155 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_156 != 32'h0);
-  assign _zz_158 = (_zz_157 & externalInterruptArray_regNext);
-  assign externalInterruptS = (_zz_158 != 32'h0);
-  assign _zz_27 = decode_SRC1_CTRL;
-  assign _zz_25 = _zz_50;
-  assign _zz_38 = decode_to_execute_SRC1_CTRL;
-  assign _zz_24 = decode_ALU_CTRL;
-  assign _zz_22 = _zz_49;
-  assign _zz_39 = decode_to_execute_ALU_CTRL;
-  assign _zz_21 = decode_SRC2_CTRL;
-  assign _zz_19 = _zz_48;
-  assign _zz_37 = decode_to_execute_SRC2_CTRL;
-  assign _zz_18 = decode_ALU_BITWISE_CTRL;
-  assign _zz_16 = _zz_47;
-  assign _zz_40 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_15 = decode_SHIFT_CTRL;
-  assign _zz_12 = execute_SHIFT_CTRL;
-  assign _zz_13 = _zz_46;
-  assign _zz_35 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_34 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_10 = decode_BRANCH_CTRL;
-  assign _zz_8 = _zz_45;
-  assign _zz_31 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_44;
-  assign _zz_29 = decode_to_execute_ENV_CTRL;
-  assign _zz_28 = execute_to_memory_ENV_CTRL;
-  assign _zz_30 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign _zz_CsrPlugin_csrMapping_readDataInit_3 = (_zz_CsrPlugin_csrMapping_readDataInit_2 & externalInterruptArray_regNext);
+  assign externalInterruptS = (_zz_CsrPlugin_csrMapping_readDataInit_3 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_36 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5260,269 +5499,307 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_159 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_159[12 : 0] = 13'h1000;
-      _zz_159[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_160 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_160[19 : 19] = MmuPlugin_status_mxr;
-      _zz_160[18 : 18] = MmuPlugin_status_sum;
-      _zz_160[17 : 17] = MmuPlugin_status_mprv;
-      _zz_160[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_160[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_160[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_160[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_160[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_160[1 : 1] = CsrPlugin_sstatus_SIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
-  always @ (*) begin
-    _zz_161 = 32'h0;
-    if(execute_CsrPlugin_csr_256)begin
-      _zz_161[19 : 19] = MmuPlugin_status_mxr;
-      _zz_161[18 : 18] = MmuPlugin_status_sum;
-      _zz_161[17 : 17] = MmuPlugin_status_mprv;
-      _zz_161[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_161[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_161[1 : 1] = CsrPlugin_sstatus_SIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_256) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[19 : 19] = MmuPlugin_status_mxr;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[18 : 18] = MmuPlugin_status_sum;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[17 : 17] = MmuPlugin_status_mprv;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
-  always @ (*) begin
-    _zz_162 = 32'h0;
-    if(execute_CsrPlugin_csr_384)begin
-      _zz_162[31 : 31] = MmuPlugin_satp_mode;
-      _zz_162[30 : 22] = MmuPlugin_satp_asid;
-      _zz_162[19 : 0] = MmuPlugin_satp_ppn;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_384) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = MmuPlugin_satp_mode;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[30 : 22] = MmuPlugin_satp_asid;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[19 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
-  always @ (*) begin
-    _zz_163 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_163[0 : 0] = 1'b1;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[0 : 0] = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_164[1 : 0] = 2'b10;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[1 : 0] = 2'b10;
     end
   end
 
-  always @ (*) begin
-    _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_165[1 : 0] = 2'b11;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = 2'b11;
     end
   end
 
-  always @ (*) begin
-    _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_166[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_166[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_166[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_166[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_166[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_166[9 : 9] = CsrPlugin_sip_SEIP_OR;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_11[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
-  always @ (*) begin
-    _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_167[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_167[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_167[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_167[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_167[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_167[1 : 1] = CsrPlugin_sie_SSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_12[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_168[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_169[31 : 0] = CsrPlugin_mscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_170[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_170[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_171[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_324)begin
-      _zz_172[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_172[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_172[9 : 9] = CsrPlugin_sip_SEIP_OR;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_324) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_17[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
-  always @ (*) begin
-    _zz_173 = 32'h0;
-    if(execute_CsrPlugin_csr_260)begin
-      _zz_173[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_173[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_173[1 : 1] = CsrPlugin_sie_SSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_260) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_18[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_174 = 32'h0;
-    if(execute_CsrPlugin_csr_261)begin
-      _zz_174[31 : 2] = CsrPlugin_stvec_base;
-      _zz_174[1 : 0] = CsrPlugin_stvec_mode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_261) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 2] = CsrPlugin_stvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_19[1 : 0] = CsrPlugin_stvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_175 = 32'h0;
-    if(execute_CsrPlugin_csr_321)begin
-      _zz_175[31 : 0] = CsrPlugin_sepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_321) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_sepc;
     end
   end
 
-  always @ (*) begin
-    _zz_176 = 32'h0;
-    if(execute_CsrPlugin_csr_320)begin
-      _zz_176[31 : 0] = CsrPlugin_sscratch;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_320) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_177 = 32'h0;
-    if(execute_CsrPlugin_csr_322)begin
-      _zz_177[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_177[3 : 0] = CsrPlugin_scause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_322) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_22[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_178 = 32'h0;
-    if(execute_CsrPlugin_csr_323)begin
-      _zz_178[31 : 0] = CsrPlugin_stval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_323) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = CsrPlugin_stval;
     end
   end
 
-  always @ (*) begin
-    _zz_179 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_179[31 : 0] = _zz_155;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_180 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_180[31 : 0] = _zz_156;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_25[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  always @ (*) begin
-    _zz_181 = 32'h0;
-    if(execute_CsrPlugin_csr_2496)begin
-      _zz_181[31 : 0] = _zz_157;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_26 = 32'h0;
+    if(execute_CsrPlugin_csr_2496) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_26[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_2;
     end
   end
 
-  always @ (*) begin
-    _zz_182 = 32'h0;
-    if(execute_CsrPlugin_csr_3520)begin
-      _zz_182[31 : 0] = _zz_158;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_27 = 32'h0;
+    if(execute_CsrPlugin_csr_3520) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_27[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_3;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_159 | _zz_160) | (_zz_161 | _zz_162)) | ((_zz_163 | _zz_164) | (_zz_165 | _zz_653))) | (((_zz_166 | _zz_167) | (_zz_168 | _zz_169)) | ((_zz_170 | _zz_171) | (_zz_172 | _zz_173)))) | ((((_zz_174 | _zz_175) | (_zz_176 | _zz_177)) | ((_zz_178 | _zz_179) | (_zz_180 | _zz_181))) | _zz_182));
-  assign iBusWishbone_ADR = {_zz_436,_zz_183};
-  assign iBusWishbone_CTI = ((_zz_183 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5) | (_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7)) | ((_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_28))) | (((_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12) | (_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14)) | ((_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16) | (_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20) | (_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22)) | ((_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24) | (_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26))) | _zz_CsrPlugin_csrMapping_readDataInit_27));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_286)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_286)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_184;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_190 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_186 = dBus_cmd_valid;
-  assign _zz_188 = dBus_cmd_payload_wr;
-  assign _zz_189 = (_zz_185 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_187 && (_zz_188 || _zz_189));
-  assign dBusWishbone_ADR = ((_zz_190 ? {{dBus_cmd_payload_address[31 : 5],_zz_185},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_190 ? (_zz_189 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_188 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_188;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_187 = (_zz_186 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_186;
-  assign dBusWishbone_STB = _zz_186;
-  assign dBus_rsp_valid = _zz_191;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_66 <= 1'b0;
-      _zz_68 <= 1'b0;
-      _zz_71 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_5 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_73;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_74;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
@@ -5540,9 +5817,9 @@ module VexRiscv (
       MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
       MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
       MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
-      _zz_110 <= 1'b1;
-      _zz_122 <= 1'b0;
-      _zz_141 <= 2'b11;
+      _zz_2 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
+      _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -5586,219 +5863,219 @@ module VexRiscv (
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
       memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_155 <= 32'h0;
-      _zz_157 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit_2 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
-      _zz_183 <= 3'b000;
-      _zz_184 <= 1'b0;
-      _zz_185 <= 3'b000;
-      _zz_191 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_66 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_64)begin
-        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_68 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_68 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_71 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_2_output_ready)begin
-        _zz_71 <= (IBusCachedPlugin_iBusRsp_stages_2_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_2_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_2_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_3_input_ready)))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_5 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_5) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_5 <= IBusCachedPlugin_injector_nextPcCalc_valids_4;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_5 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_287)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
       MmuPlugin_ports_0_entryToReplace_value <= MmuPlugin_ports_0_entryToReplace_valueNext;
-      if(contextSwitching)begin
-        if(MmuPlugin_ports_0_cache_0_exception)begin
+      if(contextSwitching) begin
+        if(MmuPlugin_ports_0_cache_0_exception) begin
           MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_1_exception)begin
+        if(MmuPlugin_ports_0_cache_1_exception) begin
           MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_2_exception)begin
+        if(MmuPlugin_ports_0_cache_2_exception) begin
           MmuPlugin_ports_0_cache_2_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_0_cache_3_exception)begin
+        if(MmuPlugin_ports_0_cache_3_exception) begin
           MmuPlugin_ports_0_cache_3_valid <= 1'b0;
         end
       end
       MmuPlugin_ports_1_entryToReplace_value <= MmuPlugin_ports_1_entryToReplace_valueNext;
-      if(contextSwitching)begin
-        if(MmuPlugin_ports_1_cache_0_exception)begin
+      if(contextSwitching) begin
+        if(MmuPlugin_ports_1_cache_0_exception) begin
           MmuPlugin_ports_1_cache_0_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_1_exception)begin
+        if(MmuPlugin_ports_1_cache_1_exception) begin
           MmuPlugin_ports_1_cache_1_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_2_exception)begin
+        if(MmuPlugin_ports_1_cache_2_exception) begin
           MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         end
-        if(MmuPlugin_ports_1_cache_3_exception)begin
+        if(MmuPlugin_ports_1_cache_3_exception) begin
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
       end
       MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
       case(MmuPlugin_shared_state_1)
         `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-          if(_zz_288)begin
+          if(when_MmuPlugin_l217) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
-          if(MmuPlugin_dBusAccess_cmd_ready)begin
+          if(MmuPlugin_dBusAccess_cmd_ready) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
-          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+          if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
-            if((MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception))begin
+            if(when_MmuPlugin_l243) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
             end
-            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
             end
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
-          if(MmuPlugin_dBusAccess_cmd_ready)begin
+          if(MmuPlugin_dBusAccess_cmd_ready) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
           end
         end
         default : begin
-          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+          if(MmuPlugin_shared_dBusRspStaged_valid) begin
             MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo) begin
               MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             end
           end
         end
       endcase
-      if(_zz_272)begin
-        if(_zz_273)begin
-          if(_zz_289)begin
+      if(when_MmuPlugin_l272) begin
+        if(when_MmuPlugin_l274) begin
+          if(when_MmuPlugin_l280) begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(_zz_290)begin
+          if(when_MmuPlugin_l280_1) begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(_zz_291)begin
+          if(when_MmuPlugin_l280_2) begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(_zz_292)begin
+          if(when_MmuPlugin_l280_3) begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(_zz_274)begin
-          if(_zz_293)begin
+        if(when_MmuPlugin_l274_1) begin
+          if(when_MmuPlugin_l280_4) begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(_zz_294)begin
+          if(when_MmuPlugin_l280_5) begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(_zz_295)begin
+          if(when_MmuPlugin_l280_6) begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(_zz_296)begin
+          if(when_MmuPlugin_l280_7) begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
       end
-      if((writeBack_arbitration_isValid && writeBack_IS_SFENCE_VMA))begin
+      if(when_MmuPlugin_l304) begin
         MmuPlugin_ports_0_cache_0_valid <= 1'b0;
         MmuPlugin_ports_0_cache_1_valid <= 1'b0;
         MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -5808,83 +6085,83 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_110 <= 1'b0;
-      _zz_122 <= (_zz_42 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_2 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_297)begin
-        if(_zz_298)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_299)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_300)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(_zz_301)begin
-        if(_zz_302)begin
+      if(when_CsrPlugin_l946_1) begin
+        if(when_CsrPlugin_l952_3) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_303)begin
+        if(when_CsrPlugin_l952_4) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_304)begin
+        if(when_CsrPlugin_l952_5) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_305)begin
+        if(when_CsrPlugin_l952_6) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_306)begin
+        if(when_CsrPlugin_l952_7) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_307)begin
+        if(when_CsrPlugin_l952_8) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_266)begin
-        _zz_141 <= CsrPlugin_targetPrivilege;
+      if(when_CsrPlugin_l1019) begin
+        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b01 : begin
             CsrPlugin_sstatus_SIE <= 1'b0;
@@ -5900,79 +6177,83 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_267)begin
-        case(_zz_268)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_141 <= CsrPlugin_mstatus_MPP;
+            _zz_CsrPlugin_privilege <= CsrPlugin_mstatus_MPP;
           end
           2'b01 : begin
             CsrPlugin_sstatus_SPP <= 1'b0;
             CsrPlugin_sstatus_SIE <= CsrPlugin_sstatus_SPIE;
             CsrPlugin_sstatus_SPIE <= 1'b1;
-            _zz_141 <= {1'b0,CsrPlugin_sstatus_SPP};
+            _zz_CsrPlugin_privilege <= {1'b0,CsrPlugin_sstatus_SPP};
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_147,{_zz_146,{_zz_145,{_zz_144,{_zz_143,_zz_142}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_5,{_zz_when_CsrPlugin_l952_4,{_zz_when_CsrPlugin_l952_3,{_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
-      if((! memory_arbitration_isStuck))begin
+      if(when_Pipeline_l124_55) begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Pipeline_l124_56) begin
         memory_to_writeBack_IS_DBUS_SHARING <= memory_IS_DBUS_SHARING;
       end
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(MmuPlugin_dBusAccess_rsp_valid)begin
+      if(MmuPlugin_dBusAccess_rsp_valid) begin
         memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_391[0];
-          MmuPlugin_status_sum <= _zz_392[0];
-          MmuPlugin_status_mprv <= _zz_393[0];
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_394[0];
-          CsrPlugin_mstatus_MIE <= _zz_395[0];
-          CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_396[0];
-          CsrPlugin_sstatus_SIE <= _zz_397[0];
+      if(MmuPlugin_dBusAccess_rsp_valid) begin
+        memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
+      end
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_status_mxr <= CsrPlugin_csrMapping_writeDataSignal[19];
+          MmuPlugin_status_sum <= CsrPlugin_csrMapping_writeDataSignal[18];
+          MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          CsrPlugin_sstatus_SPP <= CsrPlugin_csrMapping_writeDataSignal[8 : 8];
+          CsrPlugin_sstatus_SPIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sstatus_SIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_256)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_398[0];
-          MmuPlugin_status_sum <= _zz_399[0];
-          MmuPlugin_status_mprv <= _zz_400[0];
-          CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_401[0];
-          CsrPlugin_sstatus_SIE <= _zz_402[0];
+      if(execute_CsrPlugin_csr_256) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_status_mxr <= CsrPlugin_csrMapping_writeDataSignal[19];
+          MmuPlugin_status_sum <= CsrPlugin_csrMapping_writeDataSignal[18];
+          MmuPlugin_status_mprv <= CsrPlugin_csrMapping_writeDataSignal[17];
+          CsrPlugin_sstatus_SPP <= CsrPlugin_csrMapping_writeDataSignal[8 : 8];
+          CsrPlugin_sstatus_SPIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sstatus_SIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_384)begin
-        if(execute_CsrPlugin_writeInstruction)begin
+      if(execute_CsrPlugin_csr_384) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          MmuPlugin_satp_mode <= CsrPlugin_csrMapping_writeDataSignal[31];
           MmuPlugin_ports_0_cache_0_valid <= 1'b0;
           MmuPlugin_ports_0_cache_1_valid <= 1'b0;
           MmuPlugin_ports_0_cache_2_valid <= 1'b0;
@@ -5982,125 +6263,122 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_valid <= 1'b0;
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
-        if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_satp_mode <= _zz_403[0];
+      end
+      if(execute_CsrPlugin_csr_836) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sip_STIP <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sip_SSIP <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_sip_SEIP_SOFT <= CsrPlugin_csrMapping_writeDataSignal[9];
         end
       end
-      if(execute_CsrPlugin_csr_836)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_405[0];
-          CsrPlugin_sip_SSIP <= _zz_406[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_407[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          CsrPlugin_sie_SEIE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_sie_STIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sie_SSIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_408[0];
-          CsrPlugin_mie_MTIE <= _zz_409[0];
-          CsrPlugin_mie_MSIE <= _zz_410[0];
-          CsrPlugin_sie_SEIE <= _zz_411[0];
-          CsrPlugin_sie_STIE <= _zz_412[0];
-          CsrPlugin_sie_SSIE <= _zz_413[0];
+      if(execute_CsrPlugin_csr_770) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_medeleg_IAM <= CsrPlugin_csrMapping_writeDataSignal[0];
+          CsrPlugin_medeleg_IAF <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_medeleg_II <= CsrPlugin_csrMapping_writeDataSignal[2];
+          CsrPlugin_medeleg_LAM <= CsrPlugin_csrMapping_writeDataSignal[4];
+          CsrPlugin_medeleg_LAF <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_medeleg_SAM <= CsrPlugin_csrMapping_writeDataSignal[6];
+          CsrPlugin_medeleg_SAF <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_medeleg_EU <= CsrPlugin_csrMapping_writeDataSignal[8];
+          CsrPlugin_medeleg_ES <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_medeleg_IPF <= CsrPlugin_csrMapping_writeDataSignal[12];
+          CsrPlugin_medeleg_LPF <= CsrPlugin_csrMapping_writeDataSignal[13];
+          CsrPlugin_medeleg_SPF <= CsrPlugin_csrMapping_writeDataSignal[15];
         end
       end
-      if(execute_CsrPlugin_csr_770)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_medeleg_IAM <= _zz_414[0];
-          CsrPlugin_medeleg_IAF <= _zz_415[0];
-          CsrPlugin_medeleg_II <= _zz_416[0];
-          CsrPlugin_medeleg_LAM <= _zz_417[0];
-          CsrPlugin_medeleg_LAF <= _zz_418[0];
-          CsrPlugin_medeleg_SAM <= _zz_419[0];
-          CsrPlugin_medeleg_SAF <= _zz_420[0];
-          CsrPlugin_medeleg_EU <= _zz_421[0];
-          CsrPlugin_medeleg_ES <= _zz_422[0];
-          CsrPlugin_medeleg_IPF <= _zz_423[0];
-          CsrPlugin_medeleg_LPF <= _zz_424[0];
-          CsrPlugin_medeleg_SPF <= _zz_425[0];
+      if(execute_CsrPlugin_csr_771) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mideleg_SE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_mideleg_ST <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_mideleg_SS <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_771)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mideleg_SE <= _zz_426[0];
-          CsrPlugin_mideleg_ST <= _zz_427[0];
-          CsrPlugin_mideleg_SS <= _zz_428[0];
+      if(execute_CsrPlugin_csr_324) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sip_STIP <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sip_SSIP <= CsrPlugin_csrMapping_writeDataSignal[1];
+          CsrPlugin_sip_SEIP_SOFT <= CsrPlugin_csrMapping_writeDataSignal[9];
         end
       end
-      if(execute_CsrPlugin_csr_324)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_429[0];
-          CsrPlugin_sip_SSIP <= _zz_430[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_431[0];
+      if(execute_CsrPlugin_csr_260) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_sie_SEIE <= CsrPlugin_csrMapping_writeDataSignal[9];
+          CsrPlugin_sie_STIE <= CsrPlugin_csrMapping_writeDataSignal[5];
+          CsrPlugin_sie_SSIE <= CsrPlugin_csrMapping_writeDataSignal[1];
         end
       end
-      if(execute_CsrPlugin_csr_260)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sie_SEIE <= _zz_432[0];
-          CsrPlugin_sie_STIE <= _zz_433[0];
-          CsrPlugin_sie_SSIE <= _zz_434[0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_155 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_2496) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_2496)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_157 <= execute_CsrPlugin_writeData[31 : 0];
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      if(_zz_286)begin
-        if(iBusWishbone_ACK)begin
-          _zz_183 <= (_zz_183 + 3'b001);
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
         end
       end
-      _zz_184 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_186 && _zz_187))begin
-        _zz_185 <= (_zz_185 + 3'b001);
-        if(_zz_189)begin
-          _zz_185 <= 3'b000;
-        end
-      end
-      _zz_191 <= ((_zz_186 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_69 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_output_ready)begin
-      _zz_72 <= IBusCachedPlugin_iBusRsp_stages_2_output_payload;
+    if(IBusCachedPlugin_iBusRsp_stages_2_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_2_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_2_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_3_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_3_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_287)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
     MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
     MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
     MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
-    if((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)))begin
+    if(when_MmuPlugin_l205) begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -6115,10 +6393,10 @@ module VexRiscv (
     end
     case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-        if(_zz_288)begin
+        if(when_MmuPlugin_l217) begin
           MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
-          MmuPlugin_shared_vpn_1 <= _zz_93[31 : 22];
-          MmuPlugin_shared_vpn_0 <= _zz_93[21 : 12];
+          MmuPlugin_shared_vpn_1 <= _zz_MmuPlugin_shared_vpn_0[31 : 22];
+          MmuPlugin_shared_vpn_0 <= _zz_MmuPlugin_shared_vpn_0[21 : 12];
         end
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -6130,9 +6408,9 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(_zz_272)begin
-      if(_zz_273)begin
-        if(_zz_289)begin
+    if(when_MmuPlugin_l272) begin
+      if(when_MmuPlugin_l274) begin
+        if(when_MmuPlugin_l280) begin
           MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6144,7 +6422,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_290)begin
+        if(when_MmuPlugin_l280_1) begin
           MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6156,7 +6434,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_291)begin
+        if(when_MmuPlugin_l280_2) begin
           MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6168,7 +6446,7 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_292)begin
+        if(when_MmuPlugin_l280_3) begin
           MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6181,8 +6459,8 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
-      if(_zz_274)begin
-        if(_zz_293)begin
+      if(when_MmuPlugin_l274_1) begin
+        if(when_MmuPlugin_l280_4) begin
           MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6194,7 +6472,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_294)begin
+        if(when_MmuPlugin_l280_5) begin
           MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6206,7 +6484,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_295)begin
+        if(when_MmuPlugin_l280_6) begin
           MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6218,7 +6496,7 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
           MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_296)begin
+        if(when_MmuPlugin_l280_7) begin
           MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
@@ -6232,79 +6510,79 @@ module VexRiscv (
         end
       end
     end
-    _zz_123 <= _zz_41[11 : 7];
-    _zz_124 <= _zz_51;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_sip_SEIP_INPUT <= externalInterruptS;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_263)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_297)begin
-      if(_zz_298)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_299)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_300)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(_zz_301)begin
-      if(_zz_302)begin
+    if(when_CsrPlugin_l946_1) begin
+      if(when_CsrPlugin_l952_3) begin
         CsrPlugin_interrupt_code <= 4'b0101;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_303)begin
+      if(when_CsrPlugin_l952_4) begin
         CsrPlugin_interrupt_code <= 4'b0001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_304)begin
+      if(when_CsrPlugin_l952_5) begin
         CsrPlugin_interrupt_code <= 4'b1001;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_305)begin
+      if(when_CsrPlugin_l952_6) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_306)begin
+      if(when_CsrPlugin_l952_7) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_307)begin
+      if(when_CsrPlugin_l952_8) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_266)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b01 : begin
           CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_scause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_sepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_stval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -6312,7 +6590,7 @@ module VexRiscv (
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -6320,347 +6598,350 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_257)begin
-      if(_zz_265)begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_370,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
-    if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_MulDivIterativePlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_MulDivIterativePlugin_div_done <= 1'b0;
     end
-    if(_zz_258)begin
-      if(_zz_284)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_MulDivIterativePlugin_rs1[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outNumerator;
         memory_MulDivIterativePlugin_accumulator[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outRemainder;
-        if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
-          memory_MulDivIterativePlugin_div_result <= _zz_382[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_MulDivIterativePlugin_div_result <= _zz_memory_MulDivIterativePlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_285)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_153 ? (~ _zz_154) : _zz_154) + _zz_388);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_152 ? (~ execute_RS2) : execute_RS2) + _zz_390);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_153 ^ (_zz_152 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_36;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_6) begin
       decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_7) begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_execute_to_memory_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_26;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_23;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_20;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
+      execute_to_memory_MEMORY_LRSC <= execute_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_28) begin
+      memory_to_writeBack_MEMORY_LRSC <= memory_MEMORY_LRSC;
+    end
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_30) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_IS_SFENCE_VMA2 <= decode_IS_SFENCE_VMA2;
+    end
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_17;
+    if(when_Pipeline_l124_34) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_14;
+    if(when_Pipeline_l124_35) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_11;
+    if(when_Pipeline_l124_36) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_9;
+    if(when_Pipeline_l124_37) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_39) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_40) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_41) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_53) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_54) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_57) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_33;
+    if(when_Pipeline_l124_58) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_384 <= (decode_INSTRUCTION[31 : 20] == 12'h180);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_770 <= (decode_INSTRUCTION[31 : 20] == 12'h302);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_771 <= (decode_INSTRUCTION[31 : 20] == 12'h303);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_324 <= (decode_INSTRUCTION[31 : 20] == 12'h144);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_260 <= (decode_INSTRUCTION[31 : 20] == 12'h104);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_261 <= (decode_INSTRUCTION[31 : 20] == 12'h105);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_321 <= (decode_INSTRUCTION[31 : 20] == 12'h141);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_320 <= (decode_INSTRUCTION[31 : 20] == 12'h140);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_322 <= (decode_INSTRUCTION[31 : 20] == 12'h142);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_323 <= (decode_INSTRUCTION[31 : 20] == 12'h143);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_24) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_25) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_26) begin
       execute_CsrPlugin_csr_2496 <= (decode_INSTRUCTION[31 : 20] == 12'h9c0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_27) begin
       execute_CsrPlugin_csr_3520 <= (decode_INSTRUCTION[31 : 20] == 12'hdc0);
     end
-    if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        MmuPlugin_satp_asid <= execute_CsrPlugin_writeData[30 : 22];
-        MmuPlugin_satp_ppn <= execute_CsrPlugin_writeData[19 : 0];
+    if(execute_CsrPlugin_csr_384) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        MmuPlugin_satp_asid <= CsrPlugin_csrMapping_writeDataSignal[30 : 22];
+        MmuPlugin_satp_ppn <= CsrPlugin_csrMapping_writeDataSignal[19 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_404[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_261)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_stvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_stvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_261) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_stvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_stvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_321)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_sepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_321) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_sepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_320)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_sscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_320) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_sscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_322)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_scause_interrupt <= _zz_435[0];
-        CsrPlugin_scause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_322) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_scause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_scause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_323)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_stval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_323) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_stval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -6673,9 +6954,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_isLrsc,
   input               io_cpu_execute_args_isAmo,
@@ -6709,6 +6989,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -6724,9 +7005,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6734,7 +7016,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -6743,38 +7025,23 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire                _zz_19;
-  wire                _zz_20;
-  wire                _zz_21;
-  wire                _zz_22;
-  wire       [2:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [0:0]    _zz_25;
-  wire       [9:0]    _zz_26;
-  wire       [9:0]    _zz_27;
-  wire       [31:0]   _zz_28;
-  wire       [31:0]   _zz_29;
-  wire       [31:0]   _zz_30;
-  wire       [31:0]   _zz_31;
-  wire       [1:0]    _zz_32;
-  wire       [31:0]   _zz_33;
-  wire       [1:0]    _zz_34;
-  wire       [1:0]    _zz_35;
-  wire       [0:0]    _zz_36;
-  wire       [0:0]    _zz_37;
-  wire       [0:0]    _zz_38;
-  wire       [2:0]    _zz_39;
-  wire       [1:0]    _zz_40;
-  wire       [21:0]   _zz_41;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [31:0]   _zz_stageB_amo_addSub;
+  wire       [31:0]   _zz_stageB_amo_addSub_1;
+  wire       [31:0]   _zz_stageB_amo_addSub_2;
+  wire       [31:0]   _zz_stageB_amo_addSub_3;
+  wire       [31:0]   _zz_stageB_amo_addSub_4;
+  wire       [1:0]    _zz_stageB_amo_addSub_5;
+  wire       [1:0]    _zz_stageB_amo_addSub_6;
+  wire       [1:0]    _zz_stageB_amo_addSub_7;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -6799,38 +7066,45 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_isLrsc;
   reg                 stageA_request_isAmo;
   reg                 stageA_request_amoCtrl_swap;
   reg        [2:0]    stageA_request_amoCtrl_alu;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_isLrsc;
   reg                 stageB_request_isAmo;
@@ -6838,6 +7112,7 @@ module DataCache (
   reg        [2:0]    stageB_request_amoCtrl_alu;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6855,25 +7130,36 @@ module DataCache (
   reg        [31:0]   stageB_mmuRsp_ways_2_physical;
   reg                 stageB_mmuRsp_ways_3_sel;
   reg        [31:0]   stageB_mmuRsp_ways_3_physical;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   reg                 stageB_lrSc_reserved;
+  wire                when_DataCache_l866;
   wire                stageB_isExternalLsrc;
   wire                stageB_isExternalAmo;
   reg        [31:0]   stageB_requestDataBypass;
@@ -6882,14 +7168,26 @@ module DataCache (
   wire       [31:0]   stageB_amo_addSub;
   wire                stageB_amo_less;
   wire                stageB_amo_selectRf;
+  wire       [2:0]    switch_Misc_l199;
   reg        [31:0]   stageB_amo_result;
   reg        [31:0]   stageB_amo_resultReg;
   reg                 stageB_amo_internal_resultRegValid;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l984;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l997;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1010;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6901,73 +7199,62 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_42;
-  reg [7:0] _zz_43;
-  reg [7:0] _zz_44;
-  reg [7:0] _zz_45;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign _zz_16 = (! stageB_amo_internal_resultRegValid);
-  assign _zz_17 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_18 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_19 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
-  assign _zz_20 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign _zz_21 = (! stageB_flusher_hold);
-  assign _zz_22 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_23 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
-  assign _zz_24 = _zz_4[0 : 0];
-  assign _zz_25 = _zz_4[1 : 1];
-  assign _zz_26 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_27 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_28 = ($signed(_zz_29) + $signed(_zz_33));
-  assign _zz_29 = ($signed(_zz_30) + $signed(_zz_31));
-  assign _zz_30 = stageB_request_data;
-  assign _zz_31 = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_32 = (stageB_amo_compare ? _zz_34 : _zz_35);
-  assign _zz_33 = {{30{_zz_32[1]}}, _zz_32};
-  assign _zz_34 = 2'b01;
-  assign _zz_35 = 2'b00;
-  assign _zz_36 = 1'b1;
-  assign _zz_37 = (! stageB_lrSc_reserved);
-  assign _zz_38 = loader_counter_willIncrement;
-  assign _zz_39 = {2'd0, _zz_38};
-  assign _zz_40 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_41 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_stageB_amo_addSub = ($signed(_zz_stageB_amo_addSub_1) + $signed(_zz_stageB_amo_addSub_4));
+  assign _zz_stageB_amo_addSub_1 = ($signed(_zz_stageB_amo_addSub_2) + $signed(_zz_stageB_amo_addSub_3));
+  assign _zz_stageB_amo_addSub_2 = io_cpu_writeBack_storeData[31 : 0];
+  assign _zz_stageB_amo_addSub_3 = (stageB_amo_compare ? (~ stageB_dataMux[31 : 0]) : stageB_dataMux[31 : 0]);
+  assign _zz_stageB_amo_addSub_5 = (stageB_amo_compare ? _zz_stageB_amo_addSub_6 : _zz_stageB_amo_addSub_7);
+  assign _zz_stageB_amo_addSub_4 = {{30{_zz_stageB_amo_addSub_5[1]}}, _zz_stageB_amo_addSub_5};
+  assign _zz_stageB_amo_addSub_6 = 2'b01;
+  assign _zz_stageB_amo_addSub_7 = 2'b00;
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_41;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_45, _zz_44, _zz_43, _zz_42};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_42 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_43 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_44 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_45 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -6982,327 +7269,348 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_24[0];
-  assign ways_0_tagsReadRsp_error = _zz_25[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 dataWriteCmd_valid = 1'b0;
               end
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               dataWriteCmd_valid = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_36[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_26)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_27)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
-          if(_zz_19)begin
+          if(when_DataCache_l984) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 io_cpu_writeBack_haltIt = 1'b1;
               end
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign when_DataCache_l866 = ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc);
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_request_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
+  always @(*) begin
+    stageB_requestDataBypass = io_cpu_writeBack_storeData;
+    if(stageB_request_isAmo) begin
+      stageB_requestDataBypass[31 : 0] = stageB_amo_resultReg;
     end
   end
 
   assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
   assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
-  assign stageB_amo_addSub = _zz_28;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
+  assign stageB_amo_addSub = _zz_stageB_amo_addSub;
+  assign stageB_amo_less = ((io_cpu_writeBack_storeData[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : io_cpu_writeBack_storeData[31]));
   assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_23)
+  assign switch_Misc_l199 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  always @(*) begin
+    case(switch_Misc_l199)
       3'b000 : begin
         stageB_amo_result = stageB_amo_addSub;
       end
       3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] ^ stageB_dataMux[31 : 0]);
       end
       3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] | stageB_dataMux[31 : 0]);
       end
       3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
+        stageB_amo_result = (io_cpu_writeBack_storeData[31 : 0] & stageB_dataMux[31 : 0]);
       end
       default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
+        stageB_amo_result = (stageB_amo_selectRf ? io_cpu_writeBack_storeData[31 : 0] : stageB_dataMux[31 : 0]);
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7310,103 +7618,87 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            if(_zz_20)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_14)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
-          if(_zz_19)begin
+          if(when_DataCache_l984) begin
             io_mem_cmd_valid = 1'b0;
           end
         end else begin
-          if(_zz_15)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
-            if(stageB_request_isAmo)begin
-              if(_zz_16)begin
+            if(stageB_request_isAmo) begin
+              if(when_DataCache_l997) begin
                 io_mem_cmd_valid = 1'b0;
               end
             end
-            if(_zz_20)begin
+            if(when_DataCache_l1005) begin
               io_mem_cmd_valid = 1'b0;
             end
-            if(_zz_17)begin
+            if(when_DataCache_l1010) begin
               io_mem_cmd_valid = 1'b0;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(_zz_15)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -7414,12 +7706,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_14) begin
-          if(! _zz_15) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -7430,23 +7722,44 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l984 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l997 = (! stageB_amo_internal_resultRegValid);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1010 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_37};
-    end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign io_cpu_writeBack_exclusiveOk = stageB_lrSc_reserved;
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_18)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -7454,26 +7767,29 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_39);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
       stageA_request_isAmo <= io_cpu_execute_args_isAmo;
@@ -7481,18 +7797,17 @@ module DataCache (
       stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_isLrsc <= stageA_request_isLrsc;
       stageB_request_isAmo <= stageA_request_isAmo;
@@ -7500,7 +7815,7 @@ module DataCache (
       stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -7519,48 +7834,39 @@ module DataCache (
       stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
       stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_21)begin
-        if(_zz_22)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
     stageB_amo_resultReg <= stageB_amo_result;
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -7569,27 +7875,29 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_21)begin
-          if(! _zz_22) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
-      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+      if(when_DataCache_l866) begin
         stageB_lrSc_reserved <= (! stageB_request_wr);
       end
-      if(_zz_13)begin
+      if(when_DataCache_l1051) begin
         stageB_lrSc_reserved <= stageB_lrSc_reserved;
       end
       `ifndef SYNTHESIS
@@ -7597,28 +7905,27 @@ module DataCache (
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_18)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_40[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -7676,13 +7983,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -7691,8 +7994,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7706,22 +8014,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -7739,82 +8050,85 @@ module InstructionCache (
   reg        [31:0]   decodeStage_mmuRsp_ways_2_physical;
   reg                 decodeStage_mmuRsp_ways_3_sel;
   reg        [31:0]   decodeStage_mmuRsp_ways_3_physical;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7830,30 +8144,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -7861,51 +8180,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -7924,10 +8243,10 @@ module InstructionCache (
       decodeStage_mmuRsp_ways_3_sel <= io_cpu_fetch_mmuRsp_ways_3_sel;
       decodeStage_mmuRsp_ways_3_physical <= io_cpu_fetch_mmuRsp_ways_3_physical;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Lite.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Lite.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -73,18 +73,17 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_158;
-  wire                _zz_159;
-  wire                _zz_160;
-  wire                _zz_161;
-  wire                _zz_162;
-  wire                _zz_163;
-  wire                _zz_164;
-  wire                _zz_165;
-  reg                 _zz_166;
-  reg        [31:0]   _zz_167;
-  reg        [31:0]   _zz_168;
-  reg        [31:0]   _zz_169;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -97,308 +96,250 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                _zz_170;
-  wire                _zz_171;
-  wire                _zz_172;
-  wire                _zz_173;
-  wire                _zz_174;
-  wire                _zz_175;
-  wire                _zz_176;
-  wire                _zz_177;
-  wire                _zz_178;
-  wire                _zz_179;
-  wire                _zz_180;
-  wire                _zz_181;
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire       [1:0]    _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  wire                _zz_190;
-  wire                _zz_191;
-  wire                _zz_192;
-  wire                _zz_193;
-  wire                _zz_194;
-  wire                _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire                _zz_205;
-  wire       [1:0]    _zz_206;
-  wire                _zz_207;
-  wire       [0:0]    _zz_208;
-  wire       [0:0]    _zz_209;
-  wire       [0:0]    _zz_210;
-  wire       [0:0]    _zz_211;
-  wire       [0:0]    _zz_212;
-  wire       [0:0]    _zz_213;
-  wire       [0:0]    _zz_214;
-  wire       [0:0]    _zz_215;
-  wire       [0:0]    _zz_216;
-  wire       [0:0]    _zz_217;
-  wire       [0:0]    _zz_218;
-  wire       [0:0]    _zz_219;
-  wire       [0:0]    _zz_220;
-  wire       [0:0]    _zz_221;
-  wire       [0:0]    _zz_222;
-  wire       [0:0]    _zz_223;
-  wire       [2:0]    _zz_224;
-  wire       [2:0]    _zz_225;
-  wire       [31:0]   _zz_226;
-  wire       [11:0]   _zz_227;
-  wire       [31:0]   _zz_228;
-  wire       [19:0]   _zz_229;
-  wire       [11:0]   _zz_230;
-  wire       [31:0]   _zz_231;
-  wire       [31:0]   _zz_232;
-  wire       [19:0]   _zz_233;
-  wire       [11:0]   _zz_234;
-  wire       [2:0]    _zz_235;
-  wire       [0:0]    _zz_236;
-  wire       [2:0]    _zz_237;
-  wire       [4:0]    _zz_238;
-  wire       [11:0]   _zz_239;
-  wire       [11:0]   _zz_240;
-  wire       [31:0]   _zz_241;
-  wire       [31:0]   _zz_242;
-  wire       [31:0]   _zz_243;
-  wire       [31:0]   _zz_244;
-  wire       [31:0]   _zz_245;
-  wire       [31:0]   _zz_246;
-  wire       [31:0]   _zz_247;
-  wire       [31:0]   _zz_248;
-  wire       [32:0]   _zz_249;
-  wire       [11:0]   _zz_250;
-  wire       [19:0]   _zz_251;
-  wire       [11:0]   _zz_252;
-  wire       [31:0]   _zz_253;
-  wire       [31:0]   _zz_254;
-  wire       [31:0]   _zz_255;
-  wire       [11:0]   _zz_256;
-  wire       [19:0]   _zz_257;
-  wire       [11:0]   _zz_258;
-  wire       [2:0]    _zz_259;
-  wire       [1:0]    _zz_260;
-  wire       [1:0]    _zz_261;
-  wire       [1:0]    _zz_262;
-  wire       [1:0]    _zz_263;
-  wire       [0:0]    _zz_264;
-  wire       [5:0]    _zz_265;
-  wire       [33:0]   _zz_266;
-  wire       [32:0]   _zz_267;
-  wire       [33:0]   _zz_268;
-  wire       [32:0]   _zz_269;
-  wire       [33:0]   _zz_270;
-  wire       [32:0]   _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [5:0]    _zz_273;
-  wire       [32:0]   _zz_274;
-  wire       [31:0]   _zz_275;
-  wire       [31:0]   _zz_276;
-  wire       [32:0]   _zz_277;
-  wire       [32:0]   _zz_278;
-  wire       [32:0]   _zz_279;
-  wire       [32:0]   _zz_280;
-  wire       [0:0]    _zz_281;
-  wire       [32:0]   _zz_282;
-  wire       [0:0]    _zz_283;
-  wire       [32:0]   _zz_284;
-  wire       [0:0]    _zz_285;
-  wire       [31:0]   _zz_286;
-  wire       [0:0]    _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [0:0]    _zz_289;
-  wire       [0:0]    _zz_290;
-  wire       [0:0]    _zz_291;
-  wire       [0:0]    _zz_292;
-  wire       [26:0]   _zz_293;
-  wire                _zz_294;
-  wire                _zz_295;
-  wire       [1:0]    _zz_296;
-  wire       [31:0]   _zz_297;
-  wire       [31:0]   _zz_298;
-  wire       [31:0]   _zz_299;
-  wire                _zz_300;
-  wire       [0:0]    _zz_301;
-  wire       [12:0]   _zz_302;
-  wire       [31:0]   _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire                _zz_306;
-  wire       [0:0]    _zz_307;
-  wire       [6:0]    _zz_308;
-  wire       [31:0]   _zz_309;
-  wire       [31:0]   _zz_310;
-  wire       [31:0]   _zz_311;
-  wire                _zz_312;
-  wire       [0:0]    _zz_313;
-  wire       [0:0]    _zz_314;
-  wire                _zz_315;
-  wire                _zz_316;
-  wire                _zz_317;
-  wire       [31:0]   _zz_318;
-  wire       [0:0]    _zz_319;
-  wire       [1:0]    _zz_320;
-  wire       [0:0]    _zz_321;
-  wire       [0:0]    _zz_322;
-  wire                _zz_323;
-  wire       [0:0]    _zz_324;
-  wire       [24:0]   _zz_325;
-  wire       [31:0]   _zz_326;
-  wire       [31:0]   _zz_327;
-  wire       [31:0]   _zz_328;
-  wire       [0:0]    _zz_329;
-  wire       [0:0]    _zz_330;
-  wire       [1:0]    _zz_331;
-  wire       [1:0]    _zz_332;
-  wire                _zz_333;
-  wire       [0:0]    _zz_334;
-  wire       [20:0]   _zz_335;
-  wire       [31:0]   _zz_336;
-  wire       [31:0]   _zz_337;
-  wire       [31:0]   _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [31:0]   _zz_340;
-  wire       [31:0]   _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [2:0]    _zz_344;
-  wire       [2:0]    _zz_345;
-  wire                _zz_346;
-  wire       [0:0]    _zz_347;
-  wire       [17:0]   _zz_348;
-  wire       [31:0]   _zz_349;
-  wire       [31:0]   _zz_350;
-  wire       [31:0]   _zz_351;
-  wire       [31:0]   _zz_352;
-  wire                _zz_353;
-  wire                _zz_354;
-  wire                _zz_355;
-  wire       [0:0]    _zz_356;
-  wire       [0:0]    _zz_357;
-  wire                _zz_358;
-  wire       [0:0]    _zz_359;
-  wire       [0:0]    _zz_360;
-  wire                _zz_361;
-  wire       [0:0]    _zz_362;
-  wire       [14:0]   _zz_363;
-  wire       [31:0]   _zz_364;
-  wire       [31:0]   _zz_365;
-  wire       [31:0]   _zz_366;
-  wire       [31:0]   _zz_367;
-  wire       [31:0]   _zz_368;
-  wire       [31:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire       [31:0]   _zz_371;
-  wire       [0:0]    _zz_372;
-  wire       [0:0]    _zz_373;
-  wire       [1:0]    _zz_374;
-  wire       [1:0]    _zz_375;
-  wire                _zz_376;
-  wire       [0:0]    _zz_377;
-  wire       [12:0]   _zz_378;
-  wire       [31:0]   _zz_379;
-  wire       [31:0]   _zz_380;
-  wire       [31:0]   _zz_381;
-  wire       [31:0]   _zz_382;
-  wire       [31:0]   _zz_383;
-  wire       [31:0]   _zz_384;
-  wire                _zz_385;
-  wire       [0:0]    _zz_386;
-  wire       [0:0]    _zz_387;
-  wire                _zz_388;
-  wire       [0:0]    _zz_389;
-  wire       [0:0]    _zz_390;
-  wire                _zz_391;
-  wire       [0:0]    _zz_392;
-  wire       [9:0]    _zz_393;
-  wire       [31:0]   _zz_394;
-  wire       [31:0]   _zz_395;
-  wire       [31:0]   _zz_396;
-  wire       [0:0]    _zz_397;
-  wire       [0:0]    _zz_398;
-  wire       [0:0]    _zz_399;
-  wire       [4:0]    _zz_400;
-  wire       [1:0]    _zz_401;
-  wire       [1:0]    _zz_402;
-  wire                _zz_403;
-  wire       [0:0]    _zz_404;
-  wire       [6:0]    _zz_405;
-  wire       [31:0]   _zz_406;
-  wire       [31:0]   _zz_407;
-  wire       [31:0]   _zz_408;
-  wire       [31:0]   _zz_409;
-  wire                _zz_410;
-  wire       [0:0]    _zz_411;
-  wire       [1:0]    _zz_412;
-  wire       [31:0]   _zz_413;
-  wire       [31:0]   _zz_414;
-  wire                _zz_415;
-  wire       [0:0]    _zz_416;
-  wire       [0:0]    _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [0:0]    _zz_419;
-  wire                _zz_420;
-  wire       [0:0]    _zz_421;
-  wire       [3:0]    _zz_422;
-  wire       [31:0]   _zz_423;
-  wire       [31:0]   _zz_424;
-  wire       [31:0]   _zz_425;
-  wire                _zz_426;
-  wire                _zz_427;
-  wire       [31:0]   _zz_428;
-  wire       [31:0]   _zz_429;
-  wire       [31:0]   _zz_430;
-  wire       [31:0]   _zz_431;
-  wire       [31:0]   _zz_432;
-  wire       [31:0]   _zz_433;
-  wire       [31:0]   _zz_434;
-  wire       [0:0]    _zz_435;
-  wire       [2:0]    _zz_436;
-  wire       [0:0]    _zz_437;
-  wire       [0:0]    _zz_438;
-  wire                _zz_439;
-  wire       [0:0]    _zz_440;
-  wire       [1:0]    _zz_441;
-  wire       [31:0]   _zz_442;
-  wire       [31:0]   _zz_443;
-  wire       [31:0]   _zz_444;
-  wire       [31:0]   _zz_445;
-  wire                _zz_446;
-  wire       [0:0]    _zz_447;
-  wire       [0:0]    _zz_448;
-  wire       [31:0]   _zz_449;
-  wire       [31:0]   _zz_450;
-  wire       [0:0]    _zz_451;
-  wire       [1:0]    _zz_452;
-  wire       [1:0]    _zz_453;
-  wire       [1:0]    _zz_454;
-  wire                _zz_455;
-  wire                _zz_456;
-  wire       [31:0]   _zz_457;
-  wire       [31:0]   _zz_458;
-  wire       [31:0]   _zz_459;
-  wire       [31:0]   _zz_460;
-  wire       [31:0]   _zz_461;
-  wire       [31:0]   _zz_462;
-  wire       [31:0]   _zz_463;
-  wire       [31:0]   _zz_464;
-  wire       [31:0]   _zz_465;
-  wire                _zz_466;
-  wire       [31:0]   _zz_467;
-  wire       [31:0]   _zz_468;
-  wire                _zz_469;
-  wire                _zz_470;
-  wire                _zz_471;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [2:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
+  wire       [31:0]   _zz__zz_decode_IS_DIV;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_1;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_2;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_3;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_4;
+  wire                _zz__zz_decode_IS_DIV_5;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_6;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_7;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_8;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_9;
+  wire       [24:0]   _zz__zz_decode_IS_DIV_10;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_11;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_12;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_13;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_14;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_15;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_18;
+  wire                _zz__zz_decode_IS_DIV_19;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_20;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_21;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_23;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_24;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_25;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_26;
+  wire       [20:0]   _zz__zz_decode_IS_DIV_27;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_28;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_29;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_30;
+  wire                _zz__zz_decode_IS_DIV_31;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_32;
+  wire                _zz__zz_decode_IS_DIV_33;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_34;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_35;
+  wire                _zz__zz_decode_IS_DIV_36;
+  wire                _zz__zz_decode_IS_DIV_37;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_39;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_40;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_41;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_42;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_43;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_44;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_45;
+  wire                _zz__zz_decode_IS_DIV_46;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_47;
+  wire       [17:0]   _zz__zz_decode_IS_DIV_48;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_49;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_50;
+  wire                _zz__zz_decode_IS_DIV_51;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_52;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_53;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_54;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_55;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_56;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_57;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_58;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_59;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_60;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_61;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_62;
+  wire       [14:0]   _zz__zz_decode_IS_DIV_63;
+  wire                _zz__zz_decode_IS_DIV_64;
+  wire                _zz__zz_decode_IS_DIV_65;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_66;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_67;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_68;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_69;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_70;
+  wire                _zz__zz_decode_IS_DIV_71;
+  wire       [12:0]   _zz__zz_decode_IS_DIV_72;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_73;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_75;
+  wire                _zz__zz_decode_IS_DIV_76;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_77;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_78;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_79;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_80;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_81;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_82;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_83;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_84;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_85;
+  wire                _zz__zz_decode_IS_DIV_86;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_87;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_88;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_89;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_90;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_91;
+  wire                _zz__zz_decode_IS_DIV_92;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_93;
+  wire                _zz__zz_decode_IS_DIV_94;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_95;
+  wire       [9:0]    _zz__zz_decode_IS_DIV_96;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_97;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_98;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_99;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_100;
+  wire                _zz__zz_decode_IS_DIV_101;
+  wire                _zz__zz_decode_IS_DIV_102;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_103;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_104;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_105;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_106;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_107;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_108;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_109;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_110;
+  wire       [6:0]    _zz__zz_decode_IS_DIV_111;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_112;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_113;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_114;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_115;
+  wire                _zz__zz_decode_IS_DIV_116;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_117;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_118;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_119;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_120;
+  wire                _zz__zz_decode_IS_DIV_121;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_122;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_123;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_124;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_125;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_126;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_127;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_128;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_129;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_130;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_131;
+  wire                _zz__zz_decode_IS_DIV_132;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_133;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_134;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_135;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_136;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_137;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_138;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_139;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_140;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_141;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_142;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_143;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_144;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_145;
+  wire                _zz__zz_decode_IS_DIV_146;
+  wire                _zz__zz_decode_IS_DIV_147;
+  wire                _zz__zz_decode_IS_DIV_148;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_149;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_150;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [31:0]   _zz__zz_decode_RS2_3;
+  wire       [32:0]   _zz__zz_decode_RS2_3_1;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1;
+  wire                _zz_when;
+  wire                _zz_when_1;
+  wire       [5:0]    _zz_memory_MulDivIterativePlugin_mul_counter_valueNext;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_2;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator_3;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_4;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_5;
+  wire       [5:0]    _zz_memory_MulDivIterativePlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_2;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
@@ -414,43 +355,43 @@ module VexRiscv (
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_16;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_19;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire                decode_MEMORY_ENABLE;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_22;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -466,11 +407,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -478,54 +419,54 @@ module VexRiscv (
   wire       [31:0]   execute_RS1;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   _zz_29;
+  reg        [31:0]   _zz_decode_RS2;
   wire                memory_REGFILE_WRITE_VALID;
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
-  reg        [31:0]   _zz_30;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
-  wire       [31:0]   _zz_37;
-  wire                _zz_38;
-  reg                 _zz_39;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
@@ -545,10 +486,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_49;
-  reg        [31:0]   _zz_50;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -639,6 +580,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -656,27 +602,33 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_51;
-  wire       [2:0]    _zz_52;
-  wire                _zz_53;
-  wire                _zz_54;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -699,16 +651,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_55;
-  wire                _zz_56;
-  wire                _zz_57;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_58;
-  wire                _zz_59;
-  reg                 _zz_60;
-  wire                _zz_61;
-  reg                 _zz_62;
-  reg        [31:0]   _zz_63;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -716,22 +670,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_64;
-  reg        [18:0]   _zz_65;
-  wire                _zz_66;
-  reg        [10:0]   _zz_67;
-  wire                _zz_68;
-  reg        [18:0]   _zz_69;
-  reg                 _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -739,7 +700,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_75;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -747,6 +708,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -756,31 +722,38 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_76;
+  wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_77;
-  reg        [3:0]    _zz_78;
+  reg        [31:0]   _zz_dBus_cmd_payload_data;
+  wire                when_DBusSimplePlugin_l426;
+  reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
+  wire                when_DBusSimplePlugin_l479;
+  wire                when_DBusSimplePlugin_l486;
+  wire                when_DBusSimplePlugin_l512;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_79;
-  reg        [31:0]   _zz_80;
-  wire                _zz_81;
-  reg        [31:0]   _zz_82;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [30:0]   _zz_83;
-  wire                _zz_84;
-  wire                _zz_85;
-  wire                _zz_86;
-  wire                _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_90;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_91;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_92;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_94;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_96;
+  wire                when_DBusSimplePlugin_l558;
+  wire       [30:0]   _zz_decode_IS_DIV;
+  wire                _zz_decode_IS_DIV_1;
+  wire                _zz_decode_IS_DIV_2;
+  wire                _zz_decode_IS_DIV_3;
+  wire                _zz_decode_IS_DIV_4;
+  wire                _zz_decode_IS_DIV_5;
+  wire                _zz_decode_IS_DIV_6;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -788,15 +761,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_97;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_98;
-  reg        [31:0]   _zz_99;
-  wire                _zz_100;
-  reg        [19:0]   _zz_101;
-  wire                _zz_102;
-  reg        [19:0]   _zz_103;
-  reg        [31:0]   _zz_104;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -805,38 +778,59 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_105;
-  reg                 _zz_106;
-  reg                 _zz_107;
-  reg                 _zz_108;
-  reg        [4:0]    _zz_109;
-  reg        [31:0]   _zz_110;
-  wire                _zz_111;
-  wire                _zz_112;
-  wire                _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
+  wire                when_ShiftPlugins_l169;
+  reg        [31:0]   _zz_decode_RS2_3;
+  wire                when_ShiftPlugins_l175;
+  wire                when_ShiftPlugins_l184;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_117;
-  reg                 _zz_118;
-  reg                 _zz_119;
-  wire                _zz_120;
-  reg        [19:0]   _zz_121;
-  wire                _zz_122;
-  reg        [10:0]   _zz_123;
-  wire                _zz_124;
-  reg        [18:0]   _zz_125;
-  reg                 _zz_126;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_127;
-  reg        [19:0]   _zz_128;
-  wire                _zz_129;
-  reg        [10:0]   _zz_130;
-  wire                _zz_131;
-  reg        [18:0]   _zz_132;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -857,9 +851,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -872,37 +866,60 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_136;
-  wire                _zz_137;
-  wire       [1:0]    _zz_138;
-  wire                _zz_139;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -914,6 +931,10 @@ module VexRiscv (
   reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
   wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
   wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
+  wire                when_MulDivIterativePlugin_l96;
+  wire                when_MulDivIterativePlugin_l97;
+  wire                when_MulDivIterativePlugin_l100;
+  wire                when_MulDivIterativePlugin_l110;
   reg                 memory_MulDivIterativePlugin_div_needRevert;
   reg                 memory_MulDivIterativePlugin_div_counter_willIncrement;
   reg                 memory_MulDivIterativePlugin_div_counter_willClear;
@@ -922,91 +943,169 @@ module VexRiscv (
   wire                memory_MulDivIterativePlugin_div_counter_willOverflowIfInc;
   wire                memory_MulDivIterativePlugin_div_counter_willOverflow;
   reg                 memory_MulDivIterativePlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_MulDivIterativePlugin_div_result;
-  wire       [31:0]   _zz_140;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  reg        [32:0]   _zz_144;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs1;
+  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_145;
-  wire       [31:0]   _zz_146;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_12;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_15;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_16;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_17;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 decode_to_execute_MEMORY_STORE;
+  wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_MEMORY_STORE;
+  wire                when_Pipeline_l124_24;
   reg                 memory_to_writeBack_MEMORY_STORE;
+  wire                when_Pipeline_l124_25;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_26;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_27;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_28;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_30;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_32;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_34;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_35;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_37;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_38;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_39;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_40;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_43;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_44;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_45;
   reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  wire                when_Pipeline_l124_46;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_47;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_48;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_49;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_50;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_51;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_147;
-  reg        [31:0]   _zz_148;
-  reg        [31:0]   _zz_149;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [2:0]    _zz_155;
-  reg                 _zz_156;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -1020,77 +1119,79 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_157;
+  wire                when_Stream_l399;
+  reg        [3:0]    _zz_dBusWishbone_SEL;
+  wire                when_DBusSimplePlugin_l189;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] _zz_12_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_13_string;
-  reg [39:0] _zz_14_string;
-  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_16_string;
-  reg [23:0] _zz_17_string;
-  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_19_string;
-  reg [63:0] _zz_20_string;
-  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_22_string;
-  reg [95:0] _zz_23_string;
-  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_25_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_26_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_28_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36_string;
-  reg [39:0] _zz_40_string;
-  reg [31:0] _zz_41_string;
-  reg [71:0] _zz_42_string;
-  reg [39:0] _zz_43_string;
-  reg [23:0] _zz_44_string;
-  reg [63:0] _zz_45_string;
-  reg [95:0] _zz_46_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_48_string;
-  reg [95:0] _zz_90_string;
-  reg [63:0] _zz_91_string;
-  reg [23:0] _zz_92_string;
-  reg [39:0] _zz_93_string;
-  reg [71:0] _zz_94_string;
-  reg [31:0] _zz_95_string;
-  reg [39:0] _zz_96_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1099,413 +1200,352 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_170 = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_171 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_172 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_173 = 1'b1;
-  assign _zz_174 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_175 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_176 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_177 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_178 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_179 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_180 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_181 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_182 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_183 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_184 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_185 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_186 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_187 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_188 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_189 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_190 = (1'b0 || (! 1'b1));
-  assign _zz_191 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_192 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_193 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_194 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_195 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_196 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_197 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
-  assign _zz_198 = (! memory_arbitration_isStuck);
-  assign _zz_199 = (iBus_cmd_valid || (_zz_155 != 3'b000));
-  assign _zz_200 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_201 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_202 = ((_zz_133 && 1'b1) && (! 1'b0));
-  assign _zz_203 = ((_zz_134 && 1'b1) && (! 1'b0));
-  assign _zz_204 = ((_zz_135 && 1'b1) && (! 1'b0));
-  assign _zz_205 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_206 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_207 = execute_INSTRUCTION[13];
-  assign _zz_208 = _zz_83[30 : 30];
-  assign _zz_209 = _zz_83[29 : 29];
-  assign _zz_210 = _zz_83[28 : 28];
-  assign _zz_211 = _zz_83[27 : 27];
-  assign _zz_212 = _zz_83[24 : 24];
-  assign _zz_213 = _zz_83[16 : 16];
-  assign _zz_214 = _zz_83[13 : 13];
-  assign _zz_215 = _zz_83[12 : 12];
-  assign _zz_216 = _zz_83[11 : 11];
-  assign _zz_217 = _zz_83[4 : 4];
-  assign _zz_218 = _zz_83[15 : 15];
-  assign _zz_219 = _zz_83[5 : 5];
-  assign _zz_220 = _zz_83[3 : 3];
-  assign _zz_221 = _zz_83[19 : 19];
-  assign _zz_222 = _zz_83[10 : 10];
-  assign _zz_223 = _zz_83[0 : 0];
-  assign _zz_224 = (_zz_51 - 3'b001);
-  assign _zz_225 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_226 = {29'd0, _zz_225};
-  assign _zz_227 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_228 = {{_zz_65,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_229 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_230 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_231 = {{_zz_67,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_232 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_233 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_234 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_235 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
-  assign _zz_236 = execute_SRC_LESS;
-  assign _zz_237 = 3'b100;
-  assign _zz_238 = execute_INSTRUCTION[19 : 15];
-  assign _zz_239 = execute_INSTRUCTION[31 : 20];
-  assign _zz_240 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_241 = ($signed(_zz_242) + $signed(_zz_245));
-  assign _zz_242 = ($signed(_zz_243) + $signed(_zz_244));
-  assign _zz_243 = execute_SRC1;
-  assign _zz_244 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_245 = (execute_SRC_USE_SUB_LESS ? _zz_246 : _zz_247);
-  assign _zz_246 = 32'h00000001;
-  assign _zz_247 = 32'h0;
-  assign _zz_248 = (_zz_249 >>> 1);
-  assign _zz_249 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_250 = execute_INSTRUCTION[31 : 20];
-  assign _zz_251 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_252 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_253 = {_zz_121,execute_INSTRUCTION[31 : 20]};
-  assign _zz_254 = {{_zz_123,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_255 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_256 = execute_INSTRUCTION[31 : 20];
-  assign _zz_257 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_258 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_259 = 3'b100;
-  assign _zz_260 = (_zz_136 & (~ _zz_261));
-  assign _zz_261 = (_zz_136 - 2'b01);
-  assign _zz_262 = (_zz_138 & (~ _zz_263));
-  assign _zz_263 = (_zz_138 - 2'b01);
-  assign _zz_264 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_265 = {5'd0, _zz_264};
-  assign _zz_266 = (_zz_268 + _zz_270);
-  assign _zz_267 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_268 = {{1{_zz_267[32]}}, _zz_267};
-  assign _zz_269 = _zz_271;
-  assign _zz_270 = {{1{_zz_269[32]}}, _zz_269};
-  assign _zz_271 = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_272 = memory_MulDivIterativePlugin_div_counter_willIncrement;
-  assign _zz_273 = {5'd0, _zz_272};
-  assign _zz_274 = {1'd0, memory_MulDivIterativePlugin_rs2};
-  assign _zz_275 = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_276 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_277 = {_zz_140,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_278 = _zz_279;
-  assign _zz_279 = _zz_280;
-  assign _zz_280 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_282);
-  assign _zz_281 = memory_MulDivIterativePlugin_div_needRevert;
-  assign _zz_282 = {32'd0, _zz_281};
-  assign _zz_283 = _zz_143;
-  assign _zz_284 = {32'd0, _zz_283};
-  assign _zz_285 = _zz_142;
-  assign _zz_286 = {31'd0, _zz_285};
-  assign _zz_287 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_288 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_289 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_290 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_291 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_292 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_293 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_294 = 1'b1;
-  assign _zz_295 = 1'b1;
-  assign _zz_296 = {_zz_54,_zz_53};
-  assign _zz_297 = 32'h0000107f;
-  assign _zz_298 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_299 = 32'h00002073;
-  assign _zz_300 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_301 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_302 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_303) == 32'h00000003),{(_zz_304 == _zz_305),{_zz_306,{_zz_307,_zz_308}}}}}};
-  assign _zz_303 = 32'h0000505f;
-  assign _zz_304 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_305 = 32'h00000063;
-  assign _zz_306 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_307 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_308 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_309) == 32'h00005033),{(_zz_310 == _zz_311),{_zz_312,{_zz_313,_zz_314}}}}}};
-  assign _zz_309 = 32'hbe00707f;
-  assign _zz_310 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_311 = 32'h00000033;
-  assign _zz_312 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_313 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_314 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_315 = decode_INSTRUCTION[31];
-  assign _zz_316 = decode_INSTRUCTION[31];
-  assign _zz_317 = decode_INSTRUCTION[7];
-  assign _zz_318 = 32'h02004064;
-  assign _zz_319 = _zz_89;
-  assign _zz_320 = {_zz_87,_zz_88};
-  assign _zz_321 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_322 = 1'b0;
-  assign _zz_323 = (((decode_INSTRUCTION & _zz_326) == 32'h00000050) != 1'b0);
-  assign _zz_324 = ((_zz_327 == _zz_328) != 1'b0);
-  assign _zz_325 = {({_zz_329,_zz_330} != 2'b00),{(_zz_331 != _zz_332),{_zz_333,{_zz_334,_zz_335}}}};
-  assign _zz_326 = 32'h10003050;
-  assign _zz_327 = (decode_INSTRUCTION & 32'h10403050);
-  assign _zz_328 = 32'h10000050;
-  assign _zz_329 = ((decode_INSTRUCTION & _zz_336) == 32'h00001050);
-  assign _zz_330 = ((decode_INSTRUCTION & _zz_337) == 32'h00002050);
-  assign _zz_331 = {_zz_86,(_zz_338 == _zz_339)};
-  assign _zz_332 = 2'b00;
-  assign _zz_333 = ((_zz_340 == _zz_341) != 1'b0);
-  assign _zz_334 = ({_zz_342,_zz_343} != 2'b00);
-  assign _zz_335 = {(_zz_344 != _zz_345),{_zz_346,{_zz_347,_zz_348}}};
-  assign _zz_336 = 32'h00001050;
-  assign _zz_337 = 32'h00002050;
-  assign _zz_338 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_339 = 32'h00000004;
-  assign _zz_340 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_341 = 32'h00000040;
-  assign _zz_342 = ((decode_INSTRUCTION & _zz_349) == 32'h00005010);
-  assign _zz_343 = ((decode_INSTRUCTION & _zz_350) == 32'h00005020);
-  assign _zz_344 = {(_zz_351 == _zz_352),{_zz_353,_zz_354}};
-  assign _zz_345 = 3'b000;
-  assign _zz_346 = ({_zz_355,{_zz_356,_zz_357}} != 3'b000);
-  assign _zz_347 = (_zz_358 != 1'b0);
-  assign _zz_348 = {(_zz_359 != _zz_360),{_zz_361,{_zz_362,_zz_363}}};
-  assign _zz_349 = 32'h00007034;
-  assign _zz_350 = 32'h02007064;
-  assign _zz_351 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_352 = 32'h40001010;
-  assign _zz_353 = ((decode_INSTRUCTION & _zz_364) == 32'h00001010);
-  assign _zz_354 = ((decode_INSTRUCTION & _zz_365) == 32'h00001010);
-  assign _zz_355 = ((decode_INSTRUCTION & _zz_366) == 32'h00000024);
-  assign _zz_356 = (_zz_367 == _zz_368);
-  assign _zz_357 = (_zz_369 == _zz_370);
-  assign _zz_358 = ((decode_INSTRUCTION & _zz_371) == 32'h00001000);
-  assign _zz_359 = _zz_87;
-  assign _zz_360 = 1'b0;
-  assign _zz_361 = ({_zz_372,_zz_373} != 2'b00);
-  assign _zz_362 = (_zz_374 != _zz_375);
-  assign _zz_363 = {_zz_376,{_zz_377,_zz_378}};
-  assign _zz_364 = 32'h00007034;
-  assign _zz_365 = 32'h02007054;
-  assign _zz_366 = 32'h00000064;
-  assign _zz_367 = (decode_INSTRUCTION & 32'h00003034);
-  assign _zz_368 = 32'h00001010;
-  assign _zz_369 = (decode_INSTRUCTION & 32'h02003054);
-  assign _zz_370 = 32'h00001010;
-  assign _zz_371 = 32'h00001000;
-  assign _zz_372 = ((decode_INSTRUCTION & _zz_379) == 32'h00002000);
-  assign _zz_373 = ((decode_INSTRUCTION & _zz_380) == 32'h00001000);
-  assign _zz_374 = {(_zz_381 == _zz_382),(_zz_383 == _zz_384)};
-  assign _zz_375 = 2'b00;
-  assign _zz_376 = ({_zz_385,{_zz_386,_zz_387}} != 3'b000);
-  assign _zz_377 = (_zz_388 != 1'b0);
-  assign _zz_378 = {(_zz_389 != _zz_390),{_zz_391,{_zz_392,_zz_393}}};
-  assign _zz_379 = 32'h00002010;
-  assign _zz_380 = 32'h00005000;
-  assign _zz_381 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_382 = 32'h00000020;
-  assign _zz_383 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_384 = 32'h00000020;
-  assign _zz_385 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_386 = ((decode_INSTRUCTION & _zz_394) == 32'h0);
-  assign _zz_387 = ((decode_INSTRUCTION & _zz_395) == 32'h00000040);
-  assign _zz_388 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_389 = ((decode_INSTRUCTION & _zz_396) == 32'h00000010);
-  assign _zz_390 = 1'b0;
-  assign _zz_391 = ({_zz_85,{_zz_397,_zz_398}} != 3'b000);
-  assign _zz_392 = ({_zz_399,_zz_400} != 6'h0);
-  assign _zz_393 = {(_zz_401 != _zz_402),{_zz_403,{_zz_404,_zz_405}}};
-  assign _zz_394 = 32'h00000038;
-  assign _zz_395 = 32'h00403040;
-  assign _zz_396 = 32'h00000010;
-  assign _zz_397 = ((decode_INSTRUCTION & _zz_406) == 32'h00000010);
-  assign _zz_398 = ((decode_INSTRUCTION & _zz_407) == 32'h00000020);
-  assign _zz_399 = _zz_86;
-  assign _zz_400 = {(_zz_408 == _zz_409),{_zz_410,{_zz_411,_zz_412}}};
-  assign _zz_401 = {_zz_85,(_zz_413 == _zz_414)};
-  assign _zz_402 = 2'b00;
-  assign _zz_403 = ({_zz_85,_zz_415} != 2'b00);
-  assign _zz_404 = ({_zz_416,_zz_417} != 2'b00);
-  assign _zz_405 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
-  assign _zz_406 = 32'h00000030;
-  assign _zz_407 = 32'h02000060;
-  assign _zz_408 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_409 = 32'h00001010;
-  assign _zz_410 = ((decode_INSTRUCTION & _zz_423) == 32'h00002010);
-  assign _zz_411 = (_zz_424 == _zz_425);
-  assign _zz_412 = {_zz_426,_zz_427};
-  assign _zz_413 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_414 = 32'h00000020;
-  assign _zz_415 = ((decode_INSTRUCTION & _zz_428) == 32'h0);
-  assign _zz_416 = (_zz_429 == _zz_430);
-  assign _zz_417 = (_zz_431 == _zz_432);
-  assign _zz_418 = (_zz_433 == _zz_434);
-  assign _zz_419 = 1'b0;
-  assign _zz_420 = ({_zz_435,_zz_436} != 4'b0000);
-  assign _zz_421 = (_zz_437 != _zz_438);
-  assign _zz_422 = {_zz_439,{_zz_440,_zz_441}};
-  assign _zz_423 = 32'h00002010;
-  assign _zz_424 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_425 = 32'h00000010;
-  assign _zz_426 = ((decode_INSTRUCTION & _zz_442) == 32'h00000004);
-  assign _zz_427 = ((decode_INSTRUCTION & _zz_443) == 32'h0);
-  assign _zz_428 = 32'h00000020;
-  assign _zz_429 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_430 = 32'h00006010;
-  assign _zz_431 = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz_432 = 32'h00004010;
-  assign _zz_433 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_434 = 32'h00002010;
-  assign _zz_435 = (_zz_444 == _zz_445);
-  assign _zz_436 = {_zz_446,{_zz_447,_zz_448}};
-  assign _zz_437 = (_zz_449 == _zz_450);
-  assign _zz_438 = 1'b0;
-  assign _zz_439 = ({_zz_451,_zz_452} != 3'b000);
-  assign _zz_440 = (_zz_453 != _zz_454);
-  assign _zz_441 = {_zz_455,_zz_456};
-  assign _zz_442 = 32'h0000000c;
-  assign _zz_443 = 32'h00000028;
-  assign _zz_444 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_445 = 32'h0;
-  assign _zz_446 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_447 = ((decode_INSTRUCTION & _zz_457) == 32'h00002000);
-  assign _zz_448 = ((decode_INSTRUCTION & _zz_458) == 32'h00001000);
-  assign _zz_449 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_450 = 32'h0;
-  assign _zz_451 = ((decode_INSTRUCTION & _zz_459) == 32'h00000040);
-  assign _zz_452 = {(_zz_460 == _zz_461),(_zz_462 == _zz_463)};
-  assign _zz_453 = {(_zz_464 == _zz_465),_zz_84};
-  assign _zz_454 = 2'b00;
-  assign _zz_455 = ({_zz_466,_zz_84} != 2'b00);
-  assign _zz_456 = ((_zz_467 == _zz_468) != 1'b0);
-  assign _zz_457 = 32'h00006004;
-  assign _zz_458 = 32'h00005004;
-  assign _zz_459 = 32'h00000044;
-  assign _zz_460 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_461 = 32'h00002010;
-  assign _zz_462 = (decode_INSTRUCTION & 32'h40004034);
-  assign _zz_463 = 32'h40000030;
-  assign _zz_464 = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz_465 = 32'h00000004;
-  assign _zz_466 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_467 = (decode_INSTRUCTION & 32'h00001048);
-  assign _zz_468 = 32'h00001008;
-  assign _zz_469 = execute_INSTRUCTION[31];
-  assign _zz_470 = execute_INSTRUCTION[31];
-  assign _zz_471 = execute_INSTRUCTION[7];
-  always @ (posedge clk) begin
-    if(_zz_294) begin
-      _zz_167 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_when_1 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 3'b001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1);
+  assign _zz__zz_decode_RS2_3_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 - 2'b01);
+  assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
+  assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
+  assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
+  assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
+  assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator = {_zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_MulDivIterativePlugin_div_result_1 = _zz_memory_MulDivIterativePlugin_div_result_2;
+  assign _zz_memory_MulDivIterativePlugin_div_result_2 = _zz_memory_MulDivIterativePlugin_div_result_3;
+  assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
+  assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
+  assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
+  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,_zz_IBusCachedPlugin_jump_pcLoad_payload_2};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_DIV = 32'h02004064;
+  assign _zz__zz_decode_IS_DIV_1 = _zz_decode_IS_DIV_6;
+  assign _zz__zz_decode_IS_DIV_2 = {_zz_decode_IS_DIV_4,_zz_decode_IS_DIV_5};
+  assign _zz__zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_DIV_4 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_6) == 32'h00000050) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_7 = ((_zz__zz_decode_IS_DIV_8 == _zz__zz_decode_IS_DIV_9) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_10 = {({_zz__zz_decode_IS_DIV_11,_zz__zz_decode_IS_DIV_13} != 2'b00),{(_zz__zz_decode_IS_DIV_15 != _zz__zz_decode_IS_DIV_18),{_zz__zz_decode_IS_DIV_19,{_zz__zz_decode_IS_DIV_22,_zz__zz_decode_IS_DIV_27}}}};
+  assign _zz__zz_decode_IS_DIV_6 = 32'h10003050;
+  assign _zz__zz_decode_IS_DIV_8 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_IS_DIV_9 = 32'h10000050;
+  assign _zz__zz_decode_IS_DIV_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_12) == 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_14) == 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_15 = {_zz_decode_IS_DIV_3,(_zz__zz_decode_IS_DIV_16 == _zz__zz_decode_IS_DIV_17)};
+  assign _zz__zz_decode_IS_DIV_18 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_19 = ((_zz__zz_decode_IS_DIV_20 == _zz__zz_decode_IS_DIV_21) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_22 = ({_zz__zz_decode_IS_DIV_23,_zz__zz_decode_IS_DIV_25} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_27 = {(_zz__zz_decode_IS_DIV_28 != _zz__zz_decode_IS_DIV_35),{_zz__zz_decode_IS_DIV_36,{_zz__zz_decode_IS_DIV_45,_zz__zz_decode_IS_DIV_48}}};
+  assign _zz__zz_decode_IS_DIV_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_DIV_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_DIV_16 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_IS_DIV_17 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_20 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_DIV_21 = 32'h00000040;
+  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_24) == 32'h00005010);
+  assign _zz__zz_decode_IS_DIV_25 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_26) == 32'h00005020);
+  assign _zz__zz_decode_IS_DIV_28 = {(_zz__zz_decode_IS_DIV_29 == _zz__zz_decode_IS_DIV_30),{_zz__zz_decode_IS_DIV_31,_zz__zz_decode_IS_DIV_33}};
+  assign _zz__zz_decode_IS_DIV_35 = 3'b000;
+  assign _zz__zz_decode_IS_DIV_36 = ({_zz__zz_decode_IS_DIV_37,{_zz__zz_decode_IS_DIV_39,_zz__zz_decode_IS_DIV_42}} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_45 = (_zz__zz_decode_IS_DIV_46 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_48 = {(_zz__zz_decode_IS_DIV_49 != _zz__zz_decode_IS_DIV_50),{_zz__zz_decode_IS_DIV_51,{_zz__zz_decode_IS_DIV_56,_zz__zz_decode_IS_DIV_63}}};
+  assign _zz__zz_decode_IS_DIV_24 = 32'h00007034;
+  assign _zz__zz_decode_IS_DIV_26 = 32'h02007064;
+  assign _zz__zz_decode_IS_DIV_29 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_IS_DIV_30 = 32'h40001010;
+  assign _zz__zz_decode_IS_DIV_31 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_32) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_33 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_34) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_37 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_38) == 32'h00000024);
+  assign _zz__zz_decode_IS_DIV_39 = (_zz__zz_decode_IS_DIV_40 == _zz__zz_decode_IS_DIV_41);
+  assign _zz__zz_decode_IS_DIV_42 = (_zz__zz_decode_IS_DIV_43 == _zz__zz_decode_IS_DIV_44);
+  assign _zz__zz_decode_IS_DIV_46 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_47) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_49 = _zz_decode_IS_DIV_4;
+  assign _zz__zz_decode_IS_DIV_50 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_51 = ({_zz__zz_decode_IS_DIV_52,_zz__zz_decode_IS_DIV_54} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_56 = (_zz__zz_decode_IS_DIV_57 != _zz__zz_decode_IS_DIV_62);
+  assign _zz__zz_decode_IS_DIV_63 = {_zz__zz_decode_IS_DIV_64,{_zz__zz_decode_IS_DIV_70,_zz__zz_decode_IS_DIV_72}};
+  assign _zz__zz_decode_IS_DIV_32 = 32'h00007034;
+  assign _zz__zz_decode_IS_DIV_34 = 32'h02007054;
+  assign _zz__zz_decode_IS_DIV_38 = 32'h00000064;
+  assign _zz__zz_decode_IS_DIV_40 = (decode_INSTRUCTION & 32'h00003034);
+  assign _zz__zz_decode_IS_DIV_41 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_43 = (decode_INSTRUCTION & 32'h02003054);
+  assign _zz__zz_decode_IS_DIV_44 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_47 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_52 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_53) == 32'h00002000);
+  assign _zz__zz_decode_IS_DIV_54 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_55) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_57 = {(_zz__zz_decode_IS_DIV_58 == _zz__zz_decode_IS_DIV_59),(_zz__zz_decode_IS_DIV_60 == _zz__zz_decode_IS_DIV_61)};
+  assign _zz__zz_decode_IS_DIV_62 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_64 = ({_zz__zz_decode_IS_DIV_65,{_zz__zz_decode_IS_DIV_66,_zz__zz_decode_IS_DIV_68}} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_70 = (_zz__zz_decode_IS_DIV_71 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_72 = {(_zz__zz_decode_IS_DIV_73 != _zz__zz_decode_IS_DIV_75),{_zz__zz_decode_IS_DIV_76,{_zz__zz_decode_IS_DIV_81,_zz__zz_decode_IS_DIV_96}}};
+  assign _zz__zz_decode_IS_DIV_53 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_55 = 32'h00005000;
+  assign _zz__zz_decode_IS_DIV_58 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_DIV_59 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_60 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_61 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_65 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_67) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_68 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_69) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_71 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_74) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_75 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_76 = ({_zz_decode_IS_DIV_2,{_zz__zz_decode_IS_DIV_77,_zz__zz_decode_IS_DIV_79}} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_81 = ({_zz__zz_decode_IS_DIV_82,_zz__zz_decode_IS_DIV_83} != 6'h0);
+  assign _zz__zz_decode_IS_DIV_96 = {(_zz__zz_decode_IS_DIV_97 != _zz__zz_decode_IS_DIV_100),{_zz__zz_decode_IS_DIV_101,{_zz__zz_decode_IS_DIV_104,_zz__zz_decode_IS_DIV_111}}};
+  assign _zz__zz_decode_IS_DIV_67 = 32'h00000038;
+  assign _zz__zz_decode_IS_DIV_69 = 32'h00403040;
+  assign _zz__zz_decode_IS_DIV_74 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_77 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_78) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_80) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_82 = _zz_decode_IS_DIV_3;
+  assign _zz__zz_decode_IS_DIV_83 = {(_zz__zz_decode_IS_DIV_84 == _zz__zz_decode_IS_DIV_85),{_zz__zz_decode_IS_DIV_86,{_zz__zz_decode_IS_DIV_88,_zz__zz_decode_IS_DIV_91}}};
+  assign _zz__zz_decode_IS_DIV_97 = {_zz_decode_IS_DIV_2,(_zz__zz_decode_IS_DIV_98 == _zz__zz_decode_IS_DIV_99)};
+  assign _zz__zz_decode_IS_DIV_100 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_101 = ({_zz_decode_IS_DIV_2,_zz__zz_decode_IS_DIV_102} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_104 = ({_zz__zz_decode_IS_DIV_105,_zz__zz_decode_IS_DIV_108} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_111 = {(_zz__zz_decode_IS_DIV_112 != _zz__zz_decode_IS_DIV_115),{_zz__zz_decode_IS_DIV_116,{_zz__zz_decode_IS_DIV_126,_zz__zz_decode_IS_DIV_131}}};
+  assign _zz__zz_decode_IS_DIV_78 = 32'h00000030;
+  assign _zz__zz_decode_IS_DIV_80 = 32'h02000060;
+  assign _zz__zz_decode_IS_DIV_84 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_85 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_86 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_87) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_88 = (_zz__zz_decode_IS_DIV_89 == _zz__zz_decode_IS_DIV_90);
+  assign _zz__zz_decode_IS_DIV_91 = {_zz__zz_decode_IS_DIV_92,_zz__zz_decode_IS_DIV_94};
+  assign _zz__zz_decode_IS_DIV_98 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_DIV_99 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_102 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_103) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_105 = (_zz__zz_decode_IS_DIV_106 == _zz__zz_decode_IS_DIV_107);
+  assign _zz__zz_decode_IS_DIV_108 = (_zz__zz_decode_IS_DIV_109 == _zz__zz_decode_IS_DIV_110);
+  assign _zz__zz_decode_IS_DIV_112 = (_zz__zz_decode_IS_DIV_113 == _zz__zz_decode_IS_DIV_114);
+  assign _zz__zz_decode_IS_DIV_115 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_116 = ({_zz__zz_decode_IS_DIV_117,_zz__zz_decode_IS_DIV_120} != 4'b0000);
+  assign _zz__zz_decode_IS_DIV_126 = (_zz__zz_decode_IS_DIV_127 != _zz__zz_decode_IS_DIV_130);
+  assign _zz__zz_decode_IS_DIV_131 = {_zz__zz_decode_IS_DIV_132,{_zz__zz_decode_IS_DIV_140,_zz__zz_decode_IS_DIV_145}};
+  assign _zz__zz_decode_IS_DIV_87 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_89 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_DIV_90 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_92 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_93) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_95) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_103 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_106 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_107 = 32'h00006010;
+  assign _zz__zz_decode_IS_DIV_109 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz__zz_decode_IS_DIV_110 = 32'h00004010;
+  assign _zz__zz_decode_IS_DIV_113 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_DIV_114 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_117 = (_zz__zz_decode_IS_DIV_118 == _zz__zz_decode_IS_DIV_119);
+  assign _zz__zz_decode_IS_DIV_120 = {_zz__zz_decode_IS_DIV_121,{_zz__zz_decode_IS_DIV_122,_zz__zz_decode_IS_DIV_124}};
+  assign _zz__zz_decode_IS_DIV_127 = (_zz__zz_decode_IS_DIV_128 == _zz__zz_decode_IS_DIV_129);
+  assign _zz__zz_decode_IS_DIV_130 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_132 = ({_zz__zz_decode_IS_DIV_133,_zz__zz_decode_IS_DIV_135} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_140 = (_zz__zz_decode_IS_DIV_141 != _zz__zz_decode_IS_DIV_144);
+  assign _zz__zz_decode_IS_DIV_145 = {_zz__zz_decode_IS_DIV_146,_zz__zz_decode_IS_DIV_148};
+  assign _zz__zz_decode_IS_DIV_93 = 32'h0000000c;
+  assign _zz__zz_decode_IS_DIV_95 = 32'h00000028;
+  assign _zz__zz_decode_IS_DIV_118 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_119 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_121 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_122 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_123) == 32'h00002000);
+  assign _zz__zz_decode_IS_DIV_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_125) == 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_128 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_DIV_129 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_133 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_134) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_135 = {(_zz__zz_decode_IS_DIV_136 == _zz__zz_decode_IS_DIV_137),(_zz__zz_decode_IS_DIV_138 == _zz__zz_decode_IS_DIV_139)};
+  assign _zz__zz_decode_IS_DIV_141 = {(_zz__zz_decode_IS_DIV_142 == _zz__zz_decode_IS_DIV_143),_zz_decode_IS_DIV_1};
+  assign _zz__zz_decode_IS_DIV_144 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_146 = ({_zz__zz_decode_IS_DIV_147,_zz_decode_IS_DIV_1} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_148 = ((_zz__zz_decode_IS_DIV_149 == _zz__zz_decode_IS_DIV_150) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_123 = 32'h00006004;
+  assign _zz__zz_decode_IS_DIV_125 = 32'h00005004;
+  assign _zz__zz_decode_IS_DIV_134 = 32'h00000044;
+  assign _zz__zz_decode_IS_DIV_136 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_DIV_137 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_138 = (decode_INSTRUCTION & 32'h40004034);
+  assign _zz__zz_decode_IS_DIV_139 = 32'h40000030;
+  assign _zz__zz_decode_IS_DIV_142 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz__zz_decode_IS_DIV_143 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_147 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_149 = (decode_INSTRUCTION & 32'h00001048);
+  assign _zz__zz_decode_IS_DIV_150 = 32'h00001008;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_295) begin
-      _zz_168 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_39) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_158                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_159                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_160                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_161                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_162                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_163                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_164                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_165                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_166                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   always @(*) begin
-    case(_zz_296)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_5)
       2'b00 : begin
-        _zz_169 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_169 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_169 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1517,113 +1557,113 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13_string = "AND_1";
-      default : _zz_13_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
-      default : _zz_14_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1636,30 +1676,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_16_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_16_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_16_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_16_string = "PC ";
-      default : _zz_16_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
-      default : _zz_17_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1671,27 +1711,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19_string = "BITWISE ";
-      default : _zz_19_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
-      default : _zz_20_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1704,30 +1744,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_22_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_22_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_22_string = "URS1        ";
-      default : _zz_22_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
-      default : _zz_23_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1739,11 +1779,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25_string = "ECALL";
-      default : _zz_25_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1755,11 +1795,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
-      default : _zz_26_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1771,11 +1811,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1788,30 +1828,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_28_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_28_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_28_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_28_string = "JALR";
-      default : _zz_28_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_31)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
-      default : _zz_31_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -1824,12 +1864,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
-      default : _zz_33_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1842,12 +1882,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
-      default : _zz_34_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1859,87 +1899,87 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
-      default : _zz_35_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
-      default : _zz_36_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
-      default : _zz_40_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
-      default : _zz_41_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
-      default : _zz_42_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
-      default : _zz_44_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
-      default : _zz_45_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
-      default : _zz_46_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1952,72 +1992,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_48_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_48_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48_string = "JALR";
-      default : _zz_48_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_90)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_90_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_90_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_90_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_90_string = "URS1        ";
-      default : _zz_90_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_91)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_91_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_91_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_91_string = "BITWISE ";
-      default : _zz_91_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_92_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_92_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_92_string = "PC ";
-      default : _zz_92_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_93_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_93_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_93_string = "AND_1";
-      default : _zz_93_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_94_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_94_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_94_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_94_string = "SRA_1    ";
-      default : _zz_94_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_95_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_95_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_95_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_95_string = "JALR";
-      default : _zz_95_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_96_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_96_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_96_string = "ECALL";
-      default : _zz_96_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2048,19 +2088,19 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2102,39 +2142,39 @@ module VexRiscv (
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_98;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_DIV = _zz_208[0];
-  assign decode_IS_RS2_SIGNED = _zz_209[0];
-  assign decode_IS_RS1_SIGNED = _zz_210[0];
-  assign decode_IS_MUL = _zz_211[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_212[0];
-  assign _zz_8 = _zz_9;
-  assign decode_SHIFT_CTRL = _zz_10;
-  assign _zz_11 = _zz_12;
-  assign decode_ALU_BITWISE_CTRL = _zz_13;
-  assign _zz_14 = _zz_15;
-  assign decode_SRC_LESS_UNSIGNED = _zz_213[0];
-  assign decode_MEMORY_STORE = _zz_214[0];
+  assign decode_IS_DIV = _zz_decode_IS_DIV[30];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_DIV[29];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_DIV[28];
+  assign decode_IS_MUL = _zz_decode_IS_DIV[27];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_DIV[24];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_DIV[16];
+  assign decode_MEMORY_STORE = _zz_decode_IS_DIV[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_215[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_216[0];
-  assign decode_SRC2_CTRL = _zz_16;
-  assign _zz_17 = _zz_18;
-  assign decode_ALU_CTRL = _zz_19;
-  assign _zz_20 = _zz_21;
-  assign decode_MEMORY_ENABLE = _zz_217[0];
-  assign decode_SRC1_CTRL = _zz_22;
-  assign _zz_23 = _zz_24;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_DIV[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_DIV[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_DIV[4];
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
@@ -2149,27 +2189,27 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_25;
-  assign execute_ENV_CTRL = _zz_26;
-  assign writeBack_ENV_CTRL = _zz_27;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_119;
-  assign execute_BRANCH_CTRL = _zz_28;
-  assign decode_RS2_USE = _zz_218[0];
-  assign decode_RS1_USE = _zz_219[0];
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_DIV[15];
+  assign decode_RS1_USE = _zz_decode_IS_DIV[5];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  always @ (*) begin
-    _zz_29 = memory_REGFILE_WRITE_DATA;
-    if(_zz_170)begin
-      _zz_29 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+  always @(*) begin
+    _zz_decode_RS2 = memory_REGFILE_WRITE_DATA;
+    if(when_MulDivIterativePlugin_l96) begin
+      _zz_decode_RS2 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
     end
-    if(_zz_171)begin
-      _zz_29 = memory_MulDivIterativePlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2 = memory_MulDivIterativePlugin_div_result;
     end
   end
 
@@ -2177,114 +2217,114 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_108)begin
-      if((_zz_109 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_110;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_172)begin
-      if(_zz_173)begin
-        if(_zz_112)begin
-          decode_RS2 = _zz_47;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_174)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_114)begin
-          decode_RS2 = _zz_29;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
-    if(_zz_175)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_116)begin
-          decode_RS2 = _zz_30;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_108)begin
-      if((_zz_109 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_110;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_172)begin
-      if(_zz_173)begin
-        if(_zz_111)begin
-          decode_RS1 = _zz_47;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_174)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_113)begin
-          decode_RS1 = _zz_29;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
-    if(_zz_175)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_115)begin
-          decode_RS1 = _zz_30;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
   end
 
-  always @ (*) begin
-    _zz_30 = execute_REGFILE_WRITE_DATA;
-    if(_zz_176)begin
-      _zz_30 = _zz_105;
+  always @(*) begin
+    _zz_decode_RS2_1 = execute_REGFILE_WRITE_DATA;
+    if(when_ShiftPlugins_l169) begin
+      _zz_decode_RS2_1 = _zz_decode_RS2_3;
     end
-    if(_zz_177)begin
-      _zz_30 = execute_CsrPlugin_readData;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2_1 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33;
-  assign execute_SRC1_CTRL = _zz_34;
-  assign decode_SRC_USE_SUB_LESS = _zz_220[0];
-  assign decode_SRC_ADD_ZERO = _zz_221[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_DIV[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35;
-  assign execute_SRC2 = _zz_104;
-  assign execute_SRC1 = _zz_99;
-  assign execute_ALU_BITWISE_CTRL = _zz_36;
-  assign _zz_37 = writeBack_INSTRUCTION;
-  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_39 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_39 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_222[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_DIV[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_297) == 32'h00001073),{(_zz_298 == _zz_299),{_zz_300,{_zz_301,_zz_302}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
-  always @ (*) begin
-    _zz_47 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusSimplePlugin_l558) begin
+      _zz_decode_RS2_2 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
@@ -2301,48 +2341,48 @@ module VexRiscv (
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
-  assign decode_FLUSH_ALL = _zz_223[0];
-  always @ (*) begin
+  assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_178)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_179)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_180)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_181)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_48;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_49 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_49 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_50 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_50 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -2350,134 +2390,134 @@ module VexRiscv (
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   assign decode_arbitration_haltItself = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_106 || _zz_107)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_182)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_182)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76)))begin
+    if(when_DBusSimplePlugin_l426) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_176)begin
-      if((! execute_LightShifterPlugin_done))begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l184) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_177)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign execute_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
+    if(when_DBusSimplePlugin_l479) begin
       memory_arbitration_haltItself = 1'b1;
     end
-    if(_zz_170)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l97) begin
         memory_arbitration_haltItself = 1'b1;
       end
-      if(_zz_183)begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_171)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_184)begin
+    if(_zz_when_1) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_184)begin
+    if(_zz_when_1) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltItself = 1'b0;
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
   assign writeBack_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_185)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_186)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2486,45 +2526,47 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_185)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_186)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_185)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_186)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_185)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_186)begin
-      case(_zz_187)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2537,58 +2579,64 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
-  assign _zz_51 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
-  assign _zz_52 = (_zz_51 & (~ _zz_224));
-  assign _zz_53 = _zz_52[1];
-  assign _zz_54 = _zz_52[2];
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_169;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[1];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_226);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -2596,314 +2644,332 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_55 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_55);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_55);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_56 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_56);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_56);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_57 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_57);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_57);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_58;
-  assign _zz_58 = ((1'b0 && (! _zz_59)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_59 = _zz_60;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_59;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_61)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_61 = _zz_62;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_61;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_63;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_64 = _zz_227[11];
-  always @ (*) begin
-    _zz_65[18] = _zz_64;
-    _zz_65[17] = _zz_64;
-    _zz_65[16] = _zz_64;
-    _zz_65[15] = _zz_64;
-    _zz_65[14] = _zz_64;
-    _zz_65[13] = _zz_64;
-    _zz_65[12] = _zz_64;
-    _zz_65[11] = _zz_64;
-    _zz_65[10] = _zz_64;
-    _zz_65[9] = _zz_64;
-    _zz_65[8] = _zz_64;
-    _zz_65[7] = _zz_64;
-    _zz_65[6] = _zz_64;
-    _zz_65[5] = _zz_64;
-    _zz_65[4] = _zz_64;
-    _zz_65[3] = _zz_64;
-    _zz_65[2] = _zz_64;
-    _zz_65[1] = _zz_64;
-    _zz_65[0] = _zz_64;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_228[31]));
-    if(_zz_70)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_66 = _zz_229[19];
-  always @ (*) begin
-    _zz_67[10] = _zz_66;
-    _zz_67[9] = _zz_66;
-    _zz_67[8] = _zz_66;
-    _zz_67[7] = _zz_66;
-    _zz_67[6] = _zz_66;
-    _zz_67[5] = _zz_66;
-    _zz_67[4] = _zz_66;
-    _zz_67[3] = _zz_66;
-    _zz_67[2] = _zz_66;
-    _zz_67[1] = _zz_66;
-    _zz_67[0] = _zz_66;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_68 = _zz_230[11];
-  always @ (*) begin
-    _zz_69[18] = _zz_68;
-    _zz_69[17] = _zz_68;
-    _zz_69[16] = _zz_68;
-    _zz_69[15] = _zz_68;
-    _zz_69[14] = _zz_68;
-    _zz_69[13] = _zz_68;
-    _zz_69[12] = _zz_68;
-    _zz_69[11] = _zz_68;
-    _zz_69[10] = _zz_68;
-    _zz_69[9] = _zz_68;
-    _zz_69[8] = _zz_68;
-    _zz_69[7] = _zz_68;
-    _zz_69[6] = _zz_68;
-    _zz_69[5] = _zz_68;
-    _zz_69[4] = _zz_68;
-    _zz_69[3] = _zz_68;
-    _zz_69[2] = _zz_68;
-    _zz_69[1] = _zz_68;
-    _zz_69[0] = _zz_68;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_70 = _zz_231[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_70 = _zz_232[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_71 = _zz_233[19];
-  always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_73 = _zz_234[11];
-  always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_72,{{{_zz_315,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_74,{{{_zz_316,_zz_317},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_159 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_160 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_161 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_160;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_163 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_164 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_165 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_181)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_179)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_166 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_179)begin
-      _zz_166 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_180)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_178)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_180)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_178)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_158 = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign _zz_76 = 1'b0;
-  always @ (*) begin
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_dBus_cmd_valid = 1'b0;
+  always @(*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
-    if(execute_ALIGNEMENT_FAULT)begin
+    if(execute_ALIGNEMENT_FAULT) begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_77 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_dBus_cmd_payload_data = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_77 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_dBus_cmd_payload_data = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_77 = execute_RS2[31 : 0];
+        _zz_dBus_cmd_payload_data = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_77;
-  always @ (*) begin
+  assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
+  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_78 = 4'b0001;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0001;
       end
       2'b01 : begin
-        _zz_78 = 4'b0011;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0011;
       end
       default : begin
-        _zz_78 = 4'b1111;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_78 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_188)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
+    if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
+    if(when_DBusSimplePlugin_l512) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_188)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_235};
+    if(memory_ALIGNEMENT_FAULT) begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_DBusSimplePlugin_memoryExceptionPort_payload_code};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l486 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l512 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
@@ -2920,63 +2986,64 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_79 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_80[31] = _zz_79;
-    _zz_80[30] = _zz_79;
-    _zz_80[29] = _zz_79;
-    _zz_80[28] = _zz_79;
-    _zz_80[27] = _zz_79;
-    _zz_80[26] = _zz_79;
-    _zz_80[25] = _zz_79;
-    _zz_80[24] = _zz_79;
-    _zz_80[23] = _zz_79;
-    _zz_80[22] = _zz_79;
-    _zz_80[21] = _zz_79;
-    _zz_80[20] = _zz_79;
-    _zz_80[19] = _zz_79;
-    _zz_80[18] = _zz_79;
-    _zz_80[17] = _zz_79;
-    _zz_80[16] = _zz_79;
-    _zz_80[15] = _zz_79;
-    _zz_80[14] = _zz_79;
-    _zz_80[13] = _zz_79;
-    _zz_80[12] = _zz_79;
-    _zz_80[11] = _zz_79;
-    _zz_80[10] = _zz_79;
-    _zz_80[9] = _zz_79;
-    _zz_80[8] = _zz_79;
-    _zz_80[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[30] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[29] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[28] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[27] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[26] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[25] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[24] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[23] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[22] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[21] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[20] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[19] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[18] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[17] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[16] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[15] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[14] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[13] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[12] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[11] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[10] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[9] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[8] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_81 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_82[31] = _zz_81;
-    _zz_82[30] = _zz_81;
-    _zz_82[29] = _zz_81;
-    _zz_82[28] = _zz_81;
-    _zz_82[27] = _zz_81;
-    _zz_82[26] = _zz_81;
-    _zz_82[25] = _zz_81;
-    _zz_82[24] = _zz_81;
-    _zz_82[23] = _zz_81;
-    _zz_82[22] = _zz_81;
-    _zz_82[21] = _zz_81;
-    _zz_82[20] = _zz_81;
-    _zz_82[19] = _zz_81;
-    _zz_82[18] = _zz_81;
-    _zz_82[17] = _zz_81;
-    _zz_82[16] = _zz_81;
-    _zz_82[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated_2 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[31] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[30] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[29] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[28] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[27] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[26] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[25] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[24] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[23] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[22] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[21] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[20] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[19] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[18] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[17] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[16] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_206)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_80;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_82;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_3;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2984,6 +3051,7 @@ module VexRiscv (
     endcase
   end
 
+  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -2993,61 +3061,62 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_84 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_85 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_86 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_87 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_83 = {(((decode_INSTRUCTION & _zz_318) == 32'h02004020) != 1'b0),{({_zz_89,_zz_88} != 2'b00),{({_zz_319,_zz_320} != 3'b000),{(_zz_321 != _zz_322),{_zz_323,{_zz_324,_zz_325}}}}}};
-  assign _zz_90 = _zz_83[2 : 1];
-  assign _zz_46 = _zz_90;
-  assign _zz_91 = _zz_83[7 : 6];
-  assign _zz_45 = _zz_91;
-  assign _zz_92 = _zz_83[9 : 8];
-  assign _zz_44 = _zz_92;
-  assign _zz_93 = _zz_83[18 : 17];
-  assign _zz_43 = _zz_93;
-  assign _zz_94 = _zz_83[21 : 20];
-  assign _zz_42 = _zz_94;
-  assign _zz_95 = _zz_83[23 : 22];
-  assign _zz_41 = _zz_95;
-  assign _zz_96 = _zz_83[26 : 25];
-  assign _zz_40 = _zz_96;
+  assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_decode_IS_DIV_6 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_decode_IS_DIV = {(((decode_INSTRUCTION & _zz__zz_decode_IS_DIV) == 32'h02004020) != 1'b0),{({_zz_decode_IS_DIV_6,_zz_decode_IS_DIV_5} != 2'b00),{({_zz__zz_decode_IS_DIV_1,_zz__zz_decode_IS_DIV_2} != 3'b000),{(_zz__zz_decode_IS_DIV_3 != _zz__zz_decode_IS_DIV_4),{_zz__zz_decode_IS_DIV_5,{_zz__zz_decode_IS_DIV_7,_zz__zz_decode_IS_DIV_10}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_DIV[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_DIV[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_DIV[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_DIV[18 : 17];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_DIV[21 : 20];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_DIV[23 : 22];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_DIV[26 : 25];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_167;
-  assign decode_RegFilePlugin_rs2Data = _zz_168;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
-    if(_zz_97)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
-    if(_zz_97)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_47;
-    if(_zz_97)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3056,296 +3125,322 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_98 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_98 = {31'd0, _zz_236};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_98 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_99 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_99 = {29'd0, _zz_237};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_99 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_99 = {27'd0, _zz_238};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_100 = _zz_239[11];
-  always @ (*) begin
-    _zz_101[19] = _zz_100;
-    _zz_101[18] = _zz_100;
-    _zz_101[17] = _zz_100;
-    _zz_101[16] = _zz_100;
-    _zz_101[15] = _zz_100;
-    _zz_101[14] = _zz_100;
-    _zz_101[13] = _zz_100;
-    _zz_101[12] = _zz_100;
-    _zz_101[11] = _zz_100;
-    _zz_101[10] = _zz_100;
-    _zz_101[9] = _zz_100;
-    _zz_101[8] = _zz_100;
-    _zz_101[7] = _zz_100;
-    _zz_101[6] = _zz_100;
-    _zz_101[5] = _zz_100;
-    _zz_101[4] = _zz_100;
-    _zz_101[3] = _zz_100;
-    _zz_101[2] = _zz_100;
-    _zz_101[1] = _zz_100;
-    _zz_101[0] = _zz_100;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_102 = _zz_240[11];
-  always @ (*) begin
-    _zz_103[19] = _zz_102;
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_104 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_104 = {_zz_101,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_104 = {_zz_103,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_104 = _zz_32;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_241;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  always @ (*) begin
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_105 = (execute_LightShifterPlugin_shiftInput <<< 1);
+      `ShiftCtrlEnum_defaultEncoding_SLL : begin
+        _zz_decode_RS2_3 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_105 = _zz_248;
+        _zz_decode_RS2_3 = _zz__zz_decode_RS2_3;
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_106 = 1'b0;
-    if(_zz_189)begin
-      if(_zz_190)begin
-        if(_zz_111)begin
-          _zz_106 = 1'b1;
+  assign when_ShiftPlugins_l175 = (! execute_arbitration_isStuckByOthers);
+  assign when_ShiftPlugins_l184 = (! execute_LightShifterPlugin_done);
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_191)begin
-      if(_zz_192)begin
-        if(_zz_113)begin
-          _zz_106 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_193)begin
-      if(_zz_194)begin
-        if(_zz_115)begin
-          _zz_106 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_106 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_107 = 1'b0;
-    if(_zz_189)begin
-      if(_zz_190)begin
-        if(_zz_112)begin
-          _zz_107 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_191)begin
-      if(_zz_192)begin
-        if(_zz_114)begin
-          _zz_107 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_193)begin
-      if(_zz_194)begin
-        if(_zz_116)begin
-          _zz_107 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS2_USE))begin
-      _zz_107 = 1'b0;
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
     end
   end
 
-  assign _zz_111 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_112 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_113 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_114 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_115 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_117 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_117 == 3'b000)) begin
-        _zz_118 = execute_BranchPlugin_eq;
-    end else if((_zz_117 == 3'b001)) begin
-        _zz_118 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_117 & 3'b101) == 3'b101))) begin
-        _zz_118 = (! execute_SRC_LESS);
-    end else begin
-        _zz_118 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_119 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_119 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_119 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_119 = _zz_118;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_120 = _zz_250[11];
-  always @ (*) begin
-    _zz_121[19] = _zz_120;
-    _zz_121[18] = _zz_120;
-    _zz_121[17] = _zz_120;
-    _zz_121[16] = _zz_120;
-    _zz_121[15] = _zz_120;
-    _zz_121[14] = _zz_120;
-    _zz_121[13] = _zz_120;
-    _zz_121[12] = _zz_120;
-    _zz_121[11] = _zz_120;
-    _zz_121[10] = _zz_120;
-    _zz_121[9] = _zz_120;
-    _zz_121[8] = _zz_120;
-    _zz_121[7] = _zz_120;
-    _zz_121[6] = _zz_120;
-    _zz_121[5] = _zz_120;
-    _zz_121[4] = _zz_120;
-    _zz_121[3] = _zz_120;
-    _zz_121[2] = _zz_120;
-    _zz_121[1] = _zz_120;
-    _zz_121[0] = _zz_120;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_122 = _zz_251[19];
-  always @ (*) begin
-    _zz_123[10] = _zz_122;
-    _zz_123[9] = _zz_122;
-    _zz_123[8] = _zz_122;
-    _zz_123[7] = _zz_122;
-    _zz_123[6] = _zz_122;
-    _zz_123[5] = _zz_122;
-    _zz_123[4] = _zz_122;
-    _zz_123[3] = _zz_122;
-    _zz_123[2] = _zz_122;
-    _zz_123[1] = _zz_122;
-    _zz_123[0] = _zz_122;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_124 = _zz_252[11];
-  always @ (*) begin
-    _zz_125[18] = _zz_124;
-    _zz_125[17] = _zz_124;
-    _zz_125[16] = _zz_124;
-    _zz_125[15] = _zz_124;
-    _zz_125[14] = _zz_124;
-    _zz_125[13] = _zz_124;
-    _zz_125[12] = _zz_124;
-    _zz_125[11] = _zz_124;
-    _zz_125[10] = _zz_124;
-    _zz_125[9] = _zz_124;
-    _zz_125[8] = _zz_124;
-    _zz_125[7] = _zz_124;
-    _zz_125[6] = _zz_124;
-    _zz_125[5] = _zz_124;
-    _zz_125[4] = _zz_124;
-    _zz_125[3] = _zz_124;
-    _zz_125[2] = _zz_124;
-    _zz_125[1] = _zz_124;
-    _zz_125[0] = _zz_124;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_126 = (_zz_253[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_126 = _zz_254[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_126 = _zz_255[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_126);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -3356,80 +3451,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_127 = _zz_256[11];
-  always @ (*) begin
-    _zz_128[19] = _zz_127;
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_128,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_130,{{{_zz_469,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_132,{{{_zz_470,_zz_471},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_259};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_129 = _zz_257[19];
-  always @ (*) begin
-    _zz_130[10] = _zz_129;
-    _zz_130[9] = _zz_129;
-    _zz_130[8] = _zz_129;
-    _zz_130[7] = _zz_129;
-    _zz_130[6] = _zz_129;
-    _zz_130[5] = _zz_129;
-    _zz_130[4] = _zz_129;
-    _zz_130[3] = _zz_129;
-    _zz_130[2] = _zz_129;
-    _zz_130[1] = _zz_129;
-    _zz_130[0] = _zz_129;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_131 = _zz_258[11];
-  always @ (*) begin
-    _zz_132[18] = _zz_131;
-    _zz_132[17] = _zz_131;
-    _zz_132[16] = _zz_131;
-    _zz_132[15] = _zz_131;
-    _zz_132[14] = _zz_131;
-    _zz_132[13] = _zz_131;
-    _zz_132[12] = _zz_131;
-    _zz_132[11] = _zz_131;
-    _zz_132[10] = _zz_131;
-    _zz_132[9] = _zz_131;
-    _zz_132[8] = _zz_131;
-    _zz_132[7] = _zz_131;
-    _zz_132[6] = _zz_131;
-    _zz_132[5] = _zz_131;
-    _zz_132[4] = _zz_131;
-    _zz_132[3] = _zz_131;
-    _zz_132[2] = _zz_131;
-    _zz_132[1] = _zz_131;
-    _zz_132[0] = _zz_131;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -3439,94 +3534,108 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_133 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_134 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_135 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_136 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_137 = _zz_260[0];
-  assign _zz_138 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_139 = _zz_262[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_182)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_184)begin
+    if(_zz_when_1) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -3537,8 +3646,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -3548,72 +3657,79 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_195)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_196)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_196)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3626,134 +3742,206 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_195)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_195)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_207)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_170)begin
-      if(_zz_183)begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l110) begin
       memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
     end
   end
 
   assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_265);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
-    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
+    if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end
   end
 
-  always @ (*) begin
+  assign when_MulDivIterativePlugin_l96 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign when_MulDivIterativePlugin_l97 = ((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign when_MulDivIterativePlugin_l100 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign when_MulDivIterativePlugin_l110 = (! memory_arbitration_isStuck);
+  always @(*) begin
     memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_171)begin
-      if(_zz_197)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_div_counter_willClear = 1'b0;
-    if(_zz_198)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_MulDivIterativePlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_MulDivIterativePlugin_div_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_div_counter_value == 6'h21);
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_273);
+      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
-    if(memory_MulDivIterativePlugin_div_counter_willClear)begin
+    if(memory_MulDivIterativePlugin_div_counter_willClear) begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_140 = memory_MulDivIterativePlugin_rs1[31 : 0];
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_140[31]};
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_274);
-  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_275 : _zz_276);
-  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_277[31:0];
-  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
-  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_143 = ((execute_IS_MUL && _zz_142) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_144[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted = memory_MulDivIterativePlugin_rs1[31 : 0];
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31]};
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder : _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1);
+  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
+  assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
   end
 
-  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_146 != 32'h0);
-  assign _zz_24 = decode_SRC1_CTRL;
-  assign _zz_22 = _zz_46;
-  assign _zz_34 = decode_to_execute_SRC1_CTRL;
-  assign _zz_21 = decode_ALU_CTRL;
-  assign _zz_19 = _zz_45;
-  assign _zz_35 = decode_to_execute_ALU_CTRL;
-  assign _zz_18 = decode_SRC2_CTRL;
-  assign _zz_16 = _zz_44;
-  assign _zz_33 = decode_to_execute_SRC2_CTRL;
-  assign _zz_15 = decode_ALU_BITWISE_CTRL;
-  assign _zz_13 = _zz_43;
-  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_12 = decode_SHIFT_CTRL;
-  assign _zz_10 = _zz_42;
-  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_48 = _zz_41;
-  assign _zz_28 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_40;
-  assign _zz_26 = decode_to_execute_ENV_CTRL;
-  assign _zz_25 = execute_to_memory_ENV_CTRL;
-  assign _zz_27 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_14 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_17 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_49 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3774,94 +3962,113 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_147 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_147[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_147[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_147[3 : 3] = CsrPlugin_mstatus_MIE;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_148 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_148[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_148[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_148[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_149 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_149[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_149[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_149[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_150[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_151[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_151[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_152[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_153[31 : 0] = _zz_145;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_154[31 : 0] = _zz_146;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_147 | _zz_148) | (_zz_149 | _zz_150)) | ((_zz_151 | _zz_152) | (_zz_153 | _zz_154)));
-  assign iBusWishbone_ADR = {_zz_293,_zz_155};
-  assign iBusWishbone_CTI = ((_zz_155 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_199)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_199)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_156;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
+  assign when_Stream_l399 = (! dBus_cmd_halfPipe_regs_valid);
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
   assign dBus_cmd_halfPipe_payload_wr = dBus_cmd_halfPipe_regs_payload_wr;
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_halfPipe_regs_payload_address;
@@ -3871,27 +4078,28 @@ module VexRiscv (
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_157 = 4'b0001;
+        _zz_dBusWishbone_SEL = 4'b0001;
       end
       2'b01 : begin
-        _zz_157 = 4'b0011;
+        _zz_dBusWishbone_SEL = 4'b0011;
       end
       default : begin
-        _zz_157 = 4'b1111;
+        _zz_dBusWishbone_SEL = 4'b1111;
       end
     endcase
   end
 
-  always @ (*) begin
-    dBusWishbone_SEL = (_zz_157 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if((! dBus_cmd_halfPipe_payload_wr))begin
+  always @(*) begin
+    dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    if(when_DBusSimplePlugin_l189) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
+  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -3900,24 +4108,24 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_60 <= 1'b0;
-      _zz_62 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_75;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_97 <= 1'b1;
+      _zz_7 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_108 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -3936,89 +4144,89 @@ module VexRiscv (
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
       memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_145 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_155 <= 3'b000;
-      _zz_156 <= 1'b0;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_60 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_58)begin
-        _zz_60 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_62 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_62 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       `ifndef SYNTHESIS
@@ -4041,72 +4249,72 @@ module VexRiscv (
           end
         `endif
       `endif
-      _zz_97 <= 1'b0;
-      if(_zz_176)begin
-        if(_zz_200)begin
+      _zz_7 <= 1'b0;
+      if(when_ShiftPlugins_l169) begin
+        if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
-          if(execute_LightShifterPlugin_done)begin
+          if(execute_LightShifterPlugin_done) begin
             execute_LightShifterPlugin_isActive <= 1'b0;
           end
         end
       end
-      if(execute_arbitration_removeIt)begin
+      if(execute_arbitration_removeIt) begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_108 <= (_zz_38 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_201)begin
-        if(_zz_202)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_203)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_204)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_185)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4117,8 +4325,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_186)begin
-        case(_zz_187)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4128,53 +4336,53 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_135,{_zz_134,_zz_133}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_287[0];
-          CsrPlugin_mstatus_MIE <= _zz_288[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_290[0];
-          CsrPlugin_mie_MTIE <= _zz_291[0];
-          CsrPlugin_mie_MSIE <= _zz_292[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_199)begin
-        if(iBusWishbone_ACK)begin
-          _zz_155 <= (_zz_155 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_156 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_205)begin
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_Stream_l399) begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -4184,63 +4392,63 @@ module VexRiscv (
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_63 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_176)begin
-      if(_zz_200)begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l175) begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_109 <= _zz_37[11 : 7];
-    _zz_110 <= _zz_47;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_182)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_184)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_when_1) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_201)begin
-      if(_zz_202)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_203)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_204)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_185)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -4248,238 +4456,238 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_170)begin
-      if(_zz_183)begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_266,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
-    if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_MulDivIterativePlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_MulDivIterativePlugin_div_done <= 1'b0;
     end
-    if(_zz_171)begin
-      if(_zz_197)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_MulDivIterativePlugin_rs1[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outNumerator;
         memory_MulDivIterativePlugin_accumulator[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outRemainder;
-        if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
-          memory_MulDivIterativePlugin_div_result <= _zz_278[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_MulDivIterativePlugin_div_result <= _zz_memory_MulDivIterativePlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_198)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_284);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_286);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_50;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_49;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_23;
+    if(when_Pipeline_l124_9) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_10) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_20;
+    if(when_Pipeline_l124_14) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_17;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_16) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_14;
+    if(when_Pipeline_l124_26) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_11;
+    if(when_Pipeline_l124_27) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_30) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_31) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_32) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_34) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_35) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    if(when_Pipeline_l124_48) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_29;
+    if(when_Pipeline_l124_49) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_50) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_289[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_205)begin
+    if(when_Stream_l399) begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -4532,13 +4740,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [22:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [22:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [22:0]   _zz_ways_0_tags_port1;
+  wire       [22:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -4547,8 +4751,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [6:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -4562,22 +4771,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [8:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [8:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [8:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [5:0]    _zz_6;
-  wire                _zz_7;
+  wire       [5:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [22:0]   _zz_8;
+  wire       [22:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -4587,82 +4799,85 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
   (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
-  assign _zz_11 = (! lineLoader_flushCounter[6]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[6]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -4678,30 +4893,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[10 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[10 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[10 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[22 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[10 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -4709,51 +4929,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[6];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 7'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -4764,10 +4984,10 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -81,18 +81,17 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_160;
-  wire                _zz_161;
-  wire                _zz_162;
-  wire                _zz_163;
-  wire                _zz_164;
-  wire                _zz_165;
-  wire                _zz_166;
-  wire                _zz_167;
-  reg                 _zz_168;
-  reg        [31:0]   _zz_169;
-  reg        [31:0]   _zz_170;
-  reg        [31:0]   _zz_171;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -105,312 +104,249 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                _zz_172;
-  wire                _zz_173;
-  wire                _zz_174;
-  wire                _zz_175;
-  wire                _zz_176;
-  wire                _zz_177;
-  wire                _zz_178;
-  wire                _zz_179;
-  wire                _zz_180;
-  wire                _zz_181;
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  wire                _zz_190;
-  wire                _zz_191;
-  wire       [1:0]    _zz_192;
-  wire                _zz_193;
-  wire                _zz_194;
-  wire                _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire                _zz_198;
-  wire                _zz_199;
-  wire                _zz_200;
-  wire                _zz_201;
-  wire                _zz_202;
-  wire                _zz_203;
-  wire       [5:0]    _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  wire                _zz_207;
-  wire                _zz_208;
-  wire                _zz_209;
-  wire                _zz_210;
-  wire                _zz_211;
-  wire       [1:0]    _zz_212;
-  wire                _zz_213;
-  wire       [0:0]    _zz_214;
-  wire       [0:0]    _zz_215;
-  wire       [0:0]    _zz_216;
-  wire       [0:0]    _zz_217;
-  wire       [0:0]    _zz_218;
-  wire       [0:0]    _zz_219;
-  wire       [0:0]    _zz_220;
-  wire       [0:0]    _zz_221;
-  wire       [0:0]    _zz_222;
-  wire       [0:0]    _zz_223;
-  wire       [0:0]    _zz_224;
-  wire       [0:0]    _zz_225;
-  wire       [0:0]    _zz_226;
-  wire       [0:0]    _zz_227;
-  wire       [0:0]    _zz_228;
-  wire       [0:0]    _zz_229;
-  wire       [0:0]    _zz_230;
-  wire       [2:0]    _zz_231;
-  wire       [2:0]    _zz_232;
-  wire       [31:0]   _zz_233;
-  wire       [11:0]   _zz_234;
-  wire       [31:0]   _zz_235;
-  wire       [19:0]   _zz_236;
-  wire       [11:0]   _zz_237;
-  wire       [31:0]   _zz_238;
-  wire       [31:0]   _zz_239;
-  wire       [19:0]   _zz_240;
-  wire       [11:0]   _zz_241;
-  wire       [2:0]    _zz_242;
-  wire       [0:0]    _zz_243;
-  wire       [2:0]    _zz_244;
-  wire       [4:0]    _zz_245;
-  wire       [11:0]   _zz_246;
-  wire       [11:0]   _zz_247;
-  wire       [31:0]   _zz_248;
-  wire       [31:0]   _zz_249;
-  wire       [31:0]   _zz_250;
-  wire       [31:0]   _zz_251;
-  wire       [31:0]   _zz_252;
-  wire       [31:0]   _zz_253;
-  wire       [31:0]   _zz_254;
-  wire       [31:0]   _zz_255;
-  wire       [32:0]   _zz_256;
-  wire       [11:0]   _zz_257;
-  wire       [19:0]   _zz_258;
-  wire       [11:0]   _zz_259;
-  wire       [31:0]   _zz_260;
-  wire       [31:0]   _zz_261;
-  wire       [31:0]   _zz_262;
-  wire       [11:0]   _zz_263;
-  wire       [19:0]   _zz_264;
-  wire       [11:0]   _zz_265;
-  wire       [2:0]    _zz_266;
-  wire       [1:0]    _zz_267;
-  wire       [1:0]    _zz_268;
-  wire       [1:0]    _zz_269;
-  wire       [1:0]    _zz_270;
-  wire       [0:0]    _zz_271;
-  wire       [5:0]    _zz_272;
-  wire       [33:0]   _zz_273;
-  wire       [32:0]   _zz_274;
-  wire       [33:0]   _zz_275;
-  wire       [32:0]   _zz_276;
-  wire       [33:0]   _zz_277;
-  wire       [32:0]   _zz_278;
-  wire       [0:0]    _zz_279;
-  wire       [5:0]    _zz_280;
-  wire       [32:0]   _zz_281;
-  wire       [31:0]   _zz_282;
-  wire       [31:0]   _zz_283;
-  wire       [32:0]   _zz_284;
-  wire       [32:0]   _zz_285;
-  wire       [32:0]   _zz_286;
-  wire       [32:0]   _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [32:0]   _zz_289;
-  wire       [0:0]    _zz_290;
-  wire       [32:0]   _zz_291;
-  wire       [0:0]    _zz_292;
-  wire       [31:0]   _zz_293;
-  wire       [0:0]    _zz_294;
-  wire       [0:0]    _zz_295;
-  wire       [0:0]    _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [0:0]    _zz_298;
-  wire       [0:0]    _zz_299;
-  wire       [26:0]   _zz_300;
-  wire                _zz_301;
-  wire                _zz_302;
-  wire       [1:0]    _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [31:0]   _zz_306;
-  wire                _zz_307;
-  wire       [0:0]    _zz_308;
-  wire       [12:0]   _zz_309;
-  wire       [31:0]   _zz_310;
-  wire       [31:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire                _zz_313;
-  wire       [0:0]    _zz_314;
-  wire       [6:0]    _zz_315;
-  wire       [31:0]   _zz_316;
-  wire       [31:0]   _zz_317;
-  wire       [31:0]   _zz_318;
-  wire                _zz_319;
-  wire       [0:0]    _zz_320;
-  wire       [0:0]    _zz_321;
-  wire                _zz_322;
-  wire                _zz_323;
-  wire                _zz_324;
-  wire       [31:0]   _zz_325;
-  wire       [31:0]   _zz_326;
-  wire       [31:0]   _zz_327;
-  wire       [0:0]    _zz_328;
-  wire       [0:0]    _zz_329;
-  wire       [2:0]    _zz_330;
-  wire       [2:0]    _zz_331;
-  wire                _zz_332;
-  wire       [0:0]    _zz_333;
-  wire       [25:0]   _zz_334;
-  wire       [31:0]   _zz_335;
-  wire       [31:0]   _zz_336;
-  wire       [31:0]   _zz_337;
-  wire                _zz_338;
-  wire       [1:0]    _zz_339;
-  wire       [1:0]    _zz_340;
-  wire                _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [21:0]   _zz_343;
-  wire       [31:0]   _zz_344;
-  wire       [31:0]   _zz_345;
-  wire       [31:0]   _zz_346;
-  wire       [31:0]   _zz_347;
-  wire                _zz_348;
-  wire                _zz_349;
-  wire       [1:0]    _zz_350;
-  wire       [1:0]    _zz_351;
-  wire                _zz_352;
-  wire       [0:0]    _zz_353;
-  wire       [18:0]   _zz_354;
-  wire       [31:0]   _zz_355;
-  wire       [31:0]   _zz_356;
-  wire       [31:0]   _zz_357;
-  wire       [31:0]   _zz_358;
-  wire                _zz_359;
-  wire       [0:0]    _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [0:0]    _zz_362;
-  wire       [1:0]    _zz_363;
-  wire       [0:0]    _zz_364;
-  wire       [0:0]    _zz_365;
-  wire                _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [15:0]   _zz_368;
-  wire       [31:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire       [31:0]   _zz_371;
-  wire       [31:0]   _zz_372;
-  wire       [31:0]   _zz_373;
-  wire       [31:0]   _zz_374;
-  wire       [31:0]   _zz_375;
-  wire                _zz_376;
-  wire                _zz_377;
-  wire       [31:0]   _zz_378;
-  wire       [31:0]   _zz_379;
-  wire       [1:0]    _zz_380;
-  wire       [1:0]    _zz_381;
-  wire                _zz_382;
-  wire       [0:0]    _zz_383;
-  wire       [13:0]   _zz_384;
-  wire       [31:0]   _zz_385;
-  wire       [31:0]   _zz_386;
-  wire       [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire                _zz_389;
-  wire                _zz_390;
-  wire       [0:0]    _zz_391;
-  wire       [1:0]    _zz_392;
-  wire       [0:0]    _zz_393;
-  wire       [0:0]    _zz_394;
-  wire                _zz_395;
-  wire       [0:0]    _zz_396;
-  wire       [10:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [31:0]   _zz_399;
-  wire       [31:0]   _zz_400;
-  wire       [31:0]   _zz_401;
-  wire       [31:0]   _zz_402;
-  wire       [31:0]   _zz_403;
-  wire       [31:0]   _zz_404;
-  wire       [31:0]   _zz_405;
-  wire       [0:0]    _zz_406;
-  wire       [1:0]    _zz_407;
-  wire       [5:0]    _zz_408;
-  wire       [5:0]    _zz_409;
-  wire                _zz_410;
-  wire       [0:0]    _zz_411;
-  wire       [7:0]    _zz_412;
-  wire       [31:0]   _zz_413;
-  wire       [31:0]   _zz_414;
-  wire       [31:0]   _zz_415;
-  wire       [31:0]   _zz_416;
-  wire                _zz_417;
-  wire       [0:0]    _zz_418;
-  wire       [2:0]    _zz_419;
-  wire                _zz_420;
-  wire       [0:0]    _zz_421;
-  wire       [0:0]    _zz_422;
-  wire       [1:0]    _zz_423;
-  wire       [1:0]    _zz_424;
-  wire                _zz_425;
-  wire       [0:0]    _zz_426;
-  wire       [4:0]    _zz_427;
-  wire       [31:0]   _zz_428;
-  wire       [31:0]   _zz_429;
-  wire       [31:0]   _zz_430;
-  wire                _zz_431;
-  wire       [0:0]    _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [31:0]   _zz_434;
-  wire       [31:0]   _zz_435;
-  wire       [31:0]   _zz_436;
-  wire                _zz_437;
-  wire                _zz_438;
-  wire                _zz_439;
-  wire       [3:0]    _zz_440;
-  wire       [3:0]    _zz_441;
-  wire                _zz_442;
-  wire       [0:0]    _zz_443;
-  wire       [2:0]    _zz_444;
-  wire       [31:0]   _zz_445;
-  wire       [31:0]   _zz_446;
-  wire       [31:0]   _zz_447;
-  wire       [31:0]   _zz_448;
-  wire       [31:0]   _zz_449;
-  wire       [31:0]   _zz_450;
-  wire       [31:0]   _zz_451;
-  wire       [31:0]   _zz_452;
-  wire                _zz_453;
-  wire       [0:0]    _zz_454;
-  wire       [1:0]    _zz_455;
-  wire                _zz_456;
-  wire       [2:0]    _zz_457;
-  wire       [2:0]    _zz_458;
-  wire                _zz_459;
-  wire       [0:0]    _zz_460;
-  wire       [0:0]    _zz_461;
-  wire       [31:0]   _zz_462;
-  wire       [31:0]   _zz_463;
-  wire       [31:0]   _zz_464;
-  wire       [31:0]   _zz_465;
-  wire       [31:0]   _zz_466;
-  wire       [31:0]   _zz_467;
-  wire       [31:0]   _zz_468;
-  wire                _zz_469;
-  wire                _zz_470;
-  wire                _zz_471;
-  wire       [0:0]    _zz_472;
-  wire       [0:0]    _zz_473;
-  wire                _zz_474;
-  wire                _zz_475;
-  wire                _zz_476;
-  wire                _zz_477;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [2:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_2;
+  wire       [11:0]   _zz__zz_4;
+  wire       [31:0]   _zz__zz_6;
+  wire       [31:0]   _zz__zz_6_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
+  wire       [31:0]   _zz__zz_decode_IS_DIV;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_1;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_2;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_3;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_4;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_5;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_6;
+  wire                _zz__zz_decode_IS_DIV_7;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_8;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_9;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_10;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_11;
+  wire       [25:0]   _zz__zz_decode_IS_DIV_12;
+  wire                _zz__zz_decode_IS_DIV_13;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_14;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_15;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_16;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_17;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_18;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_19;
+  wire                _zz__zz_decode_IS_DIV_20;
+  wire                _zz__zz_decode_IS_DIV_21;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_22;
+  wire                _zz__zz_decode_IS_DIV_23;
+  wire       [21:0]   _zz__zz_decode_IS_DIV_24;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_25;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_26;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_27;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_28;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_29;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_30;
+  wire                _zz__zz_decode_IS_DIV_31;
+  wire                _zz__zz_decode_IS_DIV_32;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_33;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_34;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_35;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_36;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_37;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_38;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_39;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_40;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_41;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_42;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_43;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_44;
+  wire                _zz__zz_decode_IS_DIV_45;
+  wire                _zz__zz_decode_IS_DIV_46;
+  wire       [18:0]   _zz__zz_decode_IS_DIV_47;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_48;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_49;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_50;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_51;
+  wire                _zz__zz_decode_IS_DIV_52;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_53;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_54;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_55;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_56;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_57;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_58;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_59;
+  wire       [15:0]   _zz__zz_decode_IS_DIV_60;
+  wire                _zz__zz_decode_IS_DIV_61;
+  wire                _zz__zz_decode_IS_DIV_62;
+  wire                _zz__zz_decode_IS_DIV_63;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_64;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_65;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_66;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_67;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_68;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_69;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_70;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_71;
+  wire       [13:0]   _zz__zz_decode_IS_DIV_72;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_73;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_74;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_75;
+  wire                _zz__zz_decode_IS_DIV_76;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_77;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_78;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_79;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_80;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_81;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_82;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_83;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_84;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_85;
+  wire       [10:0]   _zz__zz_decode_IS_DIV_86;
+  wire       [5:0]    _zz__zz_decode_IS_DIV_87;
+  wire                _zz__zz_decode_IS_DIV_88;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_89;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_90;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_91;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_92;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_93;
+  wire                _zz__zz_decode_IS_DIV_94;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_95;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_96;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_97;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_98;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_99;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_100;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_101;
+  wire       [5:0]    _zz__zz_decode_IS_DIV_102;
+  wire                _zz__zz_decode_IS_DIV_103;
+  wire                _zz__zz_decode_IS_DIV_104;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_105;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_106;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_107;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_108;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_109;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_110;
+  wire       [7:0]    _zz__zz_decode_IS_DIV_111;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_112;
+  wire                _zz__zz_decode_IS_DIV_113;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_114;
+  wire                _zz__zz_decode_IS_DIV_115;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_116;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_117;
+  wire                _zz__zz_decode_IS_DIV_118;
+  wire                _zz__zz_decode_IS_DIV_119;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_120;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_121;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_122;
+  wire                _zz__zz_decode_IS_DIV_123;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_124;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_125;
+  wire       [1:0]    _zz__zz_decode_IS_DIV_126;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_127;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_128;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_129;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_130;
+  wire       [3:0]    _zz__zz_decode_IS_DIV_131;
+  wire       [4:0]    _zz__zz_decode_IS_DIV_132;
+  wire                _zz__zz_decode_IS_DIV_133;
+  wire                _zz__zz_decode_IS_DIV_134;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_135;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_136;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_137;
+  wire       [31:0]   _zz__zz_decode_IS_DIV_138;
+  wire                _zz__zz_decode_IS_DIV_139;
+  wire                _zz__zz_decode_IS_DIV_140;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_141;
+  wire       [2:0]    _zz__zz_decode_IS_DIV_142;
+  wire                _zz__zz_decode_IS_DIV_143;
+  wire                _zz__zz_decode_IS_DIV_144;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_145;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_146;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_147;
+  wire       [0:0]    _zz__zz_decode_IS_DIV_148;
+  wire                _zz__zz_decode_IS_DIV_149;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [31:0]   _zz__zz_decode_RS2_3;
+  wire       [32:0]   _zz__zz_decode_RS2_3_1;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1;
+  wire                _zz_when;
+  wire                _zz_when_1;
+  wire       [5:0]    _zz_memory_MulDivIterativePlugin_mul_counter_valueNext;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_2;
+  wire       [33:0]   _zz_memory_MulDivIterativePlugin_accumulator_3;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_4;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_accumulator_5;
+  wire       [5:0]    _zz_memory_MulDivIterativePlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_1;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_2;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_3;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_div_result_4;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_div_result_5;
+  wire       [32:0]   _zz_memory_MulDivIterativePlugin_rs1_3;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs1_4;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_rs2;
+  wire       [0:0]    _zz_memory_MulDivIterativePlugin_rs2_1;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
@@ -427,43 +363,43 @@ module VexRiscv (
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_16;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_19;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire                decode_MEMORY_ENABLE;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_22;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -481,11 +417,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -493,54 +429,54 @@ module VexRiscv (
   wire       [31:0]   execute_RS1;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   _zz_29;
+  reg        [31:0]   _zz_decode_RS2;
   wire                memory_REGFILE_WRITE_VALID;
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
-  reg        [31:0]   _zz_30;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
-  wire       [31:0]   _zz_37;
-  wire                _zz_38;
-  reg                 _zz_39;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
@@ -560,10 +496,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_49;
-  reg        [31:0]   _zz_50;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -654,6 +590,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -671,30 +612,36 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_51;
-  wire       [2:0]    _zz_52;
-  wire                _zz_53;
-  wire                _zz_54;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [2:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -717,16 +664,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_55;
-  wire                _zz_56;
-  wire                _zz_57;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_58;
-  wire                _zz_59;
-  reg                 _zz_60;
-  wire                _zz_61;
-  reg                 _zz_62;
-  reg        [31:0]   _zz_63;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -734,22 +683,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_64;
-  reg        [18:0]   _zz_65;
-  wire                _zz_66;
-  reg        [10:0]   _zz_67;
-  wire                _zz_68;
-  reg        [18:0]   _zz_69;
-  reg                 _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_2;
+  reg        [10:0]   _zz_3;
+  wire                _zz_4;
+  reg        [18:0]   _zz_5;
+  reg                 _zz_6;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -757,7 +713,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_75;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -765,6 +721,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -774,31 +735,38 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_76;
+  wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_77;
-  reg        [3:0]    _zz_78;
+  reg        [31:0]   _zz_dBus_cmd_payload_data;
+  wire                when_DBusSimplePlugin_l426;
+  reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
+  wire                when_DBusSimplePlugin_l479;
+  wire                when_DBusSimplePlugin_l486;
+  wire                when_DBusSimplePlugin_l512;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_79;
-  reg        [31:0]   _zz_80;
-  wire                _zz_81;
-  reg        [31:0]   _zz_82;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [31:0]   _zz_83;
-  wire                _zz_84;
-  wire                _zz_85;
-  wire                _zz_86;
-  wire                _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_90;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_91;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_92;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_94;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_96;
+  wire                when_DBusSimplePlugin_l558;
+  wire       [31:0]   _zz_decode_IS_DIV;
+  wire                _zz_decode_IS_DIV_1;
+  wire                _zz_decode_IS_DIV_2;
+  wire                _zz_decode_IS_DIV_3;
+  wire                _zz_decode_IS_DIV_4;
+  wire                _zz_decode_IS_DIV_5;
+  wire                _zz_decode_IS_DIV_6;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -806,15 +774,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_97;
+  reg                 _zz_7;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_98;
-  reg        [31:0]   _zz_99;
-  wire                _zz_100;
-  reg        [19:0]   _zz_101;
-  wire                _zz_102;
-  reg        [19:0]   _zz_103;
-  reg        [31:0]   _zz_104;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -823,38 +791,59 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_105;
-  reg                 _zz_106;
-  reg                 _zz_107;
-  reg                 _zz_108;
-  reg        [4:0]    _zz_109;
-  reg        [31:0]   _zz_110;
-  wire                _zz_111;
-  wire                _zz_112;
-  wire                _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
+  wire                when_ShiftPlugins_l169;
+  reg        [31:0]   _zz_decode_RS2_3;
+  wire                when_ShiftPlugins_l175;
+  wire                when_ShiftPlugins_l184;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_117;
-  reg                 _zz_118;
-  reg                 _zz_119;
-  wire                _zz_120;
-  reg        [19:0]   _zz_121;
-  wire                _zz_122;
-  reg        [10:0]   _zz_123;
-  wire                _zz_124;
-  reg        [18:0]   _zz_125;
-  reg                 _zz_126;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_127;
-  reg        [19:0]   _zz_128;
-  wire                _zz_129;
-  reg        [10:0]   _zz_130;
-  wire                _zz_131;
-  reg        [18:0]   _zz_132;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -875,9 +864,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -890,37 +879,60 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_136;
-  wire                _zz_137;
-  wire       [1:0]    _zz_138;
-  wire                _zz_139;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [32:0]   memory_MulDivIterativePlugin_rs1;
   reg        [31:0]   memory_MulDivIterativePlugin_rs2;
@@ -932,6 +944,10 @@ module VexRiscv (
   reg        [5:0]    memory_MulDivIterativePlugin_mul_counter_value;
   wire                memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc;
   wire                memory_MulDivIterativePlugin_mul_counter_willOverflow;
+  wire                when_MulDivIterativePlugin_l96;
+  wire                when_MulDivIterativePlugin_l97;
+  wire                when_MulDivIterativePlugin_l100;
+  wire                when_MulDivIterativePlugin_l110;
   reg                 memory_MulDivIterativePlugin_div_needRevert;
   reg                 memory_MulDivIterativePlugin_div_counter_willIncrement;
   reg                 memory_MulDivIterativePlugin_div_counter_willClear;
@@ -940,19 +956,26 @@ module VexRiscv (
   wire                memory_MulDivIterativePlugin_div_counter_willOverflowIfInc;
   wire                memory_MulDivIterativePlugin_div_counter_willOverflow;
   reg                 memory_MulDivIterativePlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_MulDivIterativePlugin_div_result;
-  wire       [31:0]   _zz_140;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  reg        [32:0]   _zz_144;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_MulDivIterativePlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_MulDivIterativePlugin_rs1;
+  wire                _zz_memory_MulDivIterativePlugin_rs1_1;
+  reg        [32:0]   _zz_memory_MulDivIterativePlugin_rs1_2;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_145;
-  wire       [31:0]   _zz_146;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -960,85 +983,175 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_147;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_12;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_15;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_16;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_17;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 decode_to_execute_MEMORY_STORE;
+  wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_MEMORY_STORE;
+  wire                when_Pipeline_l124_24;
   reg                 memory_to_writeBack_MEMORY_STORE;
+  wire                when_Pipeline_l124_25;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_26;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_27;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_28;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_30;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_32;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_34;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_35;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_37;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_38;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_39;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_40;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_43;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_44;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_DO_EBREAK;
+  wire                when_Pipeline_l124_46;
   reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  wire                when_Pipeline_l124_47;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_48;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_49;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_50;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_51;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
-  reg        [2:0]    _zz_148;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_149;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [31:0]   _zz_156;
-  reg        [2:0]    _zz_157;
-  reg                 _zz_158;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -1052,77 +1165,79 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_159;
+  wire                when_Stream_l399;
+  reg        [3:0]    _zz_dBusWishbone_SEL;
+  wire                when_DBusSimplePlugin_l189;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] _zz_12_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_13_string;
-  reg [39:0] _zz_14_string;
-  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_16_string;
-  reg [23:0] _zz_17_string;
-  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_19_string;
-  reg [63:0] _zz_20_string;
-  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_22_string;
-  reg [95:0] _zz_23_string;
-  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_25_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_26_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_28_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36_string;
-  reg [39:0] _zz_40_string;
-  reg [31:0] _zz_41_string;
-  reg [71:0] _zz_42_string;
-  reg [39:0] _zz_43_string;
-  reg [23:0] _zz_44_string;
-  reg [63:0] _zz_45_string;
-  reg [95:0] _zz_46_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_48_string;
-  reg [95:0] _zz_90_string;
-  reg [63:0] _zz_91_string;
-  reg [23:0] _zz_92_string;
-  reg [39:0] _zz_93_string;
-  reg [71:0] _zz_94_string;
-  reg [31:0] _zz_95_string;
-  reg [39:0] _zz_96_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -1131,419 +1246,353 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_172 = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_173 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_174 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_175 = 1'b1;
-  assign _zz_176 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_177 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_178 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_179 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_180 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_181 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_182 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_183 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_184 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_185 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_186 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_187 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_188 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_189 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_190 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_191 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_192 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_193 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_194 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_195 = (1'b0 || (! 1'b1));
-  assign _zz_196 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_197 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_198 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_199 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_200 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_201 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_202 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
-  assign _zz_203 = (! memory_arbitration_isStuck);
-  assign _zz_204 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_205 = (iBus_cmd_valid || (_zz_157 != 3'b000));
-  assign _zz_206 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_207 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_208 = ((_zz_133 && 1'b1) && (! 1'b0));
-  assign _zz_209 = ((_zz_134 && 1'b1) && (! 1'b0));
-  assign _zz_210 = ((_zz_135 && 1'b1) && (! 1'b0));
-  assign _zz_211 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_212 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_213 = execute_INSTRUCTION[13];
-  assign _zz_214 = _zz_83[30 : 30];
-  assign _zz_215 = _zz_83[29 : 29];
-  assign _zz_216 = _zz_83[28 : 28];
-  assign _zz_217 = _zz_83[27 : 27];
-  assign _zz_218 = _zz_83[24 : 24];
-  assign _zz_219 = _zz_83[16 : 16];
-  assign _zz_220 = _zz_83[13 : 13];
-  assign _zz_221 = _zz_83[12 : 12];
-  assign _zz_222 = _zz_83[11 : 11];
-  assign _zz_223 = _zz_83[4 : 4];
-  assign _zz_224 = _zz_83[31 : 31];
-  assign _zz_225 = _zz_83[15 : 15];
-  assign _zz_226 = _zz_83[5 : 5];
-  assign _zz_227 = _zz_83[3 : 3];
-  assign _zz_228 = _zz_83[19 : 19];
-  assign _zz_229 = _zz_83[10 : 10];
-  assign _zz_230 = _zz_83[0 : 0];
-  assign _zz_231 = (_zz_51 - 3'b001);
-  assign _zz_232 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_233 = {29'd0, _zz_232};
-  assign _zz_234 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_235 = {{_zz_65,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_236 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_237 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_238 = {{_zz_67,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_239 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_240 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_241 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_242 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
-  assign _zz_243 = execute_SRC_LESS;
-  assign _zz_244 = 3'b100;
-  assign _zz_245 = execute_INSTRUCTION[19 : 15];
-  assign _zz_246 = execute_INSTRUCTION[31 : 20];
-  assign _zz_247 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_248 = ($signed(_zz_249) + $signed(_zz_252));
-  assign _zz_249 = ($signed(_zz_250) + $signed(_zz_251));
-  assign _zz_250 = execute_SRC1;
-  assign _zz_251 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_252 = (execute_SRC_USE_SUB_LESS ? _zz_253 : _zz_254);
-  assign _zz_253 = 32'h00000001;
-  assign _zz_254 = 32'h0;
-  assign _zz_255 = (_zz_256 >>> 1);
-  assign _zz_256 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_257 = execute_INSTRUCTION[31 : 20];
-  assign _zz_258 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_259 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_260 = {_zz_121,execute_INSTRUCTION[31 : 20]};
-  assign _zz_261 = {{_zz_123,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_262 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_263 = execute_INSTRUCTION[31 : 20];
-  assign _zz_264 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_265 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_266 = 3'b100;
-  assign _zz_267 = (_zz_136 & (~ _zz_268));
-  assign _zz_268 = (_zz_136 - 2'b01);
-  assign _zz_269 = (_zz_138 & (~ _zz_270));
-  assign _zz_270 = (_zz_138 - 2'b01);
-  assign _zz_271 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_272 = {5'd0, _zz_271};
-  assign _zz_273 = (_zz_275 + _zz_277);
-  assign _zz_274 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_275 = {{1{_zz_274[32]}}, _zz_274};
-  assign _zz_276 = _zz_278;
-  assign _zz_277 = {{1{_zz_276[32]}}, _zz_276};
-  assign _zz_278 = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_279 = memory_MulDivIterativePlugin_div_counter_willIncrement;
-  assign _zz_280 = {5'd0, _zz_279};
-  assign _zz_281 = {1'd0, memory_MulDivIterativePlugin_rs2};
-  assign _zz_282 = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_283 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_284 = {_zz_140,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_285 = _zz_286;
-  assign _zz_286 = _zz_287;
-  assign _zz_287 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_289);
-  assign _zz_288 = memory_MulDivIterativePlugin_div_needRevert;
-  assign _zz_289 = {32'd0, _zz_288};
-  assign _zz_290 = _zz_143;
-  assign _zz_291 = {32'd0, _zz_290};
-  assign _zz_292 = _zz_142;
-  assign _zz_293 = {31'd0, _zz_292};
-  assign _zz_294 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_295 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_296 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_297 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_298 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_299 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_300 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_301 = 1'b1;
-  assign _zz_302 = 1'b1;
-  assign _zz_303 = {_zz_54,_zz_53};
-  assign _zz_304 = 32'h0000107f;
-  assign _zz_305 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_306 = 32'h00002073;
-  assign _zz_307 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_308 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_309 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_310) == 32'h00000003),{(_zz_311 == _zz_312),{_zz_313,{_zz_314,_zz_315}}}}}};
-  assign _zz_310 = 32'h0000505f;
-  assign _zz_311 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_312 = 32'h00000063;
-  assign _zz_313 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_314 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_315 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_316) == 32'h00005033),{(_zz_317 == _zz_318),{_zz_319,{_zz_320,_zz_321}}}}}};
-  assign _zz_316 = 32'hbe00707f;
-  assign _zz_317 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_318 = 32'h00000033;
-  assign _zz_319 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_320 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_321 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_322 = decode_INSTRUCTION[31];
-  assign _zz_323 = decode_INSTRUCTION[31];
-  assign _zz_324 = decode_INSTRUCTION[7];
-  assign _zz_325 = 32'h10103050;
-  assign _zz_326 = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_327 = 32'h02004020;
-  assign _zz_328 = _zz_89;
-  assign _zz_329 = _zz_88;
-  assign _zz_330 = {_zz_89,{_zz_87,_zz_88}};
-  assign _zz_331 = 3'b000;
-  assign _zz_332 = (((decode_INSTRUCTION & _zz_335) == 32'h02000030) != 1'b0);
-  assign _zz_333 = ((_zz_336 == _zz_337) != 1'b0);
-  assign _zz_334 = {(_zz_338 != 1'b0),{(_zz_339 != _zz_340),{_zz_341,{_zz_342,_zz_343}}}};
-  assign _zz_335 = 32'h02004074;
-  assign _zz_336 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_337 = 32'h00000050;
-  assign _zz_338 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_339 = {(_zz_344 == _zz_345),(_zz_346 == _zz_347)};
-  assign _zz_340 = 2'b00;
-  assign _zz_341 = ({_zz_86,_zz_348} != 2'b00);
-  assign _zz_342 = (_zz_349 != 1'b0);
-  assign _zz_343 = {(_zz_350 != _zz_351),{_zz_352,{_zz_353,_zz_354}}};
-  assign _zz_344 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_345 = 32'h00001050;
-  assign _zz_346 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_347 = 32'h00002050;
-  assign _zz_348 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_349 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_350 = {(_zz_355 == _zz_356),(_zz_357 == _zz_358)};
-  assign _zz_351 = 2'b00;
-  assign _zz_352 = ({_zz_359,{_zz_360,_zz_361}} != 3'b000);
-  assign _zz_353 = ({_zz_362,_zz_363} != 3'b000);
-  assign _zz_354 = {(_zz_364 != _zz_365),{_zz_366,{_zz_367,_zz_368}}};
-  assign _zz_355 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_356 = 32'h00005010;
-  assign _zz_357 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_358 = 32'h00005020;
-  assign _zz_359 = ((decode_INSTRUCTION & _zz_369) == 32'h40001010);
-  assign _zz_360 = (_zz_370 == _zz_371);
-  assign _zz_361 = (_zz_372 == _zz_373);
-  assign _zz_362 = (_zz_374 == _zz_375);
-  assign _zz_363 = {_zz_376,_zz_377};
-  assign _zz_364 = (_zz_378 == _zz_379);
-  assign _zz_365 = 1'b0;
-  assign _zz_366 = (_zz_87 != 1'b0);
-  assign _zz_367 = (_zz_380 != _zz_381);
-  assign _zz_368 = {_zz_382,{_zz_383,_zz_384}};
-  assign _zz_369 = 32'h40003054;
-  assign _zz_370 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_371 = 32'h00001010;
-  assign _zz_372 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_373 = 32'h00001010;
-  assign _zz_374 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_375 = 32'h00000024;
-  assign _zz_376 = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
-  assign _zz_377 = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
-  assign _zz_378 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_379 = 32'h00001000;
-  assign _zz_380 = {(_zz_385 == _zz_386),(_zz_387 == _zz_388)};
-  assign _zz_381 = 2'b00;
-  assign _zz_382 = ({_zz_389,_zz_390} != 2'b00);
-  assign _zz_383 = ({_zz_391,_zz_392} != 3'b000);
-  assign _zz_384 = {(_zz_393 != _zz_394),{_zz_395,{_zz_396,_zz_397}}};
-  assign _zz_385 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_386 = 32'h00002000;
-  assign _zz_387 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_388 = 32'h00001000;
-  assign _zz_389 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_390 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_391 = ((decode_INSTRUCTION & _zz_398) == 32'h00000040);
-  assign _zz_392 = {(_zz_399 == _zz_400),(_zz_401 == _zz_402)};
-  assign _zz_393 = ((decode_INSTRUCTION & _zz_403) == 32'h00000020);
-  assign _zz_394 = 1'b0;
-  assign _zz_395 = ((_zz_404 == _zz_405) != 1'b0);
-  assign _zz_396 = ({_zz_406,_zz_407} != 3'b000);
-  assign _zz_397 = {(_zz_408 != _zz_409),{_zz_410,{_zz_411,_zz_412}}};
-  assign _zz_398 = 32'h00000050;
-  assign _zz_399 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_400 = 32'h0;
-  assign _zz_401 = (decode_INSTRUCTION & 32'h00103040);
-  assign _zz_402 = 32'h00000040;
-  assign _zz_403 = 32'h00000020;
-  assign _zz_404 = (decode_INSTRUCTION & 32'h00000010);
-  assign _zz_405 = 32'h00000010;
-  assign _zz_406 = _zz_85;
-  assign _zz_407 = {(_zz_413 == _zz_414),(_zz_415 == _zz_416)};
-  assign _zz_408 = {_zz_86,{_zz_417,{_zz_418,_zz_419}}};
-  assign _zz_409 = 6'h0;
-  assign _zz_410 = ({_zz_85,_zz_420} != 2'b00);
-  assign _zz_411 = ({_zz_421,_zz_422} != 2'b00);
-  assign _zz_412 = {(_zz_423 != _zz_424),{_zz_425,{_zz_426,_zz_427}}};
-  assign _zz_413 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_414 = 32'h00000010;
-  assign _zz_415 = (decode_INSTRUCTION & 32'h02000060);
-  assign _zz_416 = 32'h00000020;
-  assign _zz_417 = ((decode_INSTRUCTION & _zz_428) == 32'h00001010);
-  assign _zz_418 = (_zz_429 == _zz_430);
-  assign _zz_419 = {_zz_431,{_zz_432,_zz_433}};
-  assign _zz_420 = ((decode_INSTRUCTION & _zz_434) == 32'h00000020);
-  assign _zz_421 = _zz_85;
-  assign _zz_422 = (_zz_435 == _zz_436);
-  assign _zz_423 = {_zz_437,_zz_438};
-  assign _zz_424 = 2'b00;
-  assign _zz_425 = (_zz_439 != 1'b0);
-  assign _zz_426 = (_zz_440 != _zz_441);
-  assign _zz_427 = {_zz_442,{_zz_443,_zz_444}};
-  assign _zz_428 = 32'h00001010;
-  assign _zz_429 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_430 = 32'h00002010;
-  assign _zz_431 = ((decode_INSTRUCTION & _zz_445) == 32'h00000010);
-  assign _zz_432 = (_zz_446 == _zz_447);
-  assign _zz_433 = (_zz_448 == _zz_449);
-  assign _zz_434 = 32'h00000070;
-  assign _zz_435 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_436 = 32'h0;
-  assign _zz_437 = ((decode_INSTRUCTION & _zz_450) == 32'h00006010);
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_451) == 32'h00004010);
-  assign _zz_439 = ((decode_INSTRUCTION & _zz_452) == 32'h00002010);
-  assign _zz_440 = {_zz_453,{_zz_454,_zz_455}};
-  assign _zz_441 = 4'b0000;
-  assign _zz_442 = (_zz_456 != 1'b0);
-  assign _zz_443 = (_zz_457 != _zz_458);
-  assign _zz_444 = {_zz_459,{_zz_460,_zz_461}};
-  assign _zz_445 = 32'h00000050;
-  assign _zz_446 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_447 = 32'h00000004;
-  assign _zz_448 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_449 = 32'h0;
-  assign _zz_450 = 32'h00006014;
-  assign _zz_451 = 32'h00005014;
-  assign _zz_452 = 32'h00006014;
-  assign _zz_453 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz_454 = ((decode_INSTRUCTION & _zz_462) == 32'h0);
-  assign _zz_455 = {(_zz_463 == _zz_464),(_zz_465 == _zz_466)};
-  assign _zz_456 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_457 = {(_zz_467 == _zz_468),{_zz_469,_zz_470}};
-  assign _zz_458 = 3'b000;
-  assign _zz_459 = ({_zz_471,_zz_84} != 2'b00);
-  assign _zz_460 = ({_zz_472,_zz_473} != 2'b00);
-  assign _zz_461 = (_zz_474 != 1'b0);
-  assign _zz_462 = 32'h00000018;
-  assign _zz_463 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_464 = 32'h00002000;
-  assign _zz_465 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_466 = 32'h00001000;
-  assign _zz_467 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_468 = 32'h00000040;
-  assign _zz_469 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_470 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz_471 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_472 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_473 = _zz_84;
-  assign _zz_474 = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
-  assign _zz_475 = execute_INSTRUCTION[31];
-  assign _zz_476 = execute_INSTRUCTION[31];
-  assign _zz_477 = execute_INSTRUCTION[7];
-  always @ (posedge clk) begin
-    if(_zz_301) begin
-      _zz_169 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_when_1 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 3'b001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_4 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_6 = {{_zz_3,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_decode_RS2_3 = (_zz__zz_decode_RS2_3_1 >>> 1);
+  assign _zz__zz_decode_RS2_3_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 - 2'b01);
+  assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_memory_MulDivIterativePlugin_mul_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_mul_counter_valueNext_1};
+  assign _zz_memory_MulDivIterativePlugin_accumulator = (_zz_memory_MulDivIterativePlugin_accumulator_1 + _zz_memory_MulDivIterativePlugin_accumulator_3);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_2 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_memory_MulDivIterativePlugin_accumulator_1 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_2[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_2};
+  assign _zz_memory_MulDivIterativePlugin_accumulator_4 = _zz_memory_MulDivIterativePlugin_accumulator_5;
+  assign _zz_memory_MulDivIterativePlugin_accumulator_3 = {{1{_zz_memory_MulDivIterativePlugin_accumulator_4[32]}}, _zz_memory_MulDivIterativePlugin_accumulator_4};
+  assign _zz_memory_MulDivIterativePlugin_accumulator_5 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1 = memory_MulDivIterativePlugin_div_counter_willIncrement;
+  assign _zz_memory_MulDivIterativePlugin_div_counter_valueNext = {5'd0, _zz_memory_MulDivIterativePlugin_div_counter_valueNext_1};
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_MulDivIterativePlugin_rs2};
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator = {_zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_MulDivIterativePlugin_div_result_1 = _zz_memory_MulDivIterativePlugin_div_result_2;
+  assign _zz_memory_MulDivIterativePlugin_div_result_2 = _zz_memory_MulDivIterativePlugin_div_result_3;
+  assign _zz_memory_MulDivIterativePlugin_div_result_3 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_memory_MulDivIterativePlugin_div_result) : _zz_memory_MulDivIterativePlugin_div_result)} + _zz_memory_MulDivIterativePlugin_div_result_4);
+  assign _zz_memory_MulDivIterativePlugin_div_result_5 = memory_MulDivIterativePlugin_div_needRevert;
+  assign _zz_memory_MulDivIterativePlugin_div_result_4 = {32'd0, _zz_memory_MulDivIterativePlugin_div_result_5};
+  assign _zz_memory_MulDivIterativePlugin_rs1_4 = _zz_memory_MulDivIterativePlugin_rs1_1;
+  assign _zz_memory_MulDivIterativePlugin_rs1_3 = {32'd0, _zz_memory_MulDivIterativePlugin_rs1_4};
+  assign _zz_memory_MulDivIterativePlugin_rs2_1 = _zz_memory_MulDivIterativePlugin_rs1;
+  assign _zz_memory_MulDivIterativePlugin_rs2 = {31'd0, _zz_memory_MulDivIterativePlugin_rs2_1};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_3,_zz_IBusCachedPlugin_jump_pcLoad_payload_2};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz__zz_decode_IS_DIV = 32'h10103050;
+  assign _zz__zz_decode_IS_DIV_1 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_DIV_2 = 32'h02004020;
+  assign _zz__zz_decode_IS_DIV_3 = _zz_decode_IS_DIV_6;
+  assign _zz__zz_decode_IS_DIV_4 = _zz_decode_IS_DIV_5;
+  assign _zz__zz_decode_IS_DIV_5 = {_zz_decode_IS_DIV_6,{_zz_decode_IS_DIV_4,_zz_decode_IS_DIV_5}};
+  assign _zz__zz_decode_IS_DIV_6 = 3'b000;
+  assign _zz__zz_decode_IS_DIV_7 = (((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_8) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_9 = ((_zz__zz_decode_IS_DIV_10 == _zz__zz_decode_IS_DIV_11) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_12 = {(_zz__zz_decode_IS_DIV_13 != 1'b0),{(_zz__zz_decode_IS_DIV_14 != _zz__zz_decode_IS_DIV_19),{_zz__zz_decode_IS_DIV_20,{_zz__zz_decode_IS_DIV_22,_zz__zz_decode_IS_DIV_24}}}};
+  assign _zz__zz_decode_IS_DIV_8 = 32'h02004074;
+  assign _zz__zz_decode_IS_DIV_10 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_IS_DIV_11 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_13 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz__zz_decode_IS_DIV_14 = {(_zz__zz_decode_IS_DIV_15 == _zz__zz_decode_IS_DIV_16),(_zz__zz_decode_IS_DIV_17 == _zz__zz_decode_IS_DIV_18)};
+  assign _zz__zz_decode_IS_DIV_19 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_20 = ({_zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_21} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_22 = (_zz__zz_decode_IS_DIV_23 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_24 = {(_zz__zz_decode_IS_DIV_25 != _zz__zz_decode_IS_DIV_30),{_zz__zz_decode_IS_DIV_31,{_zz__zz_decode_IS_DIV_40,_zz__zz_decode_IS_DIV_47}}};
+  assign _zz__zz_decode_IS_DIV_15 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_DIV_16 = 32'h00001050;
+  assign _zz__zz_decode_IS_DIV_17 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_DIV_18 = 32'h00002050;
+  assign _zz__zz_decode_IS_DIV_21 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_23 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_25 = {(_zz__zz_decode_IS_DIV_26 == _zz__zz_decode_IS_DIV_27),(_zz__zz_decode_IS_DIV_28 == _zz__zz_decode_IS_DIV_29)};
+  assign _zz__zz_decode_IS_DIV_30 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_31 = ({_zz__zz_decode_IS_DIV_32,{_zz__zz_decode_IS_DIV_34,_zz__zz_decode_IS_DIV_37}} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_40 = ({_zz__zz_decode_IS_DIV_41,_zz__zz_decode_IS_DIV_44} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_47 = {(_zz__zz_decode_IS_DIV_48 != _zz__zz_decode_IS_DIV_51),{_zz__zz_decode_IS_DIV_52,{_zz__zz_decode_IS_DIV_53,_zz__zz_decode_IS_DIV_60}}};
+  assign _zz__zz_decode_IS_DIV_26 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_DIV_27 = 32'h00005010;
+  assign _zz__zz_decode_IS_DIV_28 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_DIV_29 = 32'h00005020;
+  assign _zz__zz_decode_IS_DIV_32 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_33) == 32'h40001010);
+  assign _zz__zz_decode_IS_DIV_34 = (_zz__zz_decode_IS_DIV_35 == _zz__zz_decode_IS_DIV_36);
+  assign _zz__zz_decode_IS_DIV_37 = (_zz__zz_decode_IS_DIV_38 == _zz__zz_decode_IS_DIV_39);
+  assign _zz__zz_decode_IS_DIV_41 = (_zz__zz_decode_IS_DIV_42 == _zz__zz_decode_IS_DIV_43);
+  assign _zz__zz_decode_IS_DIV_44 = {_zz__zz_decode_IS_DIV_45,_zz__zz_decode_IS_DIV_46};
+  assign _zz__zz_decode_IS_DIV_48 = (_zz__zz_decode_IS_DIV_49 == _zz__zz_decode_IS_DIV_50);
+  assign _zz__zz_decode_IS_DIV_51 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_52 = (_zz_decode_IS_DIV_4 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_53 = (_zz__zz_decode_IS_DIV_54 != _zz__zz_decode_IS_DIV_59);
+  assign _zz__zz_decode_IS_DIV_60 = {_zz__zz_decode_IS_DIV_61,{_zz__zz_decode_IS_DIV_64,_zz__zz_decode_IS_DIV_72}};
+  assign _zz__zz_decode_IS_DIV_33 = 32'h40003054;
+  assign _zz__zz_decode_IS_DIV_35 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_DIV_36 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_38 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_DIV_39 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_42 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_DIV_43 = 32'h00000024;
+  assign _zz__zz_decode_IS_DIV_45 = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_46 = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_49 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_DIV_50 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_54 = {(_zz__zz_decode_IS_DIV_55 == _zz__zz_decode_IS_DIV_56),(_zz__zz_decode_IS_DIV_57 == _zz__zz_decode_IS_DIV_58)};
+  assign _zz__zz_decode_IS_DIV_59 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_61 = ({_zz__zz_decode_IS_DIV_62,_zz__zz_decode_IS_DIV_63} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_64 = ({_zz__zz_decode_IS_DIV_65,_zz__zz_decode_IS_DIV_67} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_72 = {(_zz__zz_decode_IS_DIV_73 != _zz__zz_decode_IS_DIV_75),{_zz__zz_decode_IS_DIV_76,{_zz__zz_decode_IS_DIV_79,_zz__zz_decode_IS_DIV_86}}};
+  assign _zz__zz_decode_IS_DIV_55 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_56 = 32'h00002000;
+  assign _zz__zz_decode_IS_DIV_57 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_DIV_58 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_62 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_63 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_65 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_66) == 32'h00000040);
+  assign _zz__zz_decode_IS_DIV_67 = {(_zz__zz_decode_IS_DIV_68 == _zz__zz_decode_IS_DIV_69),(_zz__zz_decode_IS_DIV_70 == _zz__zz_decode_IS_DIV_71)};
+  assign _zz__zz_decode_IS_DIV_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_74) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_75 = 1'b0;
+  assign _zz__zz_decode_IS_DIV_76 = ((_zz__zz_decode_IS_DIV_77 == _zz__zz_decode_IS_DIV_78) != 1'b0);
+  assign _zz__zz_decode_IS_DIV_79 = ({_zz__zz_decode_IS_DIV_80,_zz__zz_decode_IS_DIV_81} != 3'b000);
+  assign _zz__zz_decode_IS_DIV_86 = {(_zz__zz_decode_IS_DIV_87 != _zz__zz_decode_IS_DIV_102),{_zz__zz_decode_IS_DIV_103,{_zz__zz_decode_IS_DIV_106,_zz__zz_decode_IS_DIV_111}}};
+  assign _zz__zz_decode_IS_DIV_66 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_68 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_DIV_69 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_70 = (decode_INSTRUCTION & 32'h00103040);
+  assign _zz__zz_decode_IS_DIV_71 = 32'h00000040;
+  assign _zz__zz_decode_IS_DIV_74 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_77 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_78 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_80 = _zz_decode_IS_DIV_2;
+  assign _zz__zz_decode_IS_DIV_81 = {(_zz__zz_decode_IS_DIV_82 == _zz__zz_decode_IS_DIV_83),(_zz__zz_decode_IS_DIV_84 == _zz__zz_decode_IS_DIV_85)};
+  assign _zz__zz_decode_IS_DIV_87 = {_zz_decode_IS_DIV_3,{_zz__zz_decode_IS_DIV_88,{_zz__zz_decode_IS_DIV_90,_zz__zz_decode_IS_DIV_93}}};
+  assign _zz__zz_decode_IS_DIV_102 = 6'h0;
+  assign _zz__zz_decode_IS_DIV_103 = ({_zz_decode_IS_DIV_2,_zz__zz_decode_IS_DIV_104} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_106 = ({_zz__zz_decode_IS_DIV_107,_zz__zz_decode_IS_DIV_108} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_111 = {(_zz__zz_decode_IS_DIV_112 != _zz__zz_decode_IS_DIV_117),{_zz__zz_decode_IS_DIV_118,{_zz__zz_decode_IS_DIV_121,_zz__zz_decode_IS_DIV_132}}};
+  assign _zz__zz_decode_IS_DIV_82 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_DIV_83 = 32'h00000010;
+  assign _zz__zz_decode_IS_DIV_84 = (decode_INSTRUCTION & 32'h02000060);
+  assign _zz__zz_decode_IS_DIV_85 = 32'h00000020;
+  assign _zz__zz_decode_IS_DIV_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_89) == 32'h00001010);
+  assign _zz__zz_decode_IS_DIV_90 = (_zz__zz_decode_IS_DIV_91 == _zz__zz_decode_IS_DIV_92);
+  assign _zz__zz_decode_IS_DIV_93 = {_zz__zz_decode_IS_DIV_94,{_zz__zz_decode_IS_DIV_96,_zz__zz_decode_IS_DIV_99}};
+  assign _zz__zz_decode_IS_DIV_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_105) == 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_107 = _zz_decode_IS_DIV_2;
+  assign _zz__zz_decode_IS_DIV_108 = (_zz__zz_decode_IS_DIV_109 == _zz__zz_decode_IS_DIV_110);
+  assign _zz__zz_decode_IS_DIV_112 = {_zz__zz_decode_IS_DIV_113,_zz__zz_decode_IS_DIV_115};
+  assign _zz__zz_decode_IS_DIV_117 = 2'b00;
+  assign _zz__zz_decode_IS_DIV_118 = (_zz__zz_decode_IS_DIV_119 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_121 = (_zz__zz_decode_IS_DIV_122 != _zz__zz_decode_IS_DIV_131);
+  assign _zz__zz_decode_IS_DIV_132 = {_zz__zz_decode_IS_DIV_133,{_zz__zz_decode_IS_DIV_135,_zz__zz_decode_IS_DIV_142}};
+  assign _zz__zz_decode_IS_DIV_89 = 32'h00001010;
+  assign _zz__zz_decode_IS_DIV_91 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_92 = 32'h00002010;
+  assign _zz__zz_decode_IS_DIV_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_95) == 32'h00000010);
+  assign _zz__zz_decode_IS_DIV_96 = (_zz__zz_decode_IS_DIV_97 == _zz__zz_decode_IS_DIV_98);
+  assign _zz__zz_decode_IS_DIV_99 = (_zz__zz_decode_IS_DIV_100 == _zz__zz_decode_IS_DIV_101);
+  assign _zz__zz_decode_IS_DIV_105 = 32'h00000070;
+  assign _zz__zz_decode_IS_DIV_109 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_DIV_110 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_113 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_114) == 32'h00006010);
+  assign _zz__zz_decode_IS_DIV_115 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_116) == 32'h00004010);
+  assign _zz__zz_decode_IS_DIV_119 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_120) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_122 = {_zz__zz_decode_IS_DIV_123,{_zz__zz_decode_IS_DIV_124,_zz__zz_decode_IS_DIV_126}};
+  assign _zz__zz_decode_IS_DIV_131 = 4'b0000;
+  assign _zz__zz_decode_IS_DIV_133 = (_zz__zz_decode_IS_DIV_134 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_135 = (_zz__zz_decode_IS_DIV_136 != _zz__zz_decode_IS_DIV_141);
+  assign _zz__zz_decode_IS_DIV_142 = {_zz__zz_decode_IS_DIV_143,{_zz__zz_decode_IS_DIV_145,_zz__zz_decode_IS_DIV_148}};
+  assign _zz__zz_decode_IS_DIV_95 = 32'h00000050;
+  assign _zz__zz_decode_IS_DIV_97 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_DIV_98 = 32'h00000004;
+  assign _zz__zz_decode_IS_DIV_100 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_DIV_101 = 32'h0;
+  assign _zz__zz_decode_IS_DIV_114 = 32'h00006014;
+  assign _zz__zz_decode_IS_DIV_116 = 32'h00005014;
+  assign _zz__zz_decode_IS_DIV_120 = 32'h00006014;
+  assign _zz__zz_decode_IS_DIV_123 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_124 = ((decode_INSTRUCTION & _zz__zz_decode_IS_DIV_125) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_126 = {(_zz__zz_decode_IS_DIV_127 == _zz__zz_decode_IS_DIV_128),(_zz__zz_decode_IS_DIV_129 == _zz__zz_decode_IS_DIV_130)};
+  assign _zz__zz_decode_IS_DIV_134 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_IS_DIV_136 = {(_zz__zz_decode_IS_DIV_137 == _zz__zz_decode_IS_DIV_138),{_zz__zz_decode_IS_DIV_139,_zz__zz_decode_IS_DIV_140}};
+  assign _zz__zz_decode_IS_DIV_141 = 3'b000;
+  assign _zz__zz_decode_IS_DIV_143 = ({_zz__zz_decode_IS_DIV_144,_zz_decode_IS_DIV_1} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_145 = ({_zz__zz_decode_IS_DIV_146,_zz__zz_decode_IS_DIV_147} != 2'b00);
+  assign _zz__zz_decode_IS_DIV_148 = (_zz__zz_decode_IS_DIV_149 != 1'b0);
+  assign _zz__zz_decode_IS_DIV_125 = 32'h00000018;
+  assign _zz__zz_decode_IS_DIV_127 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_DIV_128 = 32'h00002000;
+  assign _zz__zz_decode_IS_DIV_129 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_DIV_130 = 32'h00001000;
+  assign _zz__zz_decode_IS_DIV_137 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_DIV_138 = 32'h00000040;
+  assign _zz__zz_decode_IS_DIV_139 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_DIV_140 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_IS_DIV_144 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_146 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_DIV_147 = _zz_decode_IS_DIV_1;
+  assign _zz__zz_decode_IS_DIV_149 = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_302) begin
-      _zz_170 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_39) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_160                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_161                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_162                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_163                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_164                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_165                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_166                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_167                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_168                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_148[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   always @(*) begin
-    case(_zz_303)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_5)
       2'b00 : begin
-        _zz_171 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_171 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_171 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1555,113 +1604,113 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13_string = "AND_1";
-      default : _zz_13_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
-      default : _zz_14_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1674,30 +1723,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_16_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_16_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_16_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_16_string = "PC ";
-      default : _zz_16_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
-      default : _zz_17_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1709,27 +1758,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19_string = "BITWISE ";
-      default : _zz_19_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
-      default : _zz_20_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1742,30 +1791,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_22_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_22_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_22_string = "URS1        ";
-      default : _zz_22_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
-      default : _zz_23_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1777,11 +1826,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25_string = "ECALL";
-      default : _zz_25_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1793,11 +1842,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
-      default : _zz_26_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1809,11 +1858,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1826,30 +1875,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_28_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_28_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_28_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_28_string = "JALR";
-      default : _zz_28_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_31)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
-      default : _zz_31_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -1862,12 +1911,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
-      default : _zz_33_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1880,12 +1929,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
-      default : _zz_34_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1897,87 +1946,87 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
-      default : _zz_35_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
-      default : _zz_36_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
-      default : _zz_40_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
-      default : _zz_41_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
-      default : _zz_42_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
-      default : _zz_44_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
-      default : _zz_45_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
-      default : _zz_46_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1990,72 +2039,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_48_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_48_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48_string = "JALR";
-      default : _zz_48_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_90)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_90_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_90_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_90_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_90_string = "URS1        ";
-      default : _zz_90_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_91)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_91_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_91_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_91_string = "BITWISE ";
-      default : _zz_91_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_92_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_92_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_92_string = "PC ";
-      default : _zz_92_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_93_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_93_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_93_string = "AND_1";
-      default : _zz_93_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_94_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_94_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_94_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_94_string = "SRA_1    ";
-      default : _zz_94_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_95_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_95_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_95_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_95_string = "JALR";
-      default : _zz_95_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_96_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_96_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_96_string = "ECALL";
-      default : _zz_96_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2086,19 +2135,19 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -2140,7 +2189,7 @@ module VexRiscv (
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_98;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
@@ -2148,39 +2197,39 @@ module VexRiscv (
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_DIV = _zz_214[0];
-  assign decode_IS_RS2_SIGNED = _zz_215[0];
-  assign decode_IS_RS1_SIGNED = _zz_216[0];
-  assign decode_IS_MUL = _zz_217[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_218[0];
-  assign _zz_8 = _zz_9;
-  assign decode_SHIFT_CTRL = _zz_10;
-  assign _zz_11 = _zz_12;
-  assign decode_ALU_BITWISE_CTRL = _zz_13;
-  assign _zz_14 = _zz_15;
-  assign decode_SRC_LESS_UNSIGNED = _zz_219[0];
-  assign decode_MEMORY_STORE = _zz_220[0];
+  assign decode_IS_DIV = _zz_decode_IS_DIV[30];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_DIV[29];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_DIV[28];
+  assign decode_IS_MUL = _zz_decode_IS_DIV[27];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_DIV[24];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_DIV[16];
+  assign decode_MEMORY_STORE = _zz_decode_IS_DIV[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_221[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_222[0];
-  assign decode_SRC2_CTRL = _zz_16;
-  assign _zz_17 = _zz_18;
-  assign decode_ALU_CTRL = _zz_19;
-  assign _zz_20 = _zz_21;
-  assign decode_MEMORY_ENABLE = _zz_223[0];
-  assign decode_SRC1_CTRL = _zz_22;
-  assign _zz_23 = _zz_24;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_DIV[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_DIV[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_DIV[4];
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_224[0];
+  assign decode_IS_EBREAK = _zz_decode_IS_DIV[31];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
@@ -2190,27 +2239,27 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_25;
-  assign execute_ENV_CTRL = _zz_26;
-  assign writeBack_ENV_CTRL = _zz_27;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_119;
-  assign execute_BRANCH_CTRL = _zz_28;
-  assign decode_RS2_USE = _zz_225[0];
-  assign decode_RS1_USE = _zz_226[0];
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_DIV[15];
+  assign decode_RS1_USE = _zz_decode_IS_DIV[5];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  always @ (*) begin
-    _zz_29 = memory_REGFILE_WRITE_DATA;
-    if(_zz_172)begin
-      _zz_29 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+  always @(*) begin
+    _zz_decode_RS2 = memory_REGFILE_WRITE_DATA;
+    if(when_MulDivIterativePlugin_l96) begin
+      _zz_decode_RS2 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
     end
-    if(_zz_173)begin
-      _zz_29 = memory_MulDivIterativePlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2 = memory_MulDivIterativePlugin_div_result;
     end
   end
 
@@ -2218,114 +2267,114 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_108)begin
-      if((_zz_109 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_110;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_174)begin
-      if(_zz_175)begin
-        if(_zz_112)begin
-          decode_RS2 = _zz_47;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_176)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_114)begin
-          decode_RS2 = _zz_29;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
-    if(_zz_177)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_116)begin
-          decode_RS2 = _zz_30;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_108)begin
-      if((_zz_109 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_110;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_174)begin
-      if(_zz_175)begin
-        if(_zz_111)begin
-          decode_RS1 = _zz_47;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_176)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_113)begin
-          decode_RS1 = _zz_29;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
-    if(_zz_177)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_115)begin
-          decode_RS1 = _zz_30;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
   end
 
-  always @ (*) begin
-    _zz_30 = execute_REGFILE_WRITE_DATA;
-    if(_zz_178)begin
-      _zz_30 = _zz_105;
+  always @(*) begin
+    _zz_decode_RS2_1 = execute_REGFILE_WRITE_DATA;
+    if(when_ShiftPlugins_l169) begin
+      _zz_decode_RS2_1 = _zz_decode_RS2_3;
     end
-    if(_zz_179)begin
-      _zz_30 = execute_CsrPlugin_readData;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2_1 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33;
-  assign execute_SRC1_CTRL = _zz_34;
-  assign decode_SRC_USE_SUB_LESS = _zz_227[0];
-  assign decode_SRC_ADD_ZERO = _zz_228[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_DIV[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_DIV[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35;
-  assign execute_SRC2 = _zz_104;
-  assign execute_SRC1 = _zz_99;
-  assign execute_ALU_BITWISE_CTRL = _zz_36;
-  assign _zz_37 = writeBack_INSTRUCTION;
-  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_39 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_39 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_229[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_DIV[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_304) == 32'h00001073),{(_zz_305 == _zz_306),{_zz_307,{_zz_308,_zz_309}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
-  always @ (*) begin
-    _zz_47 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusSimplePlugin_l558) begin
+      _zz_decode_RS2_2 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
@@ -2342,57 +2391,57 @@ module VexRiscv (
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
-  assign decode_FLUSH_ALL = _zz_230[0];
-  always @ (*) begin
+  assign decode_FLUSH_ALL = _zz_decode_IS_DIV[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_180)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_181)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_182)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_183)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_48;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_49 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_49 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_50 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_50 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    case(_zz_148)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2401,153 +2450,153 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_106 || _zz_107)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_184)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_184)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76)))begin
+    if(when_DBusSimplePlugin_l426) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_178)begin
-      if((! execute_LightShifterPlugin_done))begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l184) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_179)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_185)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_185)begin
-      if(_zz_186)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_185)begin
-      if(_zz_186)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
+    if(when_DBusSimplePlugin_l479) begin
       memory_arbitration_haltItself = 1'b1;
     end
-    if(_zz_172)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l97) begin
         memory_arbitration_haltItself = 1'b1;
       end
-      if(_zz_187)begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_173)begin
-      if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_188)begin
+    if(_zz_when_1) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_188)begin
+    if(_zz_when_1) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltItself = 1'b0;
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
   assign writeBack_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_189)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_190)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2556,62 +2605,64 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_189)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_190)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_185)begin
-      if(_zz_186)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_191)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_189)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_190)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_189)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_190)begin
-      case(_zz_192)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2621,79 +2672,91 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
-  assign _zz_51 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
-  assign _zz_52 = (_zz_51 & (~ _zz_231));
-  assign _zz_53 = _zz_52[1];
-  assign _zz_54 = _zz_52[2];
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_171;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[1];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_233);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -2701,66 +2764,75 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_55 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_55);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_55);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_56 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_56);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_56);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_57 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_57);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_57);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_58;
-  assign _zz_58 = ((1'b0 && (! _zz_59)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_59 = _zz_60;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_59;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_61)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_61 = _zz_62;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_61;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_63;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_148)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -2772,256 +2844,265 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_64 = _zz_234[11];
-  always @ (*) begin
-    _zz_65[18] = _zz_64;
-    _zz_65[17] = _zz_64;
-    _zz_65[16] = _zz_64;
-    _zz_65[15] = _zz_64;
-    _zz_65[14] = _zz_64;
-    _zz_65[13] = _zz_64;
-    _zz_65[12] = _zz_64;
-    _zz_65[11] = _zz_64;
-    _zz_65[10] = _zz_64;
-    _zz_65[9] = _zz_64;
-    _zz_65[8] = _zz_64;
-    _zz_65[7] = _zz_64;
-    _zz_65[6] = _zz_64;
-    _zz_65[5] = _zz_64;
-    _zz_65[4] = _zz_64;
-    _zz_65[3] = _zz_64;
-    _zz_65[2] = _zz_64;
-    _zz_65[1] = _zz_64;
-    _zz_65[0] = _zz_64;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_235[31]));
-    if(_zz_70)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_66 = _zz_236[19];
-  always @ (*) begin
-    _zz_67[10] = _zz_66;
-    _zz_67[9] = _zz_66;
-    _zz_67[8] = _zz_66;
-    _zz_67[7] = _zz_66;
-    _zz_67[6] = _zz_66;
-    _zz_67[5] = _zz_66;
-    _zz_67[4] = _zz_66;
-    _zz_67[3] = _zz_66;
-    _zz_67[2] = _zz_66;
-    _zz_67[1] = _zz_66;
-    _zz_67[0] = _zz_66;
+  assign _zz_2 = _zz__zz_2[19];
+  always @(*) begin
+    _zz_3[10] = _zz_2;
+    _zz_3[9] = _zz_2;
+    _zz_3[8] = _zz_2;
+    _zz_3[7] = _zz_2;
+    _zz_3[6] = _zz_2;
+    _zz_3[5] = _zz_2;
+    _zz_3[4] = _zz_2;
+    _zz_3[3] = _zz_2;
+    _zz_3[2] = _zz_2;
+    _zz_3[1] = _zz_2;
+    _zz_3[0] = _zz_2;
   end
 
-  assign _zz_68 = _zz_237[11];
-  always @ (*) begin
-    _zz_69[18] = _zz_68;
-    _zz_69[17] = _zz_68;
-    _zz_69[16] = _zz_68;
-    _zz_69[15] = _zz_68;
-    _zz_69[14] = _zz_68;
-    _zz_69[13] = _zz_68;
-    _zz_69[12] = _zz_68;
-    _zz_69[11] = _zz_68;
-    _zz_69[10] = _zz_68;
-    _zz_69[9] = _zz_68;
-    _zz_69[8] = _zz_68;
-    _zz_69[7] = _zz_68;
-    _zz_69[6] = _zz_68;
-    _zz_69[5] = _zz_68;
-    _zz_69[4] = _zz_68;
-    _zz_69[3] = _zz_68;
-    _zz_69[2] = _zz_68;
-    _zz_69[1] = _zz_68;
-    _zz_69[0] = _zz_68;
+  assign _zz_4 = _zz__zz_4[11];
+  always @(*) begin
+    _zz_5[18] = _zz_4;
+    _zz_5[17] = _zz_4;
+    _zz_5[16] = _zz_4;
+    _zz_5[15] = _zz_4;
+    _zz_5[14] = _zz_4;
+    _zz_5[13] = _zz_4;
+    _zz_5[12] = _zz_4;
+    _zz_5[11] = _zz_4;
+    _zz_5[10] = _zz_4;
+    _zz_5[9] = _zz_4;
+    _zz_5[8] = _zz_4;
+    _zz_5[7] = _zz_4;
+    _zz_5[6] = _zz_4;
+    _zz_5[5] = _zz_4;
+    _zz_5[4] = _zz_4;
+    _zz_5[3] = _zz_4;
+    _zz_5[2] = _zz_4;
+    _zz_5[1] = _zz_4;
+    _zz_5[0] = _zz_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_70 = _zz_238[1];
+        _zz_6 = _zz__zz_6[1];
       end
       default : begin
-        _zz_70 = _zz_239[1];
+        _zz_6 = _zz__zz_6_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_71 = _zz_240[19];
-  always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_73 = _zz_241[11];
-  always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_72,{{{_zz_322,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_74,{{{_zz_323,_zz_324},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_161 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_162 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_163 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_162;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_165 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_166 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_167 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_183)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_181)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_168 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_181)begin
-      _zz_168 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_182)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_180)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_182)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_180)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_160 = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign _zz_76 = 1'b0;
-  always @ (*) begin
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_dBus_cmd_valid = 1'b0;
+  always @(*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
-    if(execute_ALIGNEMENT_FAULT)begin
+    if(execute_ALIGNEMENT_FAULT) begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_77 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_dBus_cmd_payload_data = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_77 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_dBus_cmd_payload_data = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_77 = execute_RS2[31 : 0];
+        _zz_dBus_cmd_payload_data = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_77;
-  always @ (*) begin
+  assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
+  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_78 = 4'b0001;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0001;
       end
       2'b01 : begin
-        _zz_78 = 4'b0011;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0011;
       end
       default : begin
-        _zz_78 = 4'b1111;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_78 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_193)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
+    if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
+    if(when_DBusSimplePlugin_l512) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_193)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_242};
+    if(memory_ALIGNEMENT_FAULT) begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_DBusSimplePlugin_memoryExceptionPort_payload_code};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l486 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l512 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
@@ -3038,63 +3119,64 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_79 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_80[31] = _zz_79;
-    _zz_80[30] = _zz_79;
-    _zz_80[29] = _zz_79;
-    _zz_80[28] = _zz_79;
-    _zz_80[27] = _zz_79;
-    _zz_80[26] = _zz_79;
-    _zz_80[25] = _zz_79;
-    _zz_80[24] = _zz_79;
-    _zz_80[23] = _zz_79;
-    _zz_80[22] = _zz_79;
-    _zz_80[21] = _zz_79;
-    _zz_80[20] = _zz_79;
-    _zz_80[19] = _zz_79;
-    _zz_80[18] = _zz_79;
-    _zz_80[17] = _zz_79;
-    _zz_80[16] = _zz_79;
-    _zz_80[15] = _zz_79;
-    _zz_80[14] = _zz_79;
-    _zz_80[13] = _zz_79;
-    _zz_80[12] = _zz_79;
-    _zz_80[11] = _zz_79;
-    _zz_80[10] = _zz_79;
-    _zz_80[9] = _zz_79;
-    _zz_80[8] = _zz_79;
-    _zz_80[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[30] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[29] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[28] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[27] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[26] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[25] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[24] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[23] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[22] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[21] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[20] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[19] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[18] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[17] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[16] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[15] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[14] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[13] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[12] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[11] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[10] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[9] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[8] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_81 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_82[31] = _zz_81;
-    _zz_82[30] = _zz_81;
-    _zz_82[29] = _zz_81;
-    _zz_82[28] = _zz_81;
-    _zz_82[27] = _zz_81;
-    _zz_82[26] = _zz_81;
-    _zz_82[25] = _zz_81;
-    _zz_82[24] = _zz_81;
-    _zz_82[23] = _zz_81;
-    _zz_82[22] = _zz_81;
-    _zz_82[21] = _zz_81;
-    _zz_82[20] = _zz_81;
-    _zz_82[19] = _zz_81;
-    _zz_82[18] = _zz_81;
-    _zz_82[17] = _zz_81;
-    _zz_82[16] = _zz_81;
-    _zz_82[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated_2 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[31] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[30] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[29] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[28] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[27] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[26] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[25] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[24] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[23] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[22] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[21] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[20] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[19] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[18] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[17] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[16] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_212)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_80;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_82;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_3;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -3102,6 +3184,7 @@ module VexRiscv (
     endcase
   end
 
+  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3111,61 +3194,62 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_84 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_85 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_86 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_87 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_83 = {(((decode_INSTRUCTION & _zz_325) == 32'h00100050) != 1'b0),{((_zz_326 == _zz_327) != 1'b0),{({_zz_328,_zz_329} != 2'b00),{(_zz_330 != _zz_331),{_zz_332,{_zz_333,_zz_334}}}}}};
-  assign _zz_90 = _zz_83[2 : 1];
-  assign _zz_46 = _zz_90;
-  assign _zz_91 = _zz_83[7 : 6];
-  assign _zz_45 = _zz_91;
-  assign _zz_92 = _zz_83[9 : 8];
-  assign _zz_44 = _zz_92;
-  assign _zz_93 = _zz_83[18 : 17];
-  assign _zz_43 = _zz_93;
-  assign _zz_94 = _zz_83[21 : 20];
-  assign _zz_42 = _zz_94;
-  assign _zz_95 = _zz_83[23 : 22];
-  assign _zz_41 = _zz_95;
-  assign _zz_96 = _zz_83[26 : 25];
-  assign _zz_40 = _zz_96;
+  assign _zz_decode_IS_DIV_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_DIV_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_DIV_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_DIV_4 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_decode_IS_DIV_5 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_decode_IS_DIV_6 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_decode_IS_DIV = {(((decode_INSTRUCTION & _zz__zz_decode_IS_DIV) == 32'h00100050) != 1'b0),{((_zz__zz_decode_IS_DIV_1 == _zz__zz_decode_IS_DIV_2) != 1'b0),{({_zz__zz_decode_IS_DIV_3,_zz__zz_decode_IS_DIV_4} != 2'b00),{(_zz__zz_decode_IS_DIV_5 != _zz__zz_decode_IS_DIV_6),{_zz__zz_decode_IS_DIV_7,{_zz__zz_decode_IS_DIV_9,_zz__zz_decode_IS_DIV_12}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_DIV[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_DIV[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_DIV[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_DIV[18 : 17];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_DIV[21 : 20];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_DIV[23 : 22];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_DIV[26 : 25];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_169;
-  assign decode_RegFilePlugin_rs2Data = _zz_170;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
-    if(_zz_97)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_7) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
-    if(_zz_97)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_47;
-    if(_zz_97)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_7) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3174,296 +3258,322 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_98 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_98 = {31'd0, _zz_243};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_98 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_99 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_99 = {29'd0, _zz_244};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_99 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_99 = {27'd0, _zz_245};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_100 = _zz_246[11];
-  always @ (*) begin
-    _zz_101[19] = _zz_100;
-    _zz_101[18] = _zz_100;
-    _zz_101[17] = _zz_100;
-    _zz_101[16] = _zz_100;
-    _zz_101[15] = _zz_100;
-    _zz_101[14] = _zz_100;
-    _zz_101[13] = _zz_100;
-    _zz_101[12] = _zz_100;
-    _zz_101[11] = _zz_100;
-    _zz_101[10] = _zz_100;
-    _zz_101[9] = _zz_100;
-    _zz_101[8] = _zz_100;
-    _zz_101[7] = _zz_100;
-    _zz_101[6] = _zz_100;
-    _zz_101[5] = _zz_100;
-    _zz_101[4] = _zz_100;
-    _zz_101[3] = _zz_100;
-    _zz_101[2] = _zz_100;
-    _zz_101[1] = _zz_100;
-    _zz_101[0] = _zz_100;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_102 = _zz_247[11];
-  always @ (*) begin
-    _zz_103[19] = _zz_102;
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_104 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_104 = {_zz_101,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_104 = {_zz_103,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_104 = _zz_32;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_248;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  always @ (*) begin
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_105 = (execute_LightShifterPlugin_shiftInput <<< 1);
+      `ShiftCtrlEnum_defaultEncoding_SLL : begin
+        _zz_decode_RS2_3 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_105 = _zz_255;
+        _zz_decode_RS2_3 = _zz__zz_decode_RS2_3;
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_106 = 1'b0;
-    if(_zz_194)begin
-      if(_zz_195)begin
-        if(_zz_111)begin
-          _zz_106 = 1'b1;
+  assign when_ShiftPlugins_l175 = (! execute_arbitration_isStuckByOthers);
+  assign when_ShiftPlugins_l184 = (! execute_LightShifterPlugin_done);
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_196)begin
-      if(_zz_197)begin
-        if(_zz_113)begin
-          _zz_106 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_198)begin
-      if(_zz_199)begin
-        if(_zz_115)begin
-          _zz_106 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_106 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_107 = 1'b0;
-    if(_zz_194)begin
-      if(_zz_195)begin
-        if(_zz_112)begin
-          _zz_107 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_196)begin
-      if(_zz_197)begin
-        if(_zz_114)begin
-          _zz_107 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_198)begin
-      if(_zz_199)begin
-        if(_zz_116)begin
-          _zz_107 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS2_USE))begin
-      _zz_107 = 1'b0;
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
     end
   end
 
-  assign _zz_111 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_112 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_113 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_114 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_115 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_117 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_117 == 3'b000)) begin
-        _zz_118 = execute_BranchPlugin_eq;
-    end else if((_zz_117 == 3'b001)) begin
-        _zz_118 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_117 & 3'b101) == 3'b101))) begin
-        _zz_118 = (! execute_SRC_LESS);
-    end else begin
-        _zz_118 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_119 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_119 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_119 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_119 = _zz_118;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_120 = _zz_257[11];
-  always @ (*) begin
-    _zz_121[19] = _zz_120;
-    _zz_121[18] = _zz_120;
-    _zz_121[17] = _zz_120;
-    _zz_121[16] = _zz_120;
-    _zz_121[15] = _zz_120;
-    _zz_121[14] = _zz_120;
-    _zz_121[13] = _zz_120;
-    _zz_121[12] = _zz_120;
-    _zz_121[11] = _zz_120;
-    _zz_121[10] = _zz_120;
-    _zz_121[9] = _zz_120;
-    _zz_121[8] = _zz_120;
-    _zz_121[7] = _zz_120;
-    _zz_121[6] = _zz_120;
-    _zz_121[5] = _zz_120;
-    _zz_121[4] = _zz_120;
-    _zz_121[3] = _zz_120;
-    _zz_121[2] = _zz_120;
-    _zz_121[1] = _zz_120;
-    _zz_121[0] = _zz_120;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_122 = _zz_258[19];
-  always @ (*) begin
-    _zz_123[10] = _zz_122;
-    _zz_123[9] = _zz_122;
-    _zz_123[8] = _zz_122;
-    _zz_123[7] = _zz_122;
-    _zz_123[6] = _zz_122;
-    _zz_123[5] = _zz_122;
-    _zz_123[4] = _zz_122;
-    _zz_123[3] = _zz_122;
-    _zz_123[2] = _zz_122;
-    _zz_123[1] = _zz_122;
-    _zz_123[0] = _zz_122;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_124 = _zz_259[11];
-  always @ (*) begin
-    _zz_125[18] = _zz_124;
-    _zz_125[17] = _zz_124;
-    _zz_125[16] = _zz_124;
-    _zz_125[15] = _zz_124;
-    _zz_125[14] = _zz_124;
-    _zz_125[13] = _zz_124;
-    _zz_125[12] = _zz_124;
-    _zz_125[11] = _zz_124;
-    _zz_125[10] = _zz_124;
-    _zz_125[9] = _zz_124;
-    _zz_125[8] = _zz_124;
-    _zz_125[7] = _zz_124;
-    _zz_125[6] = _zz_124;
-    _zz_125[5] = _zz_124;
-    _zz_125[4] = _zz_124;
-    _zz_125[3] = _zz_124;
-    _zz_125[2] = _zz_124;
-    _zz_125[1] = _zz_124;
-    _zz_125[0] = _zz_124;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_126 = (_zz_260[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_126 = _zz_261[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_126 = _zz_262[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_126);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -3474,80 +3584,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_127 = _zz_263[11];
-  always @ (*) begin
-    _zz_128[19] = _zz_127;
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_128,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_130,{{{_zz_475,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_132,{{{_zz_476,_zz_477},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_266};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_129 = _zz_264[19];
-  always @ (*) begin
-    _zz_130[10] = _zz_129;
-    _zz_130[9] = _zz_129;
-    _zz_130[8] = _zz_129;
-    _zz_130[7] = _zz_129;
-    _zz_130[6] = _zz_129;
-    _zz_130[5] = _zz_129;
-    _zz_130[4] = _zz_129;
-    _zz_130[3] = _zz_129;
-    _zz_130[2] = _zz_129;
-    _zz_130[1] = _zz_129;
-    _zz_130[0] = _zz_129;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_131 = _zz_265[11];
-  always @ (*) begin
-    _zz_132[18] = _zz_131;
-    _zz_132[17] = _zz_131;
-    _zz_132[16] = _zz_131;
-    _zz_132[15] = _zz_131;
-    _zz_132[14] = _zz_131;
-    _zz_132[13] = _zz_131;
-    _zz_132[12] = _zz_131;
-    _zz_132[11] = _zz_131;
-    _zz_132[10] = _zz_131;
-    _zz_132[9] = _zz_131;
-    _zz_132[8] = _zz_131;
-    _zz_132[7] = _zz_131;
-    _zz_132[6] = _zz_131;
-    _zz_132[5] = _zz_131;
-    _zz_132[4] = _zz_131;
-    _zz_132[3] = _zz_131;
-    _zz_132[2] = _zz_131;
-    _zz_132[1] = _zz_131;
-    _zz_132[0] = _zz_131;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -3557,94 +3667,108 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_133 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_134 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_135 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_136 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_137 = _zz_267[0];
-  assign _zz_138 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_139 = _zz_269[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_184)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_188)begin
+    if(_zz_when_1) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -3655,8 +3779,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -3666,72 +3790,79 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_200)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_201)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_201)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3744,115 +3875,136 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_200)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_200)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_213)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_172)begin
-      if(_zz_187)begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_mul_counter_willClear = 1'b0;
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l110) begin
       memory_MulDivIterativePlugin_mul_counter_willClear = 1'b1;
     end
   end
 
   assign memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_mul_counter_value == 6'h20);
   assign memory_MulDivIterativePlugin_mul_counter_willOverflow = (memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc && memory_MulDivIterativePlugin_mul_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_MulDivIterativePlugin_mul_counter_willOverflow) begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_272);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_memory_MulDivIterativePlugin_mul_counter_valueNext);
     end
-    if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
+    if(memory_MulDivIterativePlugin_mul_counter_willClear) begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end
   end
 
-  always @ (*) begin
+  assign when_MulDivIterativePlugin_l96 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign when_MulDivIterativePlugin_l97 = ((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign when_MulDivIterativePlugin_l100 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign when_MulDivIterativePlugin_l110 = (! memory_arbitration_isStuck);
+  always @(*) begin
     memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_173)begin
-      if(_zz_202)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_MulDivIterativePlugin_div_counter_willClear = 1'b0;
-    if(_zz_203)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_MulDivIterativePlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_MulDivIterativePlugin_div_counter_willOverflowIfInc = (memory_MulDivIterativePlugin_div_counter_value == 6'h21);
   assign memory_MulDivIterativePlugin_div_counter_willOverflow = (memory_MulDivIterativePlugin_div_counter_willOverflowIfInc && memory_MulDivIterativePlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_MulDivIterativePlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_MulDivIterativePlugin_div_counter_willOverflow) begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_280);
+      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_memory_MulDivIterativePlugin_div_counter_valueNext);
     end
-    if(memory_MulDivIterativePlugin_div_counter_willClear)begin
+    if(memory_MulDivIterativePlugin_div_counter_willClear) begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_140 = memory_MulDivIterativePlugin_rs1[31 : 0];
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_140[31]};
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_281);
-  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_282 : _zz_283);
-  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_284[31:0];
-  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
-  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_143 = ((execute_IS_MUL && _zz_142) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_144[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
+  assign _zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted = memory_MulDivIterativePlugin_rs1[31 : 0];
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31]};
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder : _zz_memory_MulDivIterativePlugin_div_stage_0_outRemainder_1);
+  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_memory_MulDivIterativePlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_MulDivIterativePlugin_div_counter_value == 6'h20);
+  assign _zz_memory_MulDivIterativePlugin_div_result = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_MulDivIterativePlugin_rs1 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_MulDivIterativePlugin_rs1_1 = ((execute_IS_MUL && _zz_memory_MulDivIterativePlugin_rs1) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_MulDivIterativePlugin_rs1_2[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_MulDivIterativePlugin_rs1_2[31 : 0] = execute_RS1;
   end
 
-  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_146 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_204)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -3862,9 +4014,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_147))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3873,12 +4025,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_204)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -3889,33 +4042,99 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_24 = decode_SRC1_CTRL;
-  assign _zz_22 = _zz_46;
-  assign _zz_34 = decode_to_execute_SRC1_CTRL;
-  assign _zz_21 = decode_ALU_CTRL;
-  assign _zz_19 = _zz_45;
-  assign _zz_35 = decode_to_execute_ALU_CTRL;
-  assign _zz_18 = decode_SRC2_CTRL;
-  assign _zz_16 = _zz_44;
-  assign _zz_33 = decode_to_execute_SRC2_CTRL;
-  assign _zz_15 = decode_ALU_BITWISE_CTRL;
-  assign _zz_13 = _zz_43;
-  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_12 = decode_SHIFT_CTRL;
-  assign _zz_10 = _zz_42;
-  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_48 = _zz_41;
-  assign _zz_28 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_40;
-  assign _zz_26 = decode_to_execute_ENV_CTRL;
-  assign _zz_25 = execute_to_memory_ENV_CTRL;
-  assign _zz_27 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_14 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_17 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_50 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3936,9 +4155,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_148)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -3947,94 +4172,108 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_149 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_149[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_149[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_149[3 : 3] = CsrPlugin_mstatus_MIE;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_150[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_150[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_150[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_151[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_151[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_151[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_152[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_153[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_153[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_154[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_155[31 : 0] = _zz_145;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_156 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_156[31 : 0] = _zz_146;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_149 | _zz_150) | (_zz_151 | _zz_152)) | ((_zz_153 | _zz_154) | (_zz_155 | _zz_156)));
-  assign iBusWishbone_ADR = {_zz_300,_zz_157};
-  assign iBusWishbone_CTI = ((_zz_157 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_205)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_205)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_158;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
+  assign when_Stream_l399 = (! dBus_cmd_halfPipe_regs_valid);
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
   assign dBus_cmd_halfPipe_payload_wr = dBus_cmd_halfPipe_regs_payload_wr;
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_halfPipe_regs_payload_address;
@@ -4044,27 +4283,28 @@ module VexRiscv (
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_159 = 4'b0001;
+        _zz_dBusWishbone_SEL = 4'b0001;
       end
       2'b01 : begin
-        _zz_159 = 4'b0011;
+        _zz_dBusWishbone_SEL = 4'b0011;
       end
       default : begin
-        _zz_159 = 4'b1111;
+        _zz_dBusWishbone_SEL = 4'b1111;
       end
     endcase
   end
 
-  always @ (*) begin
-    dBusWishbone_SEL = (_zz_159 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if((! dBus_cmd_halfPipe_payload_wr))begin
+  always @(*) begin
+    dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    if(when_DBusSimplePlugin_l189) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
+  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -4073,24 +4313,24 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_60 <= 1'b0;
-      _zz_62 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_75;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_97 <= 1'b1;
+      _zz_7 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_108 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -4109,90 +4349,90 @@ module VexRiscv (
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
       memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_145 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_148 <= 3'b000;
-      _zz_157 <= 3'b000;
-      _zz_158 <= 1'b0;
+      switch_Fetcher_l362 <= 3'b000;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_60 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_58)begin
-        _zz_60 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_62 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_62 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
       `ifndef SYNTHESIS
@@ -4215,72 +4455,72 @@ module VexRiscv (
           end
         `endif
       `endif
-      _zz_97 <= 1'b0;
-      if(_zz_178)begin
-        if(_zz_206)begin
+      _zz_7 <= 1'b0;
+      if(when_ShiftPlugins_l169) begin
+        if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
-          if(execute_LightShifterPlugin_done)begin
+          if(execute_LightShifterPlugin_done) begin
             execute_LightShifterPlugin_isActive <= 1'b0;
           end
         end
       end
-      if(execute_arbitration_removeIt)begin
+      if(execute_arbitration_removeIt) begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_108 <= (_zz_38 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_207)begin
-        if(_zz_208)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_209)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_210)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_189)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4291,8 +4531,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_190)begin
-        case(_zz_192)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4302,76 +4542,76 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_135,{_zz_134,_zz_133}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_148)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_148 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_148 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_148 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_148 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_148 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_294[0];
-          CsrPlugin_mstatus_MIE <= _zz_295[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_297[0];
-          CsrPlugin_mie_MTIE <= _zz_298[0];
-          CsrPlugin_mie_MSIE <= _zz_299[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_205)begin
-        if(iBusWishbone_ACK)begin
-          _zz_157 <= (_zz_157 + 3'b001);
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_158 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_211)begin
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_Stream_l399) begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -4381,63 +4621,63 @@ module VexRiscv (
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_63 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_178)begin
-      if(_zz_206)begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l175) begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_109 <= _zz_37[11 : 7];
-    _zz_110 <= _zz_47;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_184)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_188)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_when_1) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_207)begin
-      if(_zz_208)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_209)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_210)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_189)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -4445,241 +4685,241 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_172)begin
-      if(_zz_187)begin
+    if(when_MulDivIterativePlugin_l96) begin
+      if(when_MulDivIterativePlugin_l100) begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_273,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_memory_MulDivIterativePlugin_accumulator,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
-    if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_MulDivIterativePlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_MulDivIterativePlugin_div_done <= 1'b0;
     end
-    if(_zz_173)begin
-      if(_zz_202)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_MulDivIterativePlugin_rs1[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outNumerator;
         memory_MulDivIterativePlugin_accumulator[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outRemainder;
-        if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
-          memory_MulDivIterativePlugin_div_result <= _zz_285[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_MulDivIterativePlugin_div_result <= _zz_memory_MulDivIterativePlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_203)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_291);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_293);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ? (~ _zz_memory_MulDivIterativePlugin_rs1_2) : _zz_memory_MulDivIterativePlugin_rs1_2) + _zz_memory_MulDivIterativePlugin_rs1_3);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_memory_MulDivIterativePlugin_rs1 ? (~ execute_RS2) : execute_RS2) + _zz_memory_MulDivIterativePlugin_rs2);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_memory_MulDivIterativePlugin_rs1_1 ^ (_zz_memory_MulDivIterativePlugin_rs1 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_50;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_49;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_23;
+    if(when_Pipeline_l124_9) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_10) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_20;
+    if(when_Pipeline_l124_14) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_17;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_16) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_14;
+    if(when_Pipeline_l124_26) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_11;
+    if(when_Pipeline_l124_27) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_30) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_31) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_32) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_34) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_35) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    if(when_Pipeline_l124_49) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_29;
+    if(when_Pipeline_l124_50) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_51) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_52) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_296[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_211)begin
+    if(when_Stream_l399) begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -4687,56 +4927,67 @@ module VexRiscv (
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_47;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_147 <= debug_bus_cmd_payload_address[2];
-    if(_zz_185)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_204)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -4744,14 +4995,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_185)begin
-        if(_zz_186)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_191)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -4800,18 +5051,14 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
+  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [22:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [22:0]   _zz_17;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [22:0]   _zz_ways_0_tags_port1;
+  wire       [22:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -4820,8 +5067,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [6:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -4835,22 +5087,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [8:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [8:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [8:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [5:0]    _zz_6;
-  wire                _zz_7;
+  wire       [5:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [22:0]   _zz_8;
+  wire       [22:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -4860,82 +5115,86 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
+  wire                when_Fetcher_l398;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
   (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
-  assign _zz_13 = (! lineLoader_flushCounter[6]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[6]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -4951,30 +5210,36 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[10 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[10 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[10 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[22 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[10 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -4982,51 +5247,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[6];
-    if(_zz_14)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 7'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -5037,14 +5302,14 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
+    if(when_Fetcher_l398) begin
+      io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Min.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Min.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -73,217 +73,177 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_119;
-  wire                _zz_120;
-  reg        [31:0]   _zz_121;
-  reg        [31:0]   _zz_122;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
-  wire                _zz_123;
-  wire                _zz_124;
-  wire                _zz_125;
-  wire                _zz_126;
-  wire                _zz_127;
-  wire       [1:0]    _zz_128;
-  wire                _zz_129;
-  wire                _zz_130;
-  wire                _zz_131;
-  wire                _zz_132;
-  wire                _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
-  wire                _zz_139;
-  wire                _zz_140;
-  wire                _zz_141;
-  wire                _zz_142;
-  wire                _zz_143;
-  wire       [1:0]    _zz_144;
-  wire                _zz_145;
-  wire       [0:0]    _zz_146;
-  wire       [0:0]    _zz_147;
-  wire       [0:0]    _zz_148;
-  wire       [0:0]    _zz_149;
-  wire       [0:0]    _zz_150;
-  wire       [0:0]    _zz_151;
-  wire       [0:0]    _zz_152;
-  wire       [0:0]    _zz_153;
-  wire       [0:0]    _zz_154;
-  wire       [0:0]    _zz_155;
-  wire       [0:0]    _zz_156;
-  wire       [1:0]    _zz_157;
-  wire       [1:0]    _zz_158;
-  wire       [2:0]    _zz_159;
-  wire       [31:0]   _zz_160;
-  wire       [2:0]    _zz_161;
-  wire       [0:0]    _zz_162;
-  wire       [2:0]    _zz_163;
-  wire       [0:0]    _zz_164;
-  wire       [2:0]    _zz_165;
-  wire       [0:0]    _zz_166;
-  wire       [2:0]    _zz_167;
-  wire       [0:0]    _zz_168;
-  wire       [2:0]    _zz_169;
-  wire       [2:0]    _zz_170;
-  wire       [0:0]    _zz_171;
-  wire       [2:0]    _zz_172;
-  wire       [4:0]    _zz_173;
-  wire       [11:0]   _zz_174;
-  wire       [11:0]   _zz_175;
-  wire       [31:0]   _zz_176;
-  wire       [31:0]   _zz_177;
-  wire       [31:0]   _zz_178;
-  wire       [31:0]   _zz_179;
-  wire       [31:0]   _zz_180;
-  wire       [31:0]   _zz_181;
-  wire       [31:0]   _zz_182;
-  wire       [31:0]   _zz_183;
-  wire       [32:0]   _zz_184;
-  wire       [19:0]   _zz_185;
-  wire       [11:0]   _zz_186;
-  wire       [11:0]   _zz_187;
-  wire       [1:0]    _zz_188;
-  wire       [1:0]    _zz_189;
-  wire       [0:0]    _zz_190;
-  wire       [0:0]    _zz_191;
-  wire       [0:0]    _zz_192;
-  wire       [0:0]    _zz_193;
-  wire       [0:0]    _zz_194;
-  wire       [0:0]    _zz_195;
-  wire                _zz_196;
-  wire                _zz_197;
-  wire       [31:0]   _zz_198;
-  wire       [31:0]   _zz_199;
-  wire       [31:0]   _zz_200;
-  wire                _zz_201;
-  wire       [0:0]    _zz_202;
-  wire       [12:0]   _zz_203;
-  wire       [31:0]   _zz_204;
-  wire       [31:0]   _zz_205;
-  wire       [31:0]   _zz_206;
-  wire                _zz_207;
-  wire       [0:0]    _zz_208;
-  wire       [6:0]    _zz_209;
-  wire       [31:0]   _zz_210;
-  wire       [31:0]   _zz_211;
-  wire       [31:0]   _zz_212;
-  wire                _zz_213;
-  wire       [0:0]    _zz_214;
-  wire       [0:0]    _zz_215;
-  wire       [31:0]   _zz_216;
-  wire       [31:0]   _zz_217;
-  wire       [31:0]   _zz_218;
-  wire       [0:0]    _zz_219;
-  wire       [0:0]    _zz_220;
-  wire       [1:0]    _zz_221;
-  wire       [1:0]    _zz_222;
-  wire                _zz_223;
-  wire       [0:0]    _zz_224;
-  wire       [19:0]   _zz_225;
-  wire       [31:0]   _zz_226;
-  wire       [31:0]   _zz_227;
-  wire       [31:0]   _zz_228;
-  wire       [31:0]   _zz_229;
-  wire       [31:0]   _zz_230;
-  wire       [31:0]   _zz_231;
-  wire                _zz_232;
-  wire       [1:0]    _zz_233;
-  wire       [1:0]    _zz_234;
-  wire                _zz_235;
-  wire       [0:0]    _zz_236;
-  wire       [16:0]   _zz_237;
-  wire       [31:0]   _zz_238;
-  wire       [31:0]   _zz_239;
-  wire       [31:0]   _zz_240;
-  wire       [31:0]   _zz_241;
-  wire                _zz_242;
-  wire                _zz_243;
-  wire                _zz_244;
-  wire       [0:0]    _zz_245;
-  wire       [0:0]    _zz_246;
-  wire                _zz_247;
-  wire       [0:0]    _zz_248;
-  wire       [13:0]   _zz_249;
-  wire       [31:0]   _zz_250;
-  wire                _zz_251;
-  wire                _zz_252;
-  wire       [0:0]    _zz_253;
-  wire       [0:0]    _zz_254;
-  wire       [2:0]    _zz_255;
-  wire       [2:0]    _zz_256;
-  wire                _zz_257;
-  wire       [0:0]    _zz_258;
-  wire       [10:0]   _zz_259;
-  wire       [31:0]   _zz_260;
-  wire       [31:0]   _zz_261;
-  wire       [31:0]   _zz_262;
-  wire       [31:0]   _zz_263;
-  wire                _zz_264;
-  wire                _zz_265;
-  wire       [31:0]   _zz_266;
-  wire       [31:0]   _zz_267;
-  wire                _zz_268;
-  wire       [0:0]    _zz_269;
-  wire       [0:0]    _zz_270;
-  wire                _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [7:0]    _zz_273;
-  wire       [0:0]    _zz_274;
-  wire       [3:0]    _zz_275;
-  wire       [0:0]    _zz_276;
-  wire       [0:0]    _zz_277;
-  wire       [1:0]    _zz_278;
-  wire       [1:0]    _zz_279;
-  wire                _zz_280;
-  wire       [0:0]    _zz_281;
-  wire       [4:0]    _zz_282;
-  wire       [31:0]   _zz_283;
-  wire       [31:0]   _zz_284;
-  wire       [31:0]   _zz_285;
-  wire       [0:0]    _zz_286;
-  wire       [0:0]    _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [31:0]   _zz_289;
-  wire       [31:0]   _zz_290;
-  wire                _zz_291;
-  wire                _zz_292;
-  wire                _zz_293;
-  wire       [3:0]    _zz_294;
-  wire       [3:0]    _zz_295;
-  wire                _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [1:0]    _zz_298;
-  wire       [31:0]   _zz_299;
-  wire       [31:0]   _zz_300;
-  wire       [31:0]   _zz_301;
-  wire       [31:0]   _zz_302;
-  wire       [31:0]   _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire                _zz_306;
-  wire       [0:0]    _zz_307;
-  wire       [1:0]    _zz_308;
-  wire                _zz_309;
-  wire       [2:0]    _zz_310;
-  wire       [2:0]    _zz_311;
-  wire                _zz_312;
-  wire                _zz_313;
-  wire       [31:0]   _zz_314;
-  wire       [31:0]   _zz_315;
-  wire       [31:0]   _zz_316;
-  wire       [31:0]   _zz_317;
-  wire       [31:0]   _zz_318;
-  wire       [31:0]   _zz_319;
-  wire       [31:0]   _zz_320;
-  wire                _zz_321;
-  wire                _zz_322;
-  wire                _zz_323;
-  wire                _zz_324;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
+  wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusSimplePlugin_fetchPc_pc_1;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_1;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_2;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_3;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_4;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
+  wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_1;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_2;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_3;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_4;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_5;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_6;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_7;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_8;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_9;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_10;
+  wire                _zz__zz_decode_ENV_CTRL_2_11;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_12;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_13;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_14;
+  wire                _zz__zz_decode_ENV_CTRL_2_15;
+  wire       [19:0]   _zz__zz_decode_ENV_CTRL_2_16;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_17;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_18;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_19;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_20;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_21;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_22;
+  wire                _zz__zz_decode_ENV_CTRL_2_23;
+  wire                _zz__zz_decode_ENV_CTRL_2_24;
+  wire                _zz__zz_decode_ENV_CTRL_2_25;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_26;
+  wire                _zz__zz_decode_ENV_CTRL_2_27;
+  wire       [16:0]   _zz__zz_decode_ENV_CTRL_2_28;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_29;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_30;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_31;
+  wire                _zz__zz_decode_ENV_CTRL_2_32;
+  wire                _zz__zz_decode_ENV_CTRL_2_33;
+  wire                _zz__zz_decode_ENV_CTRL_2_34;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_35;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_36;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_37;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_38;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_39;
+  wire       [13:0]   _zz__zz_decode_ENV_CTRL_2_40;
+  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_41;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_42;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_43;
+  wire                _zz__zz_decode_ENV_CTRL_2_44;
+  wire                _zz__zz_decode_ENV_CTRL_2_45;
+  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_46;
+  wire                _zz__zz_decode_ENV_CTRL_2_47;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_48;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_49;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_50;
+  wire                _zz__zz_decode_ENV_CTRL_2_51;
+  wire       [10:0]   _zz__zz_decode_ENV_CTRL_2_52;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_53;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_54;
+  wire                _zz__zz_decode_ENV_CTRL_2_55;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_56;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_57;
+  wire       [3:0]    _zz__zz_decode_ENV_CTRL_2_58;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_59;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_60;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_61;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_62;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_63;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_64;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_65;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_66;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_67;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_68;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_69;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_70;
+  wire       [7:0]    _zz__zz_decode_ENV_CTRL_2_71;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_72;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_73;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_74;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_75;
+  wire                _zz__zz_decode_ENV_CTRL_2_76;
+  wire                _zz__zz_decode_ENV_CTRL_2_77;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_78;
+  wire                _zz__zz_decode_ENV_CTRL_2_79;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_80;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_81;
+  wire                _zz__zz_decode_ENV_CTRL_2_82;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_83;
+  wire       [4:0]    _zz__zz_decode_ENV_CTRL_2_84;
+  wire       [3:0]    _zz__zz_decode_ENV_CTRL_2_85;
+  wire                _zz__zz_decode_ENV_CTRL_2_86;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_87;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_88;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_89;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_90;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_91;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_92;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_93;
+  wire       [3:0]    _zz__zz_decode_ENV_CTRL_2_94;
+  wire                _zz__zz_decode_ENV_CTRL_2_95;
+  wire                _zz__zz_decode_ENV_CTRL_2_96;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_97;
+  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_98;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_99;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_100;
+  wire                _zz__zz_decode_ENV_CTRL_2_101;
+  wire                _zz__zz_decode_ENV_CTRL_2_102;
+  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_103;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_104;
+  wire                _zz__zz_decode_ENV_CTRL_2_105;
+  wire                _zz__zz_decode_ENV_CTRL_2_106;
+  wire                _zz__zz_decode_ENV_CTRL_2_107;
+  wire                _zz__zz_decode_ENV_CTRL_2_108;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [31:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+  wire       [32:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
@@ -296,45 +256,45 @@ module VexRiscv (
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire                decode_MEMORY_ENABLE;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -344,17 +304,17 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -363,42 +323,42 @@ module VexRiscv (
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   _zz_30;
+  reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
-  wire       [31:0]   _zz_37;
-  wire                _zz_38;
-  reg                 _zz_39;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47;
+  reg        [31:0]   _zz_lastStageRegFileWrite_payload_data;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
@@ -412,7 +372,7 @@ module VexRiscv (
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
-  reg        [31:0]   _zz_48;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire       [31:0]   writeBack_PC;
@@ -488,6 +448,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -505,22 +470,28 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
-  wire       [1:0]    _zz_49;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload;
   wire                IBusSimplePlugin_fetchPc_output_valid;
   wire                IBusSimplePlugin_fetchPc_output_ready;
   wire       [31:0]   IBusSimplePlugin_fetchPc_output_payload;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusSimplePlugin_fetchPc_correction;
   reg                 IBusSimplePlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusSimplePlugin_fetchPc_corrected;
   reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
   reg                 IBusSimplePlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
@@ -536,12 +507,12 @@ module VexRiscv (
   wire                IBusSimplePlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   wire                IBusSimplePlugin_iBusRsp_stages_1_halt;
-  wire                _zz_50;
-  wire                _zz_51;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
   wire                IBusSimplePlugin_iBusRsp_flush;
-  wire                _zz_52;
-  wire                _zz_53;
-  reg                 _zz_54;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -555,16 +526,22 @@ module VexRiscv (
   wire                IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_55;
-  reg        [31:0]   _zz_56;
-  reg                 _zz_57;
-  reg        [31:0]   _zz_58;
-  reg                 _zz_59;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  wire                when_Fetcher_l320;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
+  wire                when_Fetcher_l329_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
   wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
@@ -574,6 +551,7 @@ module VexRiscv (
   reg        [2:0]    IBusSimplePlugin_pending_value;
   wire       [2:0]    IBusSimplePlugin_pending_next;
   wire                IBusSimplePlugin_cmdFork_canEmit;
+  wire                when_IBusSimplePlugin_l304;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -584,6 +562,7 @@ module VexRiscv (
   reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
+  wire                when_IBusSimplePlugin_l375;
   wire                IBusSimplePlugin_rspJoin_join_valid;
   wire                IBusSimplePlugin_rspJoin_join_ready;
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_pc;
@@ -591,7 +570,7 @@ module VexRiscv (
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
   wire                IBusSimplePlugin_rspJoin_exceptionDetected;
-  wire                _zz_60;
+  wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -601,29 +580,36 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_61;
+  wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_62;
-  reg        [3:0]    _zz_63;
+  reg        [31:0]   _zz_dBus_cmd_payload_data;
+  wire                when_DBusSimplePlugin_l426;
+  reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
+  wire                when_DBusSimplePlugin_l479;
+  wire                when_DBusSimplePlugin_l486;
+  wire                when_DBusSimplePlugin_l512;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_64;
-  reg        [31:0]   _zz_65;
-  wire                _zz_66;
-  reg        [31:0]   _zz_67;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [25:0]   _zz_68;
-  wire                _zz_69;
-  wire                _zz_70;
-  wire                _zz_71;
-  wire                _zz_72;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_73;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_74;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_75;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_76;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_77;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_78;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_79;
+  wire                when_DBusSimplePlugin_l558;
+  wire       [25:0]   _zz_decode_ENV_CTRL_2;
+  wire                _zz_decode_ENV_CTRL_3;
+  wire                _zz_decode_ENV_CTRL_4;
+  wire                _zz_decode_ENV_CTRL_5;
+  wire                _zz_decode_ENV_CTRL_6;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_7;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -631,15 +617,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_80;
+  reg                 _zz_2;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_81;
-  reg        [31:0]   _zz_82;
-  wire                _zz_83;
-  reg        [19:0]   _zz_84;
-  wire                _zz_85;
-  reg        [19:0]   _zz_86;
-  reg        [31:0]   _zz_87;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -648,23 +634,47 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_88;
-  reg                 _zz_89;
-  reg                 _zz_90;
-  reg                 _zz_91;
-  reg        [4:0]    _zz_92;
+  wire                when_ShiftPlugins_l169;
+  reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+  wire                when_ShiftPlugins_l175;
+  wire                when_ShiftPlugins_l184;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l59;
+  wire                when_HazardSimplePlugin_l62;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l59_1;
+  wire                when_HazardSimplePlugin_l62_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l59_2;
+  wire                when_HazardSimplePlugin_l62_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_93;
-  reg                 _zz_94;
-  reg                 _zz_95;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_DO;
+  reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_96;
-  reg        [10:0]   _zz_97;
-  wire                _zz_98;
-  reg        [19:0]   _zz_99;
-  wire                _zz_100;
-  reg        [18:0]   _zz_101;
-  reg        [31:0]   _zz_102;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
+  reg        [31:0]   _zz_execute_BranchPlugin_branch_src2_6;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -686,9 +696,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_103;
-  wire                _zz_104;
-  wire                _zz_105;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -701,107 +711,193 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_106;
-  wire                _zz_107;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_108;
-  wire       [31:0]   _zz_109;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_12;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_15;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_16;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_17;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 decode_to_execute_MEMORY_STORE;
+  wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_MEMORY_STORE;
+  wire                when_Pipeline_l124_24;
   reg                 memory_to_writeBack_MEMORY_STORE;
+  wire                when_Pipeline_l124_25;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_26;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_27;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_28;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_30;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_32;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_33;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_34;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_35;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_37;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_38;
   reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  wire                when_Pipeline_l124_39;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_40;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_41;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_42;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_43;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_45;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_110;
-  reg        [31:0]   _zz_111;
-  reg        [31:0]   _zz_112;
-  reg        [31:0]   _zz_113;
-  reg        [31:0]   _zz_114;
-  reg        [31:0]   _zz_115;
-  reg        [31:0]   _zz_116;
-  reg        [31:0]   _zz_117;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
-  reg                 iBus_cmd_m2sPipe_rValid;
-  reg        [31:0]   iBus_cmd_m2sPipe_rData_pc;
+  reg                 iBus_cmd_rValid;
+  reg        [31:0]   iBus_cmd_rData_pc;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
   wire                dBus_cmd_halfPipe_payload_wr;
@@ -814,77 +910,79 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_118;
+  wire                when_Stream_l399;
+  reg        [3:0]    _zz_dBusWishbone_SEL;
+  wire                when_DBusSimplePlugin_l189;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [31:0] _zz_10_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_14_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_17_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_20_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_23_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_26_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_29_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36_string;
-  reg [39:0] _zz_40_string;
-  reg [31:0] _zz_41_string;
-  reg [71:0] _zz_42_string;
-  reg [39:0] _zz_43_string;
-  reg [23:0] _zz_44_string;
-  reg [63:0] _zz_45_string;
-  reg [95:0] _zz_46_string;
-  reg [95:0] _zz_73_string;
-  reg [63:0] _zz_74_string;
-  reg [23:0] _zz_75_string;
-  reg [39:0] _zz_76_string;
-  reg [71:0] _zz_77_string;
-  reg [31:0] _zz_78_string;
-  reg [39:0] _zz_79_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_7_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -893,271 +991,230 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_123 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_124 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_125 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_126 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_127 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_128 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_129 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_130 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_131 = (1'b1 || (! 1'b1));
-  assign _zz_132 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_133 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_134 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_135 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_136 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_137 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_138 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_139 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_140 = ((_zz_103 && 1'b1) && (! 1'b0));
-  assign _zz_141 = ((_zz_104 && 1'b1) && (! 1'b0));
-  assign _zz_142 = ((_zz_105 && 1'b1) && (! 1'b0));
-  assign _zz_143 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_144 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_145 = execute_INSTRUCTION[13];
-  assign _zz_146 = _zz_68[23 : 23];
-  assign _zz_147 = _zz_68[15 : 15];
-  assign _zz_148 = _zz_68[12 : 12];
-  assign _zz_149 = _zz_68[11 : 11];
-  assign _zz_150 = _zz_68[10 : 10];
-  assign _zz_151 = _zz_68[3 : 3];
-  assign _zz_152 = _zz_68[14 : 14];
-  assign _zz_153 = _zz_68[4 : 4];
-  assign _zz_154 = _zz_68[2 : 2];
-  assign _zz_155 = _zz_68[18 : 18];
-  assign _zz_156 = _zz_68[9 : 9];
-  assign _zz_157 = (_zz_49 & (~ _zz_158));
-  assign _zz_158 = (_zz_49 - 2'b01);
-  assign _zz_159 = {IBusSimplePlugin_fetchPc_inc,2'b00};
-  assign _zz_160 = {29'd0, _zz_159};
-  assign _zz_161 = (IBusSimplePlugin_pending_value + _zz_163);
-  assign _zz_162 = IBusSimplePlugin_pending_inc;
-  assign _zz_163 = {2'd0, _zz_162};
-  assign _zz_164 = IBusSimplePlugin_pending_dec;
-  assign _zz_165 = {2'd0, _zz_164};
-  assign _zz_166 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
-  assign _zz_167 = {2'd0, _zz_166};
-  assign _zz_168 = IBusSimplePlugin_pending_dec;
-  assign _zz_169 = {2'd0, _zz_168};
-  assign _zz_170 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
-  assign _zz_171 = execute_SRC_LESS;
-  assign _zz_172 = 3'b100;
-  assign _zz_173 = execute_INSTRUCTION[19 : 15];
-  assign _zz_174 = execute_INSTRUCTION[31 : 20];
-  assign _zz_175 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_176 = ($signed(_zz_177) + $signed(_zz_180));
-  assign _zz_177 = ($signed(_zz_178) + $signed(_zz_179));
-  assign _zz_178 = execute_SRC1;
-  assign _zz_179 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_180 = (execute_SRC_USE_SUB_LESS ? _zz_181 : _zz_182);
-  assign _zz_181 = 32'h00000001;
-  assign _zz_182 = 32'h0;
-  assign _zz_183 = (_zz_184 >>> 1);
-  assign _zz_184 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_185 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_186 = execute_INSTRUCTION[31 : 20];
-  assign _zz_187 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_188 = (_zz_106 & (~ _zz_189));
-  assign _zz_189 = (_zz_106 - 2'b01);
-  assign _zz_190 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_191 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_192 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_193 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_194 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_195 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_196 = 1'b1;
-  assign _zz_197 = 1'b1;
-  assign _zz_198 = 32'h0000107f;
-  assign _zz_199 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_200 = 32'h00002073;
-  assign _zz_201 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_202 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_203 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_204) == 32'h00000003),{(_zz_205 == _zz_206),{_zz_207,{_zz_208,_zz_209}}}}}};
-  assign _zz_204 = 32'h0000505f;
-  assign _zz_205 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_206 = 32'h00000063;
-  assign _zz_207 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_208 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_209 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_210) == 32'h00005033),{(_zz_211 == _zz_212),{_zz_213,{_zz_214,_zz_215}}}}}};
-  assign _zz_210 = 32'hbe00707f;
-  assign _zz_211 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_212 = 32'h00000033;
-  assign _zz_213 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_214 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_215 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_216 = 32'h10003050;
-  assign _zz_217 = (decode_INSTRUCTION & 32'h10403050);
-  assign _zz_218 = 32'h10000050;
-  assign _zz_219 = ((decode_INSTRUCTION & _zz_226) == 32'h00001050);
-  assign _zz_220 = ((decode_INSTRUCTION & _zz_227) == 32'h00002050);
-  assign _zz_221 = {_zz_72,(_zz_228 == _zz_229)};
-  assign _zz_222 = 2'b00;
-  assign _zz_223 = ((_zz_230 == _zz_231) != 1'b0);
-  assign _zz_224 = (_zz_232 != 1'b0);
-  assign _zz_225 = {(_zz_233 != _zz_234),{_zz_235,{_zz_236,_zz_237}}};
-  assign _zz_226 = 32'h00001050;
-  assign _zz_227 = 32'h00002050;
-  assign _zz_228 = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_229 = 32'h00000004;
-  assign _zz_230 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_231 = 32'h00000040;
-  assign _zz_232 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
-  assign _zz_233 = {(_zz_238 == _zz_239),(_zz_240 == _zz_241)};
-  assign _zz_234 = 2'b00;
-  assign _zz_235 = ({_zz_242,_zz_243} != 2'b00);
-  assign _zz_236 = (_zz_244 != 1'b0);
-  assign _zz_237 = {(_zz_245 != _zz_246),{_zz_247,{_zz_248,_zz_249}}};
-  assign _zz_238 = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_239 = 32'h40001010;
-  assign _zz_240 = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz_241 = 32'h00001010;
-  assign _zz_242 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_243 = ((decode_INSTRUCTION & 32'h00003054) == 32'h00001010);
-  assign _zz_244 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_245 = ((decode_INSTRUCTION & _zz_250) == 32'h00002000);
-  assign _zz_246 = 1'b0;
-  assign _zz_247 = ({_zz_251,_zz_252} != 2'b00);
-  assign _zz_248 = ({_zz_253,_zz_254} != 2'b00);
-  assign _zz_249 = {(_zz_255 != _zz_256),{_zz_257,{_zz_258,_zz_259}}};
-  assign _zz_250 = 32'h00003000;
-  assign _zz_251 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_252 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_253 = ((decode_INSTRUCTION & _zz_260) == 32'h00000020);
-  assign _zz_254 = ((decode_INSTRUCTION & _zz_261) == 32'h00000020);
-  assign _zz_255 = {(_zz_262 == _zz_263),{_zz_264,_zz_265}};
-  assign _zz_256 = 3'b000;
-  assign _zz_257 = ((_zz_266 == _zz_267) != 1'b0);
-  assign _zz_258 = (_zz_268 != 1'b0);
-  assign _zz_259 = {(_zz_269 != _zz_270),{_zz_271,{_zz_272,_zz_273}}};
-  assign _zz_260 = 32'h00000034;
-  assign _zz_261 = 32'h00000064;
-  assign _zz_262 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_263 = 32'h00000040;
-  assign _zz_264 = ((decode_INSTRUCTION & 32'h00000038) == 32'h0);
-  assign _zz_265 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
-  assign _zz_266 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_267 = 32'h00000020;
-  assign _zz_268 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz_269 = _zz_71;
-  assign _zz_270 = 1'b0;
-  assign _zz_271 = ({_zz_72,{_zz_274,_zz_275}} != 6'h0);
-  assign _zz_272 = ({_zz_276,_zz_277} != 2'b00);
-  assign _zz_273 = {(_zz_278 != _zz_279),{_zz_280,{_zz_281,_zz_282}}};
-  assign _zz_274 = ((decode_INSTRUCTION & _zz_283) == 32'h00001010);
-  assign _zz_275 = {(_zz_284 == _zz_285),{_zz_71,{_zz_286,_zz_287}}};
-  assign _zz_276 = _zz_70;
-  assign _zz_277 = ((decode_INSTRUCTION & _zz_288) == 32'h00000020);
-  assign _zz_278 = {_zz_70,(_zz_289 == _zz_290)};
-  assign _zz_279 = 2'b00;
-  assign _zz_280 = ({_zz_291,_zz_292} != 2'b00);
-  assign _zz_281 = (_zz_293 != 1'b0);
-  assign _zz_282 = {(_zz_294 != _zz_295),{_zz_296,{_zz_297,_zz_298}}};
-  assign _zz_283 = 32'h00001010;
-  assign _zz_284 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_285 = 32'h00002010;
-  assign _zz_286 = (_zz_299 == _zz_300);
-  assign _zz_287 = (_zz_301 == _zz_302);
-  assign _zz_288 = 32'h00000070;
-  assign _zz_289 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_290 = 32'h0;
-  assign _zz_291 = ((decode_INSTRUCTION & _zz_303) == 32'h00006010);
-  assign _zz_292 = ((decode_INSTRUCTION & _zz_304) == 32'h00004010);
-  assign _zz_293 = ((decode_INSTRUCTION & _zz_305) == 32'h00002010);
-  assign _zz_294 = {_zz_306,{_zz_307,_zz_308}};
-  assign _zz_295 = 4'b0000;
-  assign _zz_296 = (_zz_309 != 1'b0);
-  assign _zz_297 = (_zz_310 != _zz_311);
-  assign _zz_298 = {_zz_312,_zz_313};
-  assign _zz_299 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_300 = 32'h00000004;
-  assign _zz_301 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_302 = 32'h0;
-  assign _zz_303 = 32'h00006014;
-  assign _zz_304 = 32'h00005014;
-  assign _zz_305 = 32'h00006014;
-  assign _zz_306 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz_307 = ((decode_INSTRUCTION & _zz_314) == 32'h0);
-  assign _zz_308 = {(_zz_315 == _zz_316),(_zz_317 == _zz_318)};
-  assign _zz_309 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_310 = {(_zz_319 == _zz_320),{_zz_321,_zz_322}};
-  assign _zz_311 = 3'b000;
-  assign _zz_312 = ({_zz_323,_zz_69} != 2'b00);
-  assign _zz_313 = ({_zz_324,_zz_69} != 2'b00);
-  assign _zz_314 = 32'h00000018;
-  assign _zz_315 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_316 = 32'h00002000;
-  assign _zz_317 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_318 = 32'h00001000;
-  assign _zz_319 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_320 = 32'h00000040;
-  assign _zz_321 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_322 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz_323 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_324 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  always @ (posedge clk) begin
-    if(_zz_196) begin
-      _zz_121 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload & (~ _zz_IBusSimplePlugin_jump_pcLoad_payload_2));
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_2 = (_zz_IBusSimplePlugin_jump_pcLoad_payload - 2'b01);
+  assign _zz_IBusSimplePlugin_fetchPc_pc_1 = {IBusSimplePlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusSimplePlugin_fetchPc_pc = {29'd0, _zz_IBusSimplePlugin_fetchPc_pc_1};
+  assign _zz_IBusSimplePlugin_pending_next = (IBusSimplePlugin_pending_value + _zz_IBusSimplePlugin_pending_next_1);
+  assign _zz_IBusSimplePlugin_pending_next_2 = IBusSimplePlugin_pending_inc;
+  assign _zz_IBusSimplePlugin_pending_next_1 = {2'd0, _zz_IBusSimplePlugin_pending_next_2};
+  assign _zz_IBusSimplePlugin_pending_next_4 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_pending_next_3 = {2'd0, _zz_IBusSimplePlugin_pending_next_4};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2 = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3};
+  assign _zz_DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz__zz_decode_ENV_CTRL_2 = 32'h10003050;
+  assign _zz__zz_decode_ENV_CTRL_2_1 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_ENV_CTRL_2_2 = 32'h10000050;
+  assign _zz__zz_decode_ENV_CTRL_2_3 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_4) == 32'h00001050);
+  assign _zz__zz_decode_ENV_CTRL_2_5 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_6) == 32'h00002050);
+  assign _zz__zz_decode_ENV_CTRL_2_7 = {_zz_decode_ENV_CTRL_6,(_zz__zz_decode_ENV_CTRL_2_8 == _zz__zz_decode_ENV_CTRL_2_9)};
+  assign _zz__zz_decode_ENV_CTRL_2_10 = 2'b00;
+  assign _zz__zz_decode_ENV_CTRL_2_11 = ((_zz__zz_decode_ENV_CTRL_2_12 == _zz__zz_decode_ENV_CTRL_2_13) != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_14 = (_zz__zz_decode_ENV_CTRL_2_15 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_16 = {(_zz__zz_decode_ENV_CTRL_2_17 != _zz__zz_decode_ENV_CTRL_2_22),{_zz__zz_decode_ENV_CTRL_2_23,{_zz__zz_decode_ENV_CTRL_2_26,_zz__zz_decode_ENV_CTRL_2_28}}};
+  assign _zz__zz_decode_ENV_CTRL_2_4 = 32'h00001050;
+  assign _zz__zz_decode_ENV_CTRL_2_6 = 32'h00002050;
+  assign _zz__zz_decode_ENV_CTRL_2_8 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_ENV_CTRL_2_9 = 32'h00000004;
+  assign _zz__zz_decode_ENV_CTRL_2_12 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_ENV_CTRL_2_13 = 32'h00000040;
+  assign _zz__zz_decode_ENV_CTRL_2_15 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
+  assign _zz__zz_decode_ENV_CTRL_2_17 = {(_zz__zz_decode_ENV_CTRL_2_18 == _zz__zz_decode_ENV_CTRL_2_19),(_zz__zz_decode_ENV_CTRL_2_20 == _zz__zz_decode_ENV_CTRL_2_21)};
+  assign _zz__zz_decode_ENV_CTRL_2_22 = 2'b00;
+  assign _zz__zz_decode_ENV_CTRL_2_23 = ({_zz__zz_decode_ENV_CTRL_2_24,_zz__zz_decode_ENV_CTRL_2_25} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_26 = (_zz__zz_decode_ENV_CTRL_2_27 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_28 = {(_zz__zz_decode_ENV_CTRL_2_29 != _zz__zz_decode_ENV_CTRL_2_31),{_zz__zz_decode_ENV_CTRL_2_32,{_zz__zz_decode_ENV_CTRL_2_35,_zz__zz_decode_ENV_CTRL_2_40}}};
+  assign _zz__zz_decode_ENV_CTRL_2_18 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_ENV_CTRL_2_19 = 32'h40001010;
+  assign _zz__zz_decode_ENV_CTRL_2_20 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz__zz_decode_ENV_CTRL_2_21 = 32'h00001010;
+  assign _zz__zz_decode_ENV_CTRL_2_24 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_ENV_CTRL_2_25 = ((decode_INSTRUCTION & 32'h00003054) == 32'h00001010);
+  assign _zz__zz_decode_ENV_CTRL_2_27 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_ENV_CTRL_2_29 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_30) == 32'h00002000);
+  assign _zz__zz_decode_ENV_CTRL_2_31 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_32 = ({_zz__zz_decode_ENV_CTRL_2_33,_zz__zz_decode_ENV_CTRL_2_34} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_35 = ({_zz__zz_decode_ENV_CTRL_2_36,_zz__zz_decode_ENV_CTRL_2_38} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_40 = {(_zz__zz_decode_ENV_CTRL_2_41 != _zz__zz_decode_ENV_CTRL_2_46),{_zz__zz_decode_ENV_CTRL_2_47,{_zz__zz_decode_ENV_CTRL_2_50,_zz__zz_decode_ENV_CTRL_2_52}}};
+  assign _zz__zz_decode_ENV_CTRL_2_30 = 32'h00003000;
+  assign _zz__zz_decode_ENV_CTRL_2_33 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_ENV_CTRL_2_34 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_ENV_CTRL_2_36 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_37) == 32'h00000020);
+  assign _zz__zz_decode_ENV_CTRL_2_38 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_39) == 32'h00000020);
+  assign _zz__zz_decode_ENV_CTRL_2_41 = {(_zz__zz_decode_ENV_CTRL_2_42 == _zz__zz_decode_ENV_CTRL_2_43),{_zz__zz_decode_ENV_CTRL_2_44,_zz__zz_decode_ENV_CTRL_2_45}};
+  assign _zz__zz_decode_ENV_CTRL_2_46 = 3'b000;
+  assign _zz__zz_decode_ENV_CTRL_2_47 = ((_zz__zz_decode_ENV_CTRL_2_48 == _zz__zz_decode_ENV_CTRL_2_49) != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_50 = (_zz__zz_decode_ENV_CTRL_2_51 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_52 = {(_zz__zz_decode_ENV_CTRL_2_53 != _zz__zz_decode_ENV_CTRL_2_54),{_zz__zz_decode_ENV_CTRL_2_55,{_zz__zz_decode_ENV_CTRL_2_67,_zz__zz_decode_ENV_CTRL_2_71}}};
+  assign _zz__zz_decode_ENV_CTRL_2_37 = 32'h00000034;
+  assign _zz__zz_decode_ENV_CTRL_2_39 = 32'h00000064;
+  assign _zz__zz_decode_ENV_CTRL_2_42 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_ENV_CTRL_2_43 = 32'h00000040;
+  assign _zz__zz_decode_ENV_CTRL_2_44 = ((decode_INSTRUCTION & 32'h00000038) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_45 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
+  assign _zz__zz_decode_ENV_CTRL_2_48 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_ENV_CTRL_2_49 = 32'h00000020;
+  assign _zz__zz_decode_ENV_CTRL_2_51 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
+  assign _zz__zz_decode_ENV_CTRL_2_53 = _zz_decode_ENV_CTRL_5;
+  assign _zz__zz_decode_ENV_CTRL_2_54 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_55 = ({_zz_decode_ENV_CTRL_6,{_zz__zz_decode_ENV_CTRL_2_56,_zz__zz_decode_ENV_CTRL_2_58}} != 6'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_67 = ({_zz__zz_decode_ENV_CTRL_2_68,_zz__zz_decode_ENV_CTRL_2_69} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_71 = {(_zz__zz_decode_ENV_CTRL_2_72 != _zz__zz_decode_ENV_CTRL_2_75),{_zz__zz_decode_ENV_CTRL_2_76,{_zz__zz_decode_ENV_CTRL_2_81,_zz__zz_decode_ENV_CTRL_2_84}}};
+  assign _zz__zz_decode_ENV_CTRL_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_57) == 32'h00001010);
+  assign _zz__zz_decode_ENV_CTRL_2_58 = {(_zz__zz_decode_ENV_CTRL_2_59 == _zz__zz_decode_ENV_CTRL_2_60),{_zz_decode_ENV_CTRL_5,{_zz__zz_decode_ENV_CTRL_2_61,_zz__zz_decode_ENV_CTRL_2_64}}};
+  assign _zz__zz_decode_ENV_CTRL_2_68 = _zz_decode_ENV_CTRL_4;
+  assign _zz__zz_decode_ENV_CTRL_2_69 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_70) == 32'h00000020);
+  assign _zz__zz_decode_ENV_CTRL_2_72 = {_zz_decode_ENV_CTRL_4,(_zz__zz_decode_ENV_CTRL_2_73 == _zz__zz_decode_ENV_CTRL_2_74)};
+  assign _zz__zz_decode_ENV_CTRL_2_75 = 2'b00;
+  assign _zz__zz_decode_ENV_CTRL_2_76 = ({_zz__zz_decode_ENV_CTRL_2_77,_zz__zz_decode_ENV_CTRL_2_79} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_81 = (_zz__zz_decode_ENV_CTRL_2_82 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_84 = {(_zz__zz_decode_ENV_CTRL_2_85 != _zz__zz_decode_ENV_CTRL_2_94),{_zz__zz_decode_ENV_CTRL_2_95,{_zz__zz_decode_ENV_CTRL_2_97,_zz__zz_decode_ENV_CTRL_2_104}}};
+  assign _zz__zz_decode_ENV_CTRL_2_57 = 32'h00001010;
+  assign _zz__zz_decode_ENV_CTRL_2_59 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_ENV_CTRL_2_60 = 32'h00002010;
+  assign _zz__zz_decode_ENV_CTRL_2_61 = (_zz__zz_decode_ENV_CTRL_2_62 == _zz__zz_decode_ENV_CTRL_2_63);
+  assign _zz__zz_decode_ENV_CTRL_2_64 = (_zz__zz_decode_ENV_CTRL_2_65 == _zz__zz_decode_ENV_CTRL_2_66);
+  assign _zz__zz_decode_ENV_CTRL_2_70 = 32'h00000070;
+  assign _zz__zz_decode_ENV_CTRL_2_73 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_ENV_CTRL_2_74 = 32'h0;
+  assign _zz__zz_decode_ENV_CTRL_2_77 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_78) == 32'h00006010);
+  assign _zz__zz_decode_ENV_CTRL_2_79 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_80) == 32'h00004010);
+  assign _zz__zz_decode_ENV_CTRL_2_82 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_83) == 32'h00002010);
+  assign _zz__zz_decode_ENV_CTRL_2_85 = {_zz__zz_decode_ENV_CTRL_2_86,{_zz__zz_decode_ENV_CTRL_2_87,_zz__zz_decode_ENV_CTRL_2_89}};
+  assign _zz__zz_decode_ENV_CTRL_2_94 = 4'b0000;
+  assign _zz__zz_decode_ENV_CTRL_2_95 = (_zz__zz_decode_ENV_CTRL_2_96 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_97 = (_zz__zz_decode_ENV_CTRL_2_98 != _zz__zz_decode_ENV_CTRL_2_103);
+  assign _zz__zz_decode_ENV_CTRL_2_104 = {_zz__zz_decode_ENV_CTRL_2_105,_zz__zz_decode_ENV_CTRL_2_107};
+  assign _zz__zz_decode_ENV_CTRL_2_62 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_ENV_CTRL_2_63 = 32'h00000004;
+  assign _zz__zz_decode_ENV_CTRL_2_65 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_ENV_CTRL_2_66 = 32'h0;
+  assign _zz__zz_decode_ENV_CTRL_2_78 = 32'h00006014;
+  assign _zz__zz_decode_ENV_CTRL_2_80 = 32'h00005014;
+  assign _zz__zz_decode_ENV_CTRL_2_83 = 32'h00006014;
+  assign _zz__zz_decode_ENV_CTRL_2_86 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_87 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_88) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_89 = {(_zz__zz_decode_ENV_CTRL_2_90 == _zz__zz_decode_ENV_CTRL_2_91),(_zz__zz_decode_ENV_CTRL_2_92 == _zz__zz_decode_ENV_CTRL_2_93)};
+  assign _zz__zz_decode_ENV_CTRL_2_96 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_98 = {(_zz__zz_decode_ENV_CTRL_2_99 == _zz__zz_decode_ENV_CTRL_2_100),{_zz__zz_decode_ENV_CTRL_2_101,_zz__zz_decode_ENV_CTRL_2_102}};
+  assign _zz__zz_decode_ENV_CTRL_2_103 = 3'b000;
+  assign _zz__zz_decode_ENV_CTRL_2_105 = ({_zz__zz_decode_ENV_CTRL_2_106,_zz_decode_ENV_CTRL_3} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_107 = ({_zz__zz_decode_ENV_CTRL_2_108,_zz_decode_ENV_CTRL_3} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_88 = 32'h00000018;
+  assign _zz__zz_decode_ENV_CTRL_2_90 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_ENV_CTRL_2_91 = 32'h00002000;
+  assign _zz__zz_decode_ENV_CTRL_2_92 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_ENV_CTRL_2_93 = 32'h00001000;
+  assign _zz__zz_decode_ENV_CTRL_2_99 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_ENV_CTRL_2_100 = 32'h00000040;
+  assign _zz__zz_decode_ENV_CTRL_2_101 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_ENV_CTRL_2_102 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_ENV_CTRL_2_106 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_ENV_CTRL_2_108 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_197) begin
-      _zz_122 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_39) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
-    .io_push_valid            (iBus_rsp_valid                                                  ), //i
-    .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready              ), //o
-    .io_push_payload_error    (iBus_rsp_payload_error                                          ), //i
-    .io_push_payload_inst     (iBus_rsp_payload_inst[31:0]                                     ), //i
-    .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid               ), //o
-    .io_pop_ready             (_zz_119                                                         ), //i
-    .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error       ), //o
-    .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]  ), //o
-    .io_flush                 (_zz_120                                                         ), //i
-    .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy               ), //o
-    .clk                      (clk                                                             ), //i
-    .reset                    (reset                                                           )  //i
+    .io_push_valid            (iBus_rsp_valid                                             ), //i
+    .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready         ), //o
+    .io_push_payload_error    (iBus_rsp_payload_error                                     ), //i
+    .io_push_payload_inst     (iBus_rsp_payload_inst                                      ), //i
+    .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid          ), //o
+    .io_pop_ready             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready          ), //i
+    .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error  ), //o
+    .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst   ), //o
+    .io_flush                 (1'b0                                                       ), //i
+    .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy          ), //o
+    .clk                      (clk                                                        ), //i
+    .reset                    (reset                                                      )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1169,27 +1226,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1202,98 +1259,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
-      default : _zz_10_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
-      default : _zz_14_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1306,30 +1363,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
-      default : _zz_17_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1341,27 +1398,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
-      default : _zz_20_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1374,30 +1431,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
-      default : _zz_23_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1409,11 +1466,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
-      default : _zz_26_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1425,11 +1482,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1441,11 +1498,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1458,30 +1515,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_29_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_29_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_29_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_29_string = "JALR";
-      default : _zz_29_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_31)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
-      default : _zz_31_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -1494,12 +1551,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
-      default : _zz_33_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1512,12 +1569,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
-      default : _zz_34_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1529,147 +1586,147 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
-      default : _zz_35_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
-      default : _zz_36_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
-      default : _zz_40_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
-      default : _zz_41_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
-      default : _zz_42_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
-      default : _zz_44_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
-      default : _zz_45_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
-      default : _zz_46_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_73)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_73_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_73_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_73_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_73_string = "URS1        ";
-      default : _zz_73_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_74)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_74_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_74_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_74_string = "BITWISE ";
-      default : _zz_74_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_75)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_75_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_75_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_75_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_75_string = "PC ";
-      default : _zz_75_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_76)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_76_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_76_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_76_string = "AND_1";
-      default : _zz_76_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_77)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_77_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_77_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_77_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_77_string = "SRA_1    ";
-      default : _zz_77_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_78)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_78_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_78_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_78_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_78_string = "JALR";
-      default : _zz_78_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_79)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_79_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_79_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_79_string = "ECALL";
-      default : _zz_79_string = "?????";
+    case(_zz_decode_ENV_CTRL_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_7_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_7_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1700,19 +1757,19 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -1752,9 +1809,9 @@ module VexRiscv (
 
   assign memory_MEMORY_READ_DATA = dBus_rsp_data;
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_95;
+  assign execute_BRANCH_DO = _zz_execute_BRANCH_DO_1;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_81;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
@@ -1762,29 +1819,29 @@ module VexRiscv (
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_146[0];
-  assign decode_BRANCH_CTRL = _zz_8;
-  assign _zz_9 = _zz_10;
-  assign decode_SHIFT_CTRL = _zz_11;
-  assign _zz_12 = _zz_13;
-  assign decode_ALU_BITWISE_CTRL = _zz_14;
-  assign _zz_15 = _zz_16;
-  assign decode_SRC_LESS_UNSIGNED = _zz_147[0];
-  assign decode_MEMORY_STORE = _zz_148[0];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_ENV_CTRL_2[23];
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_ENV_CTRL_2[15];
+  assign decode_MEMORY_STORE = _zz_decode_ENV_CTRL_2[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_149[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_150[0];
-  assign decode_SRC2_CTRL = _zz_17;
-  assign _zz_18 = _zz_19;
-  assign decode_ALU_CTRL = _zz_20;
-  assign _zz_21 = _zz_22;
-  assign decode_MEMORY_ENABLE = _zz_151[0];
-  assign decode_SRC1_CTRL = _zz_23;
-  assign _zz_24 = _zz_25;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_ENV_CTRL_2[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_ENV_CTRL_2[10];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_MEMORY_ENABLE = _zz_decode_ENV_CTRL_2[3];
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
@@ -1793,70 +1850,70 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_26;
-  assign execute_ENV_CTRL = _zz_27;
-  assign writeBack_ENV_CTRL = _zz_28;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_29;
-  assign decode_RS2_USE = _zz_152[0];
-  assign decode_RS1_USE = _zz_153[0];
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_ENV_CTRL_2[14];
+  assign decode_RS1_USE = _zz_decode_ENV_CTRL_2[4];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_30 = execute_REGFILE_WRITE_DATA;
-    if(_zz_123)begin
-      _zz_30 = _zz_88;
+  always @(*) begin
+    _zz_execute_to_memory_REGFILE_WRITE_DATA = execute_REGFILE_WRITE_DATA;
+    if(when_ShiftPlugins_l169) begin
+      _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(_zz_124)begin
-      _zz_30 = execute_CsrPlugin_readData;
+    if(when_CsrPlugin_l1176) begin
+      _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33;
-  assign execute_SRC1_CTRL = _zz_34;
-  assign decode_SRC_USE_SUB_LESS = _zz_154[0];
-  assign decode_SRC_ADD_ZERO = _zz_155[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_ENV_CTRL_2[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_ENV_CTRL_2[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35;
-  assign execute_SRC2 = _zz_87;
-  assign execute_SRC1 = _zz_82;
-  assign execute_ALU_BITWISE_CTRL = _zz_36;
-  assign _zz_37 = writeBack_INSTRUCTION;
-  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_39 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_39 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_156[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_ENV_CTRL_2[9];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_198) == 32'h00001073),{(_zz_199 == _zz_200),{_zz_201,{_zz_202,_zz_203}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
-  always @ (*) begin
-    _zz_47 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
+  always @(*) begin
+    _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusSimplePlugin_l558) begin
+      _zz_lastStageRegFileWrite_payload_data = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
@@ -1873,10 +1930,10 @@ module VexRiscv (
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
-  always @ (*) begin
-    _zz_48 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_48 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
@@ -1885,118 +1942,118 @@ module VexRiscv (
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   assign decode_arbitration_haltItself = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_89 || _zz_90)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61)))begin
+    if(when_DBusSimplePlugin_l426) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_123)begin
-      if((! execute_LightShifterPlugin_done))begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l184) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_124)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign execute_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
+    if(when_DBusSimplePlugin_l479) begin
       memory_arbitration_haltItself = 1'b1;
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_125)begin
+    if(_zz_when) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_125)begin
+    if(_zz_when) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltItself = 1'b0;
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
   assign writeBack_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_126)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_127)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2005,48 +2062,50 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_126)begin
+    if(when_CsrPlugin_l1019) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_127)begin
+    if(when_CsrPlugin_l1064) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_incomingInstruction = 1'b0;
-    if(IBusSimplePlugin_iBusRsp_stages_1_input_valid)begin
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_valid) begin
       IBusSimplePlugin_incomingInstruction = 1'b1;
     end
-    if(IBusSimplePlugin_injector_decodeInput_valid)begin
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_126)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_127)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_126)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_127)begin
-      case(_zz_128)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2059,85 +2118,97 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
-  assign _zz_49 = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
-  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_157[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
-  always @ (*) begin
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
+  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_IBusSimplePlugin_jump_pcLoad_payload_1[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
+  always @(*) begin
     IBusSimplePlugin_fetchPc_correction = 1'b0;
-    if(IBusSimplePlugin_jump_pcLoad_valid)begin
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
       IBusSimplePlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
   assign IBusSimplePlugin_fetchPc_corrected = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusSimplePlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_ready) begin
       IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_160);
-    if(IBusSimplePlugin_jump_pcLoad_valid)begin
+  assign when_Fetcher_l131 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
       IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_jump_pcLoad_payload;
     end
     IBusSimplePlugin_fetchPc_pc[0] = 1'b0;
     IBusSimplePlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_fetchPc_flushed = 1'b0;
-    if(IBusSimplePlugin_jump_pcLoad_valid)begin
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
       IBusSimplePlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_valid = IBusSimplePlugin_fetchPc_output_valid;
   assign IBusSimplePlugin_fetchPc_output_ready = IBusSimplePlugin_iBusRsp_stages_0_input_ready;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
-    if((IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready))))begin
+    if(when_IBusSimplePlugin_l304) begin
       IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_50 = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_50);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_50);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_payload = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
   assign IBusSimplePlugin_iBusRsp_stages_1_halt = 1'b0;
-  assign _zz_51 = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_51);
-  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_51);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_52;
-  assign _zz_52 = ((1'b0 && (! _zz_53)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_53 = _zz_54;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_53;
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
-    if(IBusSimplePlugin_injector_decodeInput_valid)begin
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
-    if((! IBusSimplePlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
   assign IBusSimplePlugin_iBusRsp_output_ready = ((1'b0 && (! IBusSimplePlugin_injector_decodeInput_valid)) || IBusSimplePlugin_injector_decodeInput_ready);
-  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_55;
-  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_56;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_57;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_58;
-  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_59;
+  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  assign when_Fetcher_l320 = (! IBusSimplePlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
@@ -2147,8 +2218,9 @@ module VexRiscv (
   assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
   assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
   assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
-  assign IBusSimplePlugin_pending_next = (_zz_161 - _zz_165);
+  assign IBusSimplePlugin_pending_next = (_zz_IBusSimplePlugin_pending_next - _zz_IBusSimplePlugin_pending_next_3);
   assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
+  assign when_IBusSimplePlugin_l304 = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready)));
   assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
   assign IBusSimplePlugin_pending_inc = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
   assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
@@ -2156,17 +2228,18 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
-  assign _zz_119 = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && _zz_119);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
+  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
-    if((! IBusSimplePlugin_rspJoin_rspBuffer_output_valid))begin
+    if(when_IBusSimplePlugin_l375) begin
       IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = 1'b0;
     end
   end
 
   assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
+  assign when_IBusSimplePlugin_l375 = (! IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
   assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
@@ -2175,80 +2248,84 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready) : IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign _zz_60 = (! IBusSimplePlugin_rspJoin_exceptionDetected);
-  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_60);
-  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_60);
+  assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
+  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
+  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
   assign IBusSimplePlugin_iBusRsp_output_payload_pc = IBusSimplePlugin_rspJoin_join_payload_pc;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_error = IBusSimplePlugin_rspJoin_join_payload_rsp_error;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_inst = IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   assign IBusSimplePlugin_iBusRsp_output_payload_isRvc = IBusSimplePlugin_rspJoin_join_payload_isRvc;
-  assign _zz_61 = 1'b0;
-  always @ (*) begin
+  assign _zz_dBus_cmd_valid = 1'b0;
+  always @(*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
-    if(execute_ALIGNEMENT_FAULT)begin
+    if(execute_ALIGNEMENT_FAULT) begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_62 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_dBus_cmd_payload_data = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_62 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_dBus_cmd_payload_data = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_62 = execute_RS2[31 : 0];
+        _zz_dBus_cmd_payload_data = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_62;
-  always @ (*) begin
+  assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
+  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_63 = 4'b0001;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0001;
       end
       2'b01 : begin
-        _zz_63 = 4'b0011;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0011;
       end
       default : begin
-        _zz_63 = 4'b1111;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_63 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_129)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
+    if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
+    if(when_DBusSimplePlugin_l512) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_129)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_170};
+    if(memory_ALIGNEMENT_FAULT) begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_DBusSimplePlugin_memoryExceptionPort_payload_code};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l486 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l512 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
@@ -2265,63 +2342,64 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_64 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_65[31] = _zz_64;
-    _zz_65[30] = _zz_64;
-    _zz_65[29] = _zz_64;
-    _zz_65[28] = _zz_64;
-    _zz_65[27] = _zz_64;
-    _zz_65[26] = _zz_64;
-    _zz_65[25] = _zz_64;
-    _zz_65[24] = _zz_64;
-    _zz_65[23] = _zz_64;
-    _zz_65[22] = _zz_64;
-    _zz_65[21] = _zz_64;
-    _zz_65[20] = _zz_64;
-    _zz_65[19] = _zz_64;
-    _zz_65[18] = _zz_64;
-    _zz_65[17] = _zz_64;
-    _zz_65[16] = _zz_64;
-    _zz_65[15] = _zz_64;
-    _zz_65[14] = _zz_64;
-    _zz_65[13] = _zz_64;
-    _zz_65[12] = _zz_64;
-    _zz_65[11] = _zz_64;
-    _zz_65[10] = _zz_64;
-    _zz_65[9] = _zz_64;
-    _zz_65[8] = _zz_64;
-    _zz_65[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[30] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[29] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[28] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[27] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[26] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[25] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[24] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[23] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[22] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[21] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[20] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[19] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[18] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[17] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[16] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[15] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[14] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[13] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[12] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[11] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[10] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[9] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[8] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_66 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_67[31] = _zz_66;
-    _zz_67[30] = _zz_66;
-    _zz_67[29] = _zz_66;
-    _zz_67[28] = _zz_66;
-    _zz_67[27] = _zz_66;
-    _zz_67[26] = _zz_66;
-    _zz_67[25] = _zz_66;
-    _zz_67[24] = _zz_66;
-    _zz_67[23] = _zz_66;
-    _zz_67[22] = _zz_66;
-    _zz_67[21] = _zz_66;
-    _zz_67[20] = _zz_66;
-    _zz_67[19] = _zz_66;
-    _zz_67[18] = _zz_66;
-    _zz_67[17] = _zz_66;
-    _zz_67[16] = _zz_66;
-    _zz_67[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated_2 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[31] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[30] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[29] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[28] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[27] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[26] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[25] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[24] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[23] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[22] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[21] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[20] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[19] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[18] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[17] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[16] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_144)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_65;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_67;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_3;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2329,59 +2407,61 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_69 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_70 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_71 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_72 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_68 = {(((decode_INSTRUCTION & _zz_216) == 32'h00000050) != 1'b0),{((_zz_217 == _zz_218) != 1'b0),{({_zz_219,_zz_220} != 2'b00),{(_zz_221 != _zz_222),{_zz_223,{_zz_224,_zz_225}}}}}};
-  assign _zz_73 = _zz_68[1 : 0];
-  assign _zz_46 = _zz_73;
-  assign _zz_74 = _zz_68[6 : 5];
-  assign _zz_45 = _zz_74;
-  assign _zz_75 = _zz_68[8 : 7];
-  assign _zz_44 = _zz_75;
-  assign _zz_76 = _zz_68[17 : 16];
-  assign _zz_43 = _zz_76;
-  assign _zz_77 = _zz_68[20 : 19];
-  assign _zz_42 = _zz_77;
-  assign _zz_78 = _zz_68[22 : 21];
-  assign _zz_41 = _zz_78;
-  assign _zz_79 = _zz_68[25 : 24];
-  assign _zz_40 = _zz_79;
+  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_decode_ENV_CTRL_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_ENV_CTRL_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_ENV_CTRL_5 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_decode_ENV_CTRL_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_ENV_CTRL_2 = {(((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2) == 32'h00000050) != 1'b0),{((_zz__zz_decode_ENV_CTRL_2_1 == _zz__zz_decode_ENV_CTRL_2_2) != 1'b0),{({_zz__zz_decode_ENV_CTRL_2_3,_zz__zz_decode_ENV_CTRL_2_5} != 2'b00),{(_zz__zz_decode_ENV_CTRL_2_7 != _zz__zz_decode_ENV_CTRL_2_10),{_zz__zz_decode_ENV_CTRL_2_11,{_zz__zz_decode_ENV_CTRL_2_14,_zz__zz_decode_ENV_CTRL_2_16}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_ENV_CTRL_2[1 : 0];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_ENV_CTRL_2[6 : 5];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_ENV_CTRL_2[8 : 7];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_ENV_CTRL_2[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_ENV_CTRL_2[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_ENV_CTRL_2[22 : 21];
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_7 = _zz_decode_ENV_CTRL_2[25 : 24];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_7;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_121;
-  assign decode_RegFilePlugin_rs2Data = _zz_122;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
-    if(_zz_80)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_2) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
-    if(_zz_80)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_47;
-    if(_zz_80)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_lastStageRegFileWrite_payload_data;
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -2390,392 +2470,434 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_81 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_81 = {31'd0, _zz_171};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_81 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_82 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_82 = {29'd0, _zz_172};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_82 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_82 = {27'd0, _zz_173};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_83 = _zz_174[11];
-  always @ (*) begin
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7] = _zz_83;
-    _zz_84[6] = _zz_83;
-    _zz_84[5] = _zz_83;
-    _zz_84[4] = _zz_83;
-    _zz_84[3] = _zz_83;
-    _zz_84[2] = _zz_83;
-    _zz_84[1] = _zz_83;
-    _zz_84[0] = _zz_83;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_85 = _zz_175[11];
-  always @ (*) begin
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15] = _zz_85;
-    _zz_86[14] = _zz_85;
-    _zz_86[13] = _zz_85;
-    _zz_86[12] = _zz_85;
-    _zz_86[11] = _zz_85;
-    _zz_86[10] = _zz_85;
-    _zz_86[9] = _zz_85;
-    _zz_86[8] = _zz_85;
-    _zz_86[7] = _zz_85;
-    _zz_86[6] = _zz_85;
-    _zz_86[5] = _zz_85;
-    _zz_86[4] = _zz_85;
-    _zz_86[3] = _zz_85;
-    _zz_86[2] = _zz_85;
-    _zz_86[1] = _zz_85;
-    _zz_86[0] = _zz_85;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_87 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_87 = {_zz_84,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_87 = {_zz_86,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_87 = _zz_32;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_176;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  always @ (*) begin
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_88 = (execute_LightShifterPlugin_shiftInput <<< 1);
+      `ShiftCtrlEnum_defaultEncoding_SLL : begin
+        _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_88 = _zz_183;
+        _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_89 = 1'b0;
-    if(_zz_91)begin
-      if((_zz_92 == decode_INSTRUCTION[19 : 15]))begin
-        _zz_89 = 1'b1;
+  assign when_ShiftPlugins_l175 = (! execute_arbitration_isStuckByOthers);
+  assign when_ShiftPlugins_l184 = (! execute_LightShifterPlugin_done);
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        HazardSimplePlugin_src0Hazard = 1'b1;
       end
     end
-    if(_zz_130)begin
-      if(_zz_131)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l59) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_132)begin
-      if(_zz_133)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l59_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_134)begin
-      if(_zz_135)begin
-        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l59_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_89 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_90 = 1'b0;
-    if(_zz_91)begin
-      if((_zz_92 == decode_INSTRUCTION[24 : 20]))begin
-        _zz_90 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        HazardSimplePlugin_src1Hazard = 1'b1;
       end
     end
-    if(_zz_130)begin
-      if(_zz_131)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l62) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_132)begin
-      if(_zz_133)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l62_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_134)begin
-      if(_zz_135)begin
-        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l62_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS2_USE))begin
-      _zz_90 = 1'b0;
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
     end
   end
 
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_lastStageRegFileWrite_payload_data;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l59 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b1 || (! 1'b1));
+  assign when_HazardSimplePlugin_l59_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l59_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_93 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_93 == 3'b000)) begin
-        _zz_94 = execute_BranchPlugin_eq;
-    end else if((_zz_93 == 3'b001)) begin
-        _zz_94 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_93 & 3'b101) == 3'b101))) begin
-        _zz_94 = (! execute_SRC_LESS);
-    end else begin
-        _zz_94 = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_95 = 1'b0;
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_95 = 1'b1;
+      3'b001 : begin
+        _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_95 = 1'b1;
+      3'b1?1 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
-        _zz_95 = _zz_94;
+        _zz_execute_BRANCH_DO = execute_SRC_LESS;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : begin
+        _zz_execute_BRANCH_DO_1 = 1'b0;
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      default : begin
+        _zz_execute_BRANCH_DO_1 = _zz_execute_BRANCH_DO;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_96 = _zz_185[19];
-  always @ (*) begin
-    _zz_97[10] = _zz_96;
-    _zz_97[9] = _zz_96;
-    _zz_97[8] = _zz_96;
-    _zz_97[7] = _zz_96;
-    _zz_97[6] = _zz_96;
-    _zz_97[5] = _zz_96;
-    _zz_97[4] = _zz_96;
-    _zz_97[3] = _zz_96;
-    _zz_97[2] = _zz_96;
-    _zz_97[1] = _zz_96;
-    _zz_97[0] = _zz_96;
+  assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  assign _zz_98 = _zz_186[11];
-  always @ (*) begin
-    _zz_99[19] = _zz_98;
-    _zz_99[18] = _zz_98;
-    _zz_99[17] = _zz_98;
-    _zz_99[16] = _zz_98;
-    _zz_99[15] = _zz_98;
-    _zz_99[14] = _zz_98;
-    _zz_99[13] = _zz_98;
-    _zz_99[12] = _zz_98;
-    _zz_99[11] = _zz_98;
-    _zz_99[10] = _zz_98;
-    _zz_99[9] = _zz_98;
-    _zz_99[8] = _zz_98;
-    _zz_99[7] = _zz_98;
-    _zz_99[6] = _zz_98;
-    _zz_99[5] = _zz_98;
-    _zz_99[4] = _zz_98;
-    _zz_99[3] = _zz_98;
-    _zz_99[2] = _zz_98;
-    _zz_99[1] = _zz_98;
-    _zz_99[0] = _zz_98;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[19] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[18] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[17] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[16] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[15] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[14] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[13] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[12] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[11] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_100 = _zz_187[11];
-  always @ (*) begin
-    _zz_101[18] = _zz_100;
-    _zz_101[17] = _zz_100;
-    _zz_101[16] = _zz_100;
-    _zz_101[15] = _zz_100;
-    _zz_101[14] = _zz_100;
-    _zz_101[13] = _zz_100;
-    _zz_101[12] = _zz_100;
-    _zz_101[11] = _zz_100;
-    _zz_101[10] = _zz_100;
-    _zz_101[9] = _zz_100;
-    _zz_101[8] = _zz_100;
-    _zz_101[7] = _zz_100;
-    _zz_101[6] = _zz_100;
-    _zz_101[5] = _zz_100;
-    _zz_101[4] = _zz_100;
-    _zz_101[3] = _zz_100;
-    _zz_101[2] = _zz_100;
-    _zz_101[1] = _zz_100;
-    _zz_101[0] = _zz_100;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_102 = {{_zz_97,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_102 = {_zz_99,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_102 = {{_zz_101,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_102;
+  assign execute_BranchPlugin_branch_src2 = _zz_execute_BranchPlugin_branch_src2_6;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_103 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_104 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_105 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_106 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_107 = _zz_188[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_125)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -2786,8 +2908,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -2797,72 +2919,79 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_136)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_137)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_137)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -2875,62 +3004,116 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_136)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_136)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_145)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_109 = (_zz_108 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_109 != 32'h0);
-  assign _zz_25 = decode_SRC1_CTRL;
-  assign _zz_23 = _zz_46;
-  assign _zz_34 = decode_to_execute_SRC1_CTRL;
-  assign _zz_22 = decode_ALU_CTRL;
-  assign _zz_20 = _zz_45;
-  assign _zz_35 = decode_to_execute_ALU_CTRL;
-  assign _zz_19 = decode_SRC2_CTRL;
-  assign _zz_17 = _zz_44;
-  assign _zz_33 = decode_to_execute_SRC2_CTRL;
-  assign _zz_16 = decode_ALU_BITWISE_CTRL;
-  assign _zz_14 = _zz_43;
-  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_13 = decode_SHIFT_CTRL;
-  assign _zz_11 = _zz_42;
-  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_10 = decode_BRANCH_CTRL;
-  assign _zz_8 = _zz_41;
-  assign _zz_29 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_40;
-  assign _zz_27 = decode_to_execute_ENV_CTRL;
-  assign _zz_26 = execute_to_memory_ENV_CTRL;
-  assign _zz_28 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_14 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_17 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -2951,85 +3134,103 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_110 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_110[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_110[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_110[3 : 3] = CsrPlugin_mstatus_MIE;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_111 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_111[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_111[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_111[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_112 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_112[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_112[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_112[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_113 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_113[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_114 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_114[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_114[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_115 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_115[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_116 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_116[31 : 0] = _zz_108;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_117 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_117[31 : 0] = _zz_109;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_110 | _zz_111) | (_zz_112 | _zz_113)) | ((_zz_114 | _zz_115) | (_zz_116 | _zz_117)));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBus_cmd_ready = ((1'b1 && (! iBus_cmd_m2sPipe_valid)) || iBus_cmd_m2sPipe_ready);
-  assign iBus_cmd_m2sPipe_valid = iBus_cmd_m2sPipe_rValid;
-  assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_m2sPipe_rData_pc;
+  assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
+  assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
   assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
   assign iBusWishbone_CTI = 3'b000;
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
   assign iBusWishbone_CYC = iBus_cmd_m2sPipe_valid;
   assign iBusWishbone_STB = iBus_cmd_m2sPipe_valid;
   assign iBus_cmd_m2sPipe_ready = (iBus_cmd_m2sPipe_valid && iBusWishbone_ACK);
   assign iBus_rsp_valid = (iBusWishbone_CYC && iBusWishbone_ACK);
   assign iBus_rsp_payload_inst = iBusWishbone_DAT_MISO;
   assign iBus_rsp_payload_error = 1'b0;
+  assign when_Stream_l399 = (! dBus_cmd_halfPipe_regs_valid);
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
   assign dBus_cmd_halfPipe_payload_wr = dBus_cmd_halfPipe_regs_payload_wr;
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_halfPipe_regs_payload_address;
@@ -3039,27 +3240,28 @@ module VexRiscv (
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_118 = 4'b0001;
+        _zz_dBusWishbone_SEL = 4'b0001;
       end
       2'b01 : begin
-        _zz_118 = 4'b0011;
+        _zz_dBusWishbone_SEL = 4'b0011;
       end
       default : begin
-        _zz_118 = 4'b1111;
+        _zz_dBusWishbone_SEL = 4'b1111;
       end
     endcase
   end
 
-  always @ (*) begin
-    dBusWishbone_SEL = (_zz_118 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if((! dBus_cmd_halfPipe_payload_wr))begin
+  always @(*) begin
+    dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    if(when_DBusSimplePlugin_l189) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
+  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -3068,15 +3270,14 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
-  assign _zz_120 = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_54 <= 1'b0;
-      _zz_55 <= 1'b0;
+      _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
@@ -3084,9 +3285,9 @@ module VexRiscv (
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusSimplePlugin_pending_value <= 3'b000;
       IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
-      _zz_80 <= 1'b1;
+      _zz_2 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_91 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -3103,91 +3304,91 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_108 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      iBus_cmd_m2sPipe_rValid <= 1'b0;
+      iBus_cmd_rValid <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
-      if(IBusSimplePlugin_fetchPc_correction)begin
+      if(IBusSimplePlugin_fetchPc_correction) begin
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusSimplePlugin_fetchPc_booted <= 1'b1;
-      if((IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
-      if(IBusSimplePlugin_iBusRsp_flush)begin
-        _zz_54 <= 1'b0;
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_52)begin
-        _zz_54 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(decode_arbitration_removeIt)begin
-        _zz_55 <= 1'b0;
+      if(decode_arbitration_removeIt) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       end
-      if(IBusSimplePlugin_iBusRsp_output_ready)begin
-        _zz_55 <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
+      if(IBusSimplePlugin_iBusRsp_output_ready) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusSimplePlugin_injector_decodeInput_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= IBusSimplePlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
       IBusSimplePlugin_pending_value <= IBusSimplePlugin_pending_next;
-      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_167);
-      if(IBusSimplePlugin_iBusRsp_flush)begin
-        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_169);
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter);
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
@@ -3209,72 +3410,72 @@ module VexRiscv (
           end
         `endif
       `endif
-      _zz_80 <= 1'b0;
-      if(_zz_123)begin
-        if(_zz_138)begin
+      _zz_2 <= 1'b0;
+      if(when_ShiftPlugins_l169) begin
+        if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
-          if(execute_LightShifterPlugin_done)begin
+          if(execute_LightShifterPlugin_done) begin
             execute_LightShifterPlugin_isActive <= 1'b0;
           end
         end
       end
-      if(execute_arbitration_removeIt)begin
+      if(execute_arbitration_removeIt) begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_91 <= (_zz_38 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_139)begin
-        if(_zz_140)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_141)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_142)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_126)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3285,8 +3486,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_127)begin
-        case(_zz_128)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3296,48 +3497,48 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_105,{_zz_104,_zz_103}} != 3'b000) || CsrPlugin_thirdPartyWake);
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_190[0];
-          CsrPlugin_mstatus_MIE <= _zz_191[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_193[0];
-          CsrPlugin_mie_MTIE <= _zz_194[0];
-          CsrPlugin_mie_MSIE <= _zz_195[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_108 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(iBus_cmd_ready)begin
-        iBus_cmd_m2sPipe_rValid <= iBus_cmd_valid;
+      if(iBus_cmd_ready) begin
+        iBus_cmd_rValid <= iBus_cmd_valid;
       end
-      if(_zz_143)begin
+      if(when_Stream_l399) begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3347,62 +3548,63 @@ module VexRiscv (
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusSimplePlugin_iBusRsp_output_ready)begin
-      _zz_56 <= IBusSimplePlugin_iBusRsp_output_payload_pc;
-      _zz_57 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
-      _zz_58 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
-      _zz_59 <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+  always @(posedge clk) begin
+    if(IBusSimplePlugin_iBusRsp_output_ready) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_pc <= IBusSimplePlugin_iBusRsp_output_payload_pc;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
     end
-    if(IBusSimplePlugin_injector_decodeInput_ready)begin
+    if(IBusSimplePlugin_injector_decodeInput_ready) begin
       IBusSimplePlugin_injector_formal_rawInDecode <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
     end
-    if(_zz_123)begin
-      if(_zz_138)begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l175) begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_92 <= _zz_37[11 : 7];
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_125)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_139)begin
-      if(_zz_140)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_141)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_142)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_126)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -3411,191 +3613,191 @@ module VexRiscv (
       endcase
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_6) begin
       decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_48;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_24;
+    if(when_Pipeline_l124_9) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_10) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_21;
+    if(when_Pipeline_l124_14) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_18;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_16) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15;
+    if(when_Pipeline_l124_26) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_12;
+    if(when_Pipeline_l124_27) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_9;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_30) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_31) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_32) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_34) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_35) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    if(when_Pipeline_l124_41) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_192[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(iBus_cmd_ready)begin
-      iBus_cmd_m2sPipe_rData_pc <= iBus_cmd_payload_pc;
+    if(iBus_cmd_ready) begin
+      iBus_cmd_rData_pc <= iBus_cmd_payload_pc;
     end
-    if(_zz_143)begin
+    if(when_Stream_l399) begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -3620,9 +3822,7 @@ module StreamFifoLowLatency (
   input               clk,
   input               reset
 );
-  wire                _zz_4;
-  wire       [0:0]    _zz_5;
-  reg                 _zz_1;
+  reg                 when_Phase_l623;
   reg                 pushPtr_willIncrement;
   reg                 pushPtr_willClear;
   wire                pushPtr_willOverflowIfInc;
@@ -3637,44 +3837,44 @@ module StreamFifoLowLatency (
   wire                full;
   wire                pushing;
   wire                popping;
-  wire       [32:0]   _zz_2;
-  reg        [32:0]   _zz_3;
+  wire                when_Stream_l1017;
+  wire       [32:0]   _zz_io_pop_payload_error;
+  wire                when_Stream_l1030;
+  reg        [32:0]   _zz_io_pop_payload_error_1;
 
-  assign _zz_4 = (! empty);
-  assign _zz_5 = _zz_2[0 : 0];
-  always @ (*) begin
-    _zz_1 = 1'b0;
-    if(pushing)begin
-      _zz_1 = 1'b1;
+  always @(*) begin
+    when_Phase_l623 = 1'b0;
+    if(pushing) begin
+      when_Phase_l623 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     pushPtr_willIncrement = 1'b0;
-    if(pushing)begin
+    if(pushing) begin
       pushPtr_willIncrement = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     pushPtr_willClear = 1'b0;
-    if(io_flush)begin
+    if(io_flush) begin
       pushPtr_willClear = 1'b1;
     end
   end
 
   assign pushPtr_willOverflowIfInc = 1'b1;
   assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @ (*) begin
+  always @(*) begin
     popPtr_willIncrement = 1'b0;
-    if(popping)begin
+    if(popping) begin
       popPtr_willIncrement = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     popPtr_willClear = 1'b0;
-    if(io_flush)begin
+    if(io_flush) begin
       popPtr_willClear = 1'b1;
     end
   end
@@ -3687,48 +3887,50 @@ module StreamFifoLowLatency (
   assign pushing = (io_push_valid && io_push_ready);
   assign popping = (io_pop_valid && io_pop_ready);
   assign io_push_ready = (! full);
-  always @ (*) begin
-    if(_zz_4)begin
+  assign when_Stream_l1017 = (! empty);
+  always @(*) begin
+    if(when_Stream_l1017) begin
       io_pop_valid = 1'b1;
     end else begin
       io_pop_valid = io_push_valid;
     end
   end
 
-  assign _zz_2 = _zz_3;
-  always @ (*) begin
-    if(_zz_4)begin
-      io_pop_payload_error = _zz_5[0];
+  assign _zz_io_pop_payload_error = _zz_io_pop_payload_error_1;
+  always @(*) begin
+    if(when_Stream_l1017) begin
+      io_pop_payload_error = _zz_io_pop_payload_error[0];
     end else begin
       io_pop_payload_error = io_push_payload_error;
     end
   end
 
-  always @ (*) begin
-    if(_zz_4)begin
-      io_pop_payload_inst = _zz_2[32 : 1];
+  always @(*) begin
+    if(when_Stream_l1017) begin
+      io_pop_payload_inst = _zz_io_pop_payload_error[32 : 1];
     end else begin
       io_pop_payload_inst = io_push_payload_inst;
     end
   end
 
+  assign when_Stream_l1030 = (pushing != popping);
   assign io_occupancy = (risingOccupancy && ptrMatch);
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       risingOccupancy <= 1'b0;
     end else begin
-      if((pushing != popping))begin
+      if(when_Stream_l1030) begin
         risingOccupancy <= pushing;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         risingOccupancy <= 1'b0;
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_1)begin
-      _zz_3 <= {io_push_payload_inst,io_push_payload_error};
+  always @(posedge clk) begin
+    if(when_Phase_l623) begin
+      _zz_io_pop_payload_error_1 <= {io_push_payload_inst,io_push_payload_error};
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -81,225 +81,180 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_121;
-  wire                _zz_122;
-  reg        [31:0]   _zz_123;
-  reg        [31:0]   _zz_124;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
-  wire                _zz_125;
-  wire                _zz_126;
-  wire                _zz_127;
-  wire                _zz_128;
-  wire                _zz_129;
-  wire                _zz_130;
-  wire                _zz_131;
-  wire                _zz_132;
-  wire       [1:0]    _zz_133;
-  wire                _zz_134;
-  wire                _zz_135;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
-  wire                _zz_139;
-  wire                _zz_140;
-  wire                _zz_141;
-  wire                _zz_142;
-  wire       [5:0]    _zz_143;
-  wire                _zz_144;
-  wire                _zz_145;
-  wire                _zz_146;
-  wire                _zz_147;
-  wire                _zz_148;
-  wire                _zz_149;
-  wire       [1:0]    _zz_150;
-  wire                _zz_151;
-  wire       [0:0]    _zz_152;
-  wire       [0:0]    _zz_153;
-  wire       [0:0]    _zz_154;
-  wire       [0:0]    _zz_155;
-  wire       [0:0]    _zz_156;
-  wire       [0:0]    _zz_157;
-  wire       [0:0]    _zz_158;
-  wire       [0:0]    _zz_159;
-  wire       [0:0]    _zz_160;
-  wire       [0:0]    _zz_161;
-  wire       [0:0]    _zz_162;
-  wire       [0:0]    _zz_163;
-  wire       [1:0]    _zz_164;
-  wire       [1:0]    _zz_165;
-  wire       [2:0]    _zz_166;
-  wire       [31:0]   _zz_167;
-  wire       [2:0]    _zz_168;
-  wire       [0:0]    _zz_169;
-  wire       [2:0]    _zz_170;
-  wire       [0:0]    _zz_171;
-  wire       [2:0]    _zz_172;
-  wire       [0:0]    _zz_173;
-  wire       [2:0]    _zz_174;
-  wire       [0:0]    _zz_175;
-  wire       [2:0]    _zz_176;
-  wire       [2:0]    _zz_177;
-  wire       [0:0]    _zz_178;
-  wire       [2:0]    _zz_179;
-  wire       [4:0]    _zz_180;
-  wire       [11:0]   _zz_181;
-  wire       [11:0]   _zz_182;
-  wire       [31:0]   _zz_183;
-  wire       [31:0]   _zz_184;
-  wire       [31:0]   _zz_185;
-  wire       [31:0]   _zz_186;
-  wire       [31:0]   _zz_187;
-  wire       [31:0]   _zz_188;
-  wire       [31:0]   _zz_189;
-  wire       [31:0]   _zz_190;
-  wire       [32:0]   _zz_191;
-  wire       [19:0]   _zz_192;
-  wire       [11:0]   _zz_193;
-  wire       [11:0]   _zz_194;
-  wire       [1:0]    _zz_195;
-  wire       [1:0]    _zz_196;
-  wire       [0:0]    _zz_197;
-  wire       [0:0]    _zz_198;
-  wire       [0:0]    _zz_199;
-  wire       [0:0]    _zz_200;
-  wire       [0:0]    _zz_201;
-  wire       [0:0]    _zz_202;
-  wire                _zz_203;
-  wire                _zz_204;
-  wire       [31:0]   _zz_205;
-  wire       [31:0]   _zz_206;
-  wire       [31:0]   _zz_207;
-  wire                _zz_208;
-  wire       [0:0]    _zz_209;
-  wire       [12:0]   _zz_210;
-  wire       [31:0]   _zz_211;
-  wire       [31:0]   _zz_212;
-  wire       [31:0]   _zz_213;
-  wire                _zz_214;
-  wire       [0:0]    _zz_215;
-  wire       [6:0]    _zz_216;
-  wire       [31:0]   _zz_217;
-  wire       [31:0]   _zz_218;
-  wire       [31:0]   _zz_219;
-  wire                _zz_220;
-  wire       [0:0]    _zz_221;
-  wire       [0:0]    _zz_222;
-  wire       [31:0]   _zz_223;
-  wire       [31:0]   _zz_224;
-  wire       [31:0]   _zz_225;
-  wire                _zz_226;
-  wire       [1:0]    _zz_227;
-  wire       [1:0]    _zz_228;
-  wire                _zz_229;
-  wire       [0:0]    _zz_230;
-  wire       [20:0]   _zz_231;
-  wire       [31:0]   _zz_232;
-  wire       [31:0]   _zz_233;
-  wire       [31:0]   _zz_234;
-  wire       [31:0]   _zz_235;
-  wire                _zz_236;
-  wire                _zz_237;
-  wire       [0:0]    _zz_238;
-  wire       [0:0]    _zz_239;
-  wire                _zz_240;
-  wire       [0:0]    _zz_241;
-  wire       [17:0]   _zz_242;
-  wire       [31:0]   _zz_243;
-  wire                _zz_244;
-  wire                _zz_245;
-  wire       [0:0]    _zz_246;
-  wire       [0:0]    _zz_247;
-  wire       [0:0]    _zz_248;
-  wire       [0:0]    _zz_249;
-  wire                _zz_250;
-  wire       [0:0]    _zz_251;
-  wire       [14:0]   _zz_252;
-  wire       [31:0]   _zz_253;
-  wire       [31:0]   _zz_254;
-  wire       [31:0]   _zz_255;
-  wire       [31:0]   _zz_256;
-  wire       [31:0]   _zz_257;
-  wire       [0:0]    _zz_258;
-  wire       [0:0]    _zz_259;
-  wire       [1:0]    _zz_260;
-  wire       [1:0]    _zz_261;
-  wire                _zz_262;
-  wire       [0:0]    _zz_263;
-  wire       [11:0]   _zz_264;
-  wire       [31:0]   _zz_265;
-  wire       [31:0]   _zz_266;
-  wire       [31:0]   _zz_267;
-  wire       [31:0]   _zz_268;
-  wire       [31:0]   _zz_269;
-  wire       [31:0]   _zz_270;
-  wire                _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [0:0]    _zz_273;
-  wire                _zz_274;
-  wire       [0:0]    _zz_275;
-  wire       [0:0]    _zz_276;
-  wire                _zz_277;
-  wire       [0:0]    _zz_278;
-  wire       [8:0]    _zz_279;
-  wire       [31:0]   _zz_280;
-  wire       [31:0]   _zz_281;
-  wire       [31:0]   _zz_282;
-  wire       [0:0]    _zz_283;
-  wire       [4:0]    _zz_284;
-  wire       [1:0]    _zz_285;
-  wire       [1:0]    _zz_286;
-  wire                _zz_287;
-  wire       [0:0]    _zz_288;
-  wire       [5:0]    _zz_289;
-  wire       [31:0]   _zz_290;
-  wire       [31:0]   _zz_291;
-  wire                _zz_292;
-  wire       [0:0]    _zz_293;
-  wire       [1:0]    _zz_294;
-  wire       [31:0]   _zz_295;
-  wire       [31:0]   _zz_296;
-  wire                _zz_297;
-  wire       [0:0]    _zz_298;
-  wire       [0:0]    _zz_299;
-  wire       [0:0]    _zz_300;
-  wire       [0:0]    _zz_301;
-  wire                _zz_302;
-  wire       [0:0]    _zz_303;
-  wire       [2:0]    _zz_304;
-  wire       [31:0]   _zz_305;
-  wire                _zz_306;
-  wire                _zz_307;
-  wire       [31:0]   _zz_308;
-  wire       [31:0]   _zz_309;
-  wire       [31:0]   _zz_310;
-  wire       [31:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  wire       [31:0]   _zz_314;
-  wire       [0:0]    _zz_315;
-  wire       [2:0]    _zz_316;
-  wire       [0:0]    _zz_317;
-  wire       [0:0]    _zz_318;
-  wire                _zz_319;
-  wire       [0:0]    _zz_320;
-  wire       [0:0]    _zz_321;
-  wire       [31:0]   _zz_322;
-  wire       [31:0]   _zz_323;
-  wire       [31:0]   _zz_324;
-  wire                _zz_325;
-  wire                _zz_326;
-  wire       [31:0]   _zz_327;
-  wire                _zz_328;
-  wire       [0:0]    _zz_329;
-  wire       [0:0]    _zz_330;
-  wire       [0:0]    _zz_331;
-  wire       [0:0]    _zz_332;
-  wire       [0:0]    _zz_333;
-  wire       [0:0]    _zz_334;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [12:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [6:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
+  wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusSimplePlugin_fetchPc_pc_1;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_1;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_2;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_3;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_4;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
+  wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_1;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_2;
+  wire                _zz__zz_decode_ENV_CTRL_2_3;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_4;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_5;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_6;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_7;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_8;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_9;
+  wire                _zz__zz_decode_ENV_CTRL_2_10;
+  wire                _zz__zz_decode_ENV_CTRL_2_11;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_12;
+  wire                _zz__zz_decode_ENV_CTRL_2_13;
+  wire       [20:0]   _zz__zz_decode_ENV_CTRL_2_14;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_15;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_16;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_17;
+  wire                _zz__zz_decode_ENV_CTRL_2_18;
+  wire                _zz__zz_decode_ENV_CTRL_2_19;
+  wire                _zz__zz_decode_ENV_CTRL_2_20;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_21;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_22;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_23;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_24;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_25;
+  wire       [17:0]   _zz__zz_decode_ENV_CTRL_2_26;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_27;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_28;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_29;
+  wire                _zz__zz_decode_ENV_CTRL_2_30;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_31;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_32;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_33;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_34;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_35;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_36;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_37;
+  wire       [14:0]   _zz__zz_decode_ENV_CTRL_2_38;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_39;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_40;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_41;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_42;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_43;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_44;
+  wire                _zz__zz_decode_ENV_CTRL_2_45;
+  wire                _zz__zz_decode_ENV_CTRL_2_46;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_47;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_48;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_49;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_50;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_51;
+  wire                _zz__zz_decode_ENV_CTRL_2_52;
+  wire       [11:0]   _zz__zz_decode_ENV_CTRL_2_53;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_54;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_55;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_56;
+  wire                _zz__zz_decode_ENV_CTRL_2_57;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_58;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_59;
+  wire       [4:0]    _zz__zz_decode_ENV_CTRL_2_60;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_61;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_62;
+  wire                _zz__zz_decode_ENV_CTRL_2_63;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_64;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_65;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_66;
+  wire                _zz__zz_decode_ENV_CTRL_2_67;
+  wire                _zz__zz_decode_ENV_CTRL_2_68;
+  wire       [8:0]    _zz__zz_decode_ENV_CTRL_2_69;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_70;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_71;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_72;
+  wire       [1:0]    _zz__zz_decode_ENV_CTRL_2_73;
+  wire                _zz__zz_decode_ENV_CTRL_2_74;
+  wire                _zz__zz_decode_ENV_CTRL_2_75;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_76;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_77;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_78;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_79;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_80;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_81;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_82;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_83;
+  wire       [5:0]    _zz__zz_decode_ENV_CTRL_2_84;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_85;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_86;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_87;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_88;
+  wire                _zz__zz_decode_ENV_CTRL_2_89;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_90;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_91;
+  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_92;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_93;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_94;
+  wire                _zz__zz_decode_ENV_CTRL_2_95;
+  wire                _zz__zz_decode_ENV_CTRL_2_96;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_97;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_98;
+  wire       [31:0]   _zz__zz_decode_ENV_CTRL_2_99;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_100;
+  wire       [2:0]    _zz__zz_decode_ENV_CTRL_2_101;
+  wire                _zz__zz_decode_ENV_CTRL_2_102;
+  wire                _zz__zz_decode_ENV_CTRL_2_103;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_104;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_105;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_106;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_107;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_108;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_109;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_110;
+  wire       [0:0]    _zz__zz_decode_ENV_CTRL_2_111;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [31:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+  wire       [32:0]   _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
   wire       [31:0]   memory_MEMORY_READ_DATA;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
@@ -313,45 +268,45 @@ module VexRiscv (
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire                decode_MEMORY_ENABLE;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -363,17 +318,17 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -382,42 +337,42 @@ module VexRiscv (
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   _zz_30;
+  reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
-  wire       [31:0]   _zz_37;
-  wire                _zz_38;
-  reg                 _zz_39;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47;
+  reg        [31:0]   _zz_lastStageRegFileWrite_payload_data;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
@@ -431,7 +386,7 @@ module VexRiscv (
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
-  reg        [31:0]   _zz_48;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire       [31:0]   writeBack_PC;
@@ -507,6 +462,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  wire                CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   wire                CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -524,25 +484,31 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusSimplePlugin_injectionPort_valid;
   reg                 IBusSimplePlugin_injectionPort_ready;
   wire       [31:0]   IBusSimplePlugin_injectionPort_payload;
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
-  wire       [1:0]    _zz_49;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload;
   wire                IBusSimplePlugin_fetchPc_output_valid;
   wire                IBusSimplePlugin_fetchPc_output_ready;
   wire       [31:0]   IBusSimplePlugin_fetchPc_output_payload;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusSimplePlugin_fetchPc_correction;
   reg                 IBusSimplePlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusSimplePlugin_fetchPc_corrected;
   reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
   reg                 IBusSimplePlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
@@ -558,12 +524,12 @@ module VexRiscv (
   wire                IBusSimplePlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   wire                IBusSimplePlugin_iBusRsp_stages_1_halt;
-  wire                _zz_50;
-  wire                _zz_51;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
   wire                IBusSimplePlugin_iBusRsp_flush;
-  wire                _zz_52;
-  wire                _zz_53;
-  reg                 _zz_54;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -577,16 +543,22 @@ module VexRiscv (
   wire                IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_55;
-  reg        [31:0]   _zz_56;
-  reg                 _zz_57;
-  reg        [31:0]   _zz_58;
-  reg                 _zz_59;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  wire                when_Fetcher_l320;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
+  wire                when_Fetcher_l329_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
   wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
@@ -596,6 +568,7 @@ module VexRiscv (
   reg        [2:0]    IBusSimplePlugin_pending_value;
   wire       [2:0]    IBusSimplePlugin_pending_next;
   wire                IBusSimplePlugin_cmdFork_canEmit;
+  wire                when_IBusSimplePlugin_l304;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -606,6 +579,7 @@ module VexRiscv (
   reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
+  wire                when_IBusSimplePlugin_l375;
   wire                IBusSimplePlugin_rspJoin_join_valid;
   wire                IBusSimplePlugin_rspJoin_join_ready;
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_pc;
@@ -613,7 +587,7 @@ module VexRiscv (
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
   wire                IBusSimplePlugin_rspJoin_exceptionDetected;
-  wire                _zz_60;
+  wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -623,29 +597,36 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_61;
+  wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_62;
-  reg        [3:0]    _zz_63;
+  reg        [31:0]   _zz_dBus_cmd_payload_data;
+  wire                when_DBusSimplePlugin_l426;
+  reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
+  wire                when_DBusSimplePlugin_l479;
+  wire                when_DBusSimplePlugin_l486;
+  wire                when_DBusSimplePlugin_l512;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_64;
-  reg        [31:0]   _zz_65;
-  wire                _zz_66;
-  reg        [31:0]   _zz_67;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [26:0]   _zz_68;
-  wire                _zz_69;
-  wire                _zz_70;
-  wire                _zz_71;
-  wire                _zz_72;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_73;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_74;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_75;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_76;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_77;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_78;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_79;
+  wire                when_DBusSimplePlugin_l558;
+  wire       [26:0]   _zz_decode_ENV_CTRL_2;
+  wire                _zz_decode_ENV_CTRL_3;
+  wire                _zz_decode_ENV_CTRL_4;
+  wire                _zz_decode_ENV_CTRL_5;
+  wire                _zz_decode_ENV_CTRL_6;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_7;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -653,15 +634,15 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_80;
+  reg                 _zz_2;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_81;
-  reg        [31:0]   _zz_82;
-  wire                _zz_83;
-  reg        [19:0]   _zz_84;
-  wire                _zz_85;
-  reg        [19:0]   _zz_86;
-  reg        [31:0]   _zz_87;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -670,23 +651,47 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_88;
-  reg                 _zz_89;
-  reg                 _zz_90;
-  reg                 _zz_91;
-  reg        [4:0]    _zz_92;
+  wire                when_ShiftPlugins_l169;
+  reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
+  wire                when_ShiftPlugins_l175;
+  wire                when_ShiftPlugins_l184;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l59;
+  wire                when_HazardSimplePlugin_l62;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l59_1;
+  wire                when_HazardSimplePlugin_l62_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l59_2;
+  wire                when_HazardSimplePlugin_l62_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_93;
-  reg                 _zz_94;
-  reg                 _zz_95;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_DO;
+  reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_96;
-  reg        [10:0]   _zz_97;
-  wire                _zz_98;
-  reg        [19:0]   _zz_99;
-  wire                _zz_100;
-  reg        [18:0]   _zz_101;
-  reg        [31:0]   _zz_102;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
+  reg        [31:0]   _zz_execute_BranchPlugin_branch_src2_6;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -708,9 +713,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_103;
-  wire                _zz_104;
-  wire                _zz_105;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -723,39 +728,62 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_106;
-  wire                _zz_107;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_108;
-  wire       [31:0]   _zz_109;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -763,81 +791,164 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_110;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_12;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_15;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_16;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_17;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 decode_to_execute_MEMORY_STORE;
+  wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_MEMORY_STORE;
+  wire                when_Pipeline_l124_24;
   reg                 memory_to_writeBack_MEMORY_STORE;
+  wire                when_Pipeline_l124_25;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_26;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_27;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_28;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_30;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_32;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_33;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_34;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_35;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_37;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_38;
   reg                 decode_to_execute_DO_EBREAK;
+  wire                when_Pipeline_l124_39;
   reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  wire                when_Pipeline_l124_40;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_41;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_42;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_44;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_45;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_46;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
-  reg        [2:0]    _zz_111;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  wire                when_Fetcher_l398;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_112;
-  reg        [31:0]   _zz_113;
-  reg        [31:0]   _zz_114;
-  reg        [31:0]   _zz_115;
-  reg        [31:0]   _zz_116;
-  reg        [31:0]   _zz_117;
-  reg        [31:0]   _zz_118;
-  reg        [31:0]   _zz_119;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
-  reg                 iBus_cmd_m2sPipe_rValid;
-  reg        [31:0]   iBus_cmd_m2sPipe_rData_pc;
+  reg                 iBus_cmd_rValid;
+  reg        [31:0]   iBus_cmd_rData_pc;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
   wire                dBus_cmd_halfPipe_payload_wr;
@@ -850,77 +961,79 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_120;
+  wire                when_Stream_l399;
+  reg        [3:0]    _zz_dBusWishbone_SEL;
+  wire                when_DBusSimplePlugin_l189;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [31:0] _zz_10_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_14_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_17_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_20_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_23_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_26_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_29_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36_string;
-  reg [39:0] _zz_40_string;
-  reg [31:0] _zz_41_string;
-  reg [71:0] _zz_42_string;
-  reg [39:0] _zz_43_string;
-  reg [23:0] _zz_44_string;
-  reg [63:0] _zz_45_string;
-  reg [95:0] _zz_46_string;
-  reg [95:0] _zz_73_string;
-  reg [63:0] _zz_74_string;
-  reg [23:0] _zz_75_string;
-  reg [39:0] _zz_76_string;
-  reg [71:0] _zz_77_string;
-  reg [31:0] _zz_78_string;
-  reg [39:0] _zz_79_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_7_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -929,279 +1042,233 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_125 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_126 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_127 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_128 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_129 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
-  assign _zz_130 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_131 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_132 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
-  assign _zz_133 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_134 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_135 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_136 = (1'b1 || (! 1'b1));
-  assign _zz_137 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_138 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_139 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_140 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_141 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_142 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_143 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_144 = (! execute_arbitration_isStuckByOthers);
-  assign _zz_145 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_146 = ((_zz_103 && 1'b1) && (! 1'b0));
-  assign _zz_147 = ((_zz_104 && 1'b1) && (! 1'b0));
-  assign _zz_148 = ((_zz_105 && 1'b1) && (! 1'b0));
-  assign _zz_149 = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_150 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_151 = execute_INSTRUCTION[13];
-  assign _zz_152 = _zz_68[23 : 23];
-  assign _zz_153 = _zz_68[15 : 15];
-  assign _zz_154 = _zz_68[12 : 12];
-  assign _zz_155 = _zz_68[11 : 11];
-  assign _zz_156 = _zz_68[10 : 10];
-  assign _zz_157 = _zz_68[3 : 3];
-  assign _zz_158 = _zz_68[26 : 26];
-  assign _zz_159 = _zz_68[14 : 14];
-  assign _zz_160 = _zz_68[4 : 4];
-  assign _zz_161 = _zz_68[2 : 2];
-  assign _zz_162 = _zz_68[18 : 18];
-  assign _zz_163 = _zz_68[9 : 9];
-  assign _zz_164 = (_zz_49 & (~ _zz_165));
-  assign _zz_165 = (_zz_49 - 2'b01);
-  assign _zz_166 = {IBusSimplePlugin_fetchPc_inc,2'b00};
-  assign _zz_167 = {29'd0, _zz_166};
-  assign _zz_168 = (IBusSimplePlugin_pending_value + _zz_170);
-  assign _zz_169 = IBusSimplePlugin_pending_inc;
-  assign _zz_170 = {2'd0, _zz_169};
-  assign _zz_171 = IBusSimplePlugin_pending_dec;
-  assign _zz_172 = {2'd0, _zz_171};
-  assign _zz_173 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
-  assign _zz_174 = {2'd0, _zz_173};
-  assign _zz_175 = IBusSimplePlugin_pending_dec;
-  assign _zz_176 = {2'd0, _zz_175};
-  assign _zz_177 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
-  assign _zz_178 = execute_SRC_LESS;
-  assign _zz_179 = 3'b100;
-  assign _zz_180 = execute_INSTRUCTION[19 : 15];
-  assign _zz_181 = execute_INSTRUCTION[31 : 20];
-  assign _zz_182 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_183 = ($signed(_zz_184) + $signed(_zz_187));
-  assign _zz_184 = ($signed(_zz_185) + $signed(_zz_186));
-  assign _zz_185 = execute_SRC1;
-  assign _zz_186 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_187 = (execute_SRC_USE_SUB_LESS ? _zz_188 : _zz_189);
-  assign _zz_188 = 32'h00000001;
-  assign _zz_189 = 32'h0;
-  assign _zz_190 = (_zz_191 >>> 1);
-  assign _zz_191 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_192 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_193 = execute_INSTRUCTION[31 : 20];
-  assign _zz_194 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_195 = (_zz_106 & (~ _zz_196));
-  assign _zz_196 = (_zz_106 - 2'b01);
-  assign _zz_197 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_198 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_199 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_200 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_201 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_202 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_203 = 1'b1;
-  assign _zz_204 = 1'b1;
-  assign _zz_205 = 32'h0000107f;
-  assign _zz_206 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_207 = 32'h00002073;
-  assign _zz_208 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_209 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_210 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_211) == 32'h00000003),{(_zz_212 == _zz_213),{_zz_214,{_zz_215,_zz_216}}}}}};
-  assign _zz_211 = 32'h0000505f;
-  assign _zz_212 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_213 = 32'h00000063;
-  assign _zz_214 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_215 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_216 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_217) == 32'h00005033),{(_zz_218 == _zz_219),{_zz_220,{_zz_221,_zz_222}}}}}};
-  assign _zz_217 = 32'hbe00707f;
-  assign _zz_218 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_219 = 32'h00000033;
-  assign _zz_220 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_221 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_222 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_223 = 32'h10103050;
-  assign _zz_224 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_225 = 32'h00000050;
-  assign _zz_226 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_227 = {(_zz_232 == _zz_233),(_zz_234 == _zz_235)};
-  assign _zz_228 = 2'b00;
-  assign _zz_229 = ({_zz_72,_zz_236} != 2'b00);
-  assign _zz_230 = (_zz_237 != 1'b0);
-  assign _zz_231 = {(_zz_238 != _zz_239),{_zz_240,{_zz_241,_zz_242}}};
-  assign _zz_232 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_233 = 32'h00001050;
-  assign _zz_234 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_235 = 32'h00002050;
-  assign _zz_236 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_237 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_238 = ((decode_INSTRUCTION & _zz_243) == 32'h00005010);
-  assign _zz_239 = 1'b0;
-  assign _zz_240 = ({_zz_244,_zz_245} != 2'b00);
-  assign _zz_241 = ({_zz_246,_zz_247} != 2'b00);
-  assign _zz_242 = {(_zz_248 != _zz_249),{_zz_250,{_zz_251,_zz_252}}};
-  assign _zz_243 = 32'h00007054;
-  assign _zz_244 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_245 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00001010);
-  assign _zz_246 = ((decode_INSTRUCTION & _zz_253) == 32'h00000024);
-  assign _zz_247 = ((decode_INSTRUCTION & _zz_254) == 32'h00001010);
-  assign _zz_248 = ((decode_INSTRUCTION & _zz_255) == 32'h00001000);
-  assign _zz_249 = 1'b0;
-  assign _zz_250 = ((_zz_256 == _zz_257) != 1'b0);
-  assign _zz_251 = ({_zz_258,_zz_259} != 2'b00);
-  assign _zz_252 = {(_zz_260 != _zz_261),{_zz_262,{_zz_263,_zz_264}}};
-  assign _zz_253 = 32'h00000064;
-  assign _zz_254 = 32'h00003054;
-  assign _zz_255 = 32'h00001000;
-  assign _zz_256 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_257 = 32'h00002000;
-  assign _zz_258 = ((decode_INSTRUCTION & _zz_265) == 32'h00002000);
-  assign _zz_259 = ((decode_INSTRUCTION & _zz_266) == 32'h00001000);
-  assign _zz_260 = {(_zz_267 == _zz_268),(_zz_269 == _zz_270)};
-  assign _zz_261 = 2'b00;
-  assign _zz_262 = ({_zz_271,{_zz_272,_zz_273}} != 3'b000);
-  assign _zz_263 = (_zz_274 != 1'b0);
-  assign _zz_264 = {(_zz_275 != _zz_276),{_zz_277,{_zz_278,_zz_279}}};
-  assign _zz_265 = 32'h00002010;
-  assign _zz_266 = 32'h00005000;
-  assign _zz_267 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_268 = 32'h00000020;
-  assign _zz_269 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_270 = 32'h00000020;
-  assign _zz_271 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_272 = ((decode_INSTRUCTION & _zz_280) == 32'h0);
-  assign _zz_273 = ((decode_INSTRUCTION & _zz_281) == 32'h00000040);
-  assign _zz_274 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_275 = ((decode_INSTRUCTION & _zz_282) == 32'h00000010);
-  assign _zz_276 = 1'b0;
-  assign _zz_277 = (_zz_71 != 1'b0);
-  assign _zz_278 = ({_zz_283,_zz_284} != 6'h0);
-  assign _zz_279 = {(_zz_285 != _zz_286),{_zz_287,{_zz_288,_zz_289}}};
-  assign _zz_280 = 32'h00000038;
-  assign _zz_281 = 32'h00103040;
-  assign _zz_282 = 32'h00000010;
-  assign _zz_283 = _zz_72;
-  assign _zz_284 = {(_zz_290 == _zz_291),{_zz_292,{_zz_293,_zz_294}}};
-  assign _zz_285 = {_zz_70,(_zz_295 == _zz_296)};
-  assign _zz_286 = 2'b00;
-  assign _zz_287 = ({_zz_70,_zz_297} != 2'b00);
-  assign _zz_288 = ({_zz_298,_zz_299} != 2'b00);
-  assign _zz_289 = {(_zz_300 != _zz_301),{_zz_302,{_zz_303,_zz_304}}};
-  assign _zz_290 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_291 = 32'h00001010;
-  assign _zz_292 = ((decode_INSTRUCTION & _zz_305) == 32'h00002010);
-  assign _zz_293 = _zz_71;
-  assign _zz_294 = {_zz_306,_zz_307};
-  assign _zz_295 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_296 = 32'h00000020;
-  assign _zz_297 = ((decode_INSTRUCTION & _zz_308) == 32'h0);
-  assign _zz_298 = (_zz_309 == _zz_310);
-  assign _zz_299 = (_zz_311 == _zz_312);
-  assign _zz_300 = (_zz_313 == _zz_314);
-  assign _zz_301 = 1'b0;
-  assign _zz_302 = ({_zz_315,_zz_316} != 4'b0000);
-  assign _zz_303 = (_zz_317 != _zz_318);
-  assign _zz_304 = {_zz_319,{_zz_320,_zz_321}};
-  assign _zz_305 = 32'h00002010;
-  assign _zz_306 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_307 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_308 = 32'h00000020;
-  assign _zz_309 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_310 = 32'h00006010;
-  assign _zz_311 = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz_312 = 32'h00004010;
-  assign _zz_313 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_314 = 32'h00002010;
-  assign _zz_315 = ((decode_INSTRUCTION & _zz_322) == 32'h0);
-  assign _zz_316 = {(_zz_323 == _zz_324),{_zz_325,_zz_326}};
-  assign _zz_317 = ((decode_INSTRUCTION & _zz_327) == 32'h0);
-  assign _zz_318 = 1'b0;
-  assign _zz_319 = ({_zz_328,{_zz_329,_zz_330}} != 3'b000);
-  assign _zz_320 = ({_zz_331,_zz_332} != 2'b00);
-  assign _zz_321 = ({_zz_333,_zz_334} != 2'b00);
-  assign _zz_322 = 32'h00000044;
-  assign _zz_323 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_324 = 32'h0;
-  assign _zz_325 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_326 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_327 = 32'h00000058;
-  assign _zz_328 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_329 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_330 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz_331 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_332 = _zz_69;
-  assign _zz_333 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_334 = _zz_69;
-  always @ (posedge clk) begin
-    if(_zz_203) begin
-      _zz_123 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload & (~ _zz_IBusSimplePlugin_jump_pcLoad_payload_2));
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_2 = (_zz_IBusSimplePlugin_jump_pcLoad_payload - 2'b01);
+  assign _zz_IBusSimplePlugin_fetchPc_pc_1 = {IBusSimplePlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusSimplePlugin_fetchPc_pc = {29'd0, _zz_IBusSimplePlugin_fetchPc_pc_1};
+  assign _zz_IBusSimplePlugin_pending_next = (IBusSimplePlugin_pending_value + _zz_IBusSimplePlugin_pending_next_1);
+  assign _zz_IBusSimplePlugin_pending_next_2 = IBusSimplePlugin_pending_inc;
+  assign _zz_IBusSimplePlugin_pending_next_1 = {2'd0, _zz_IBusSimplePlugin_pending_next_2};
+  assign _zz_IBusSimplePlugin_pending_next_4 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_pending_next_3 = {2'd0, _zz_IBusSimplePlugin_pending_next_4};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2 = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3};
+  assign _zz_DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00005033),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hbe00707f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00000033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz__zz_decode_ENV_CTRL_2 = 32'h10103050;
+  assign _zz__zz_decode_ENV_CTRL_2_1 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_ENV_CTRL_2_2 = 32'h00000050;
+  assign _zz__zz_decode_ENV_CTRL_2_3 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz__zz_decode_ENV_CTRL_2_4 = {(_zz__zz_decode_ENV_CTRL_2_5 == _zz__zz_decode_ENV_CTRL_2_6),(_zz__zz_decode_ENV_CTRL_2_7 == _zz__zz_decode_ENV_CTRL_2_8)};
+  assign _zz__zz_decode_ENV_CTRL_2_9 = 2'b00;
+  assign _zz__zz_decode_ENV_CTRL_2_10 = ({_zz_decode_ENV_CTRL_6,_zz__zz_decode_ENV_CTRL_2_11} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_12 = (_zz__zz_decode_ENV_CTRL_2_13 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_14 = {(_zz__zz_decode_ENV_CTRL_2_15 != _zz__zz_decode_ENV_CTRL_2_17),{_zz__zz_decode_ENV_CTRL_2_18,{_zz__zz_decode_ENV_CTRL_2_21,_zz__zz_decode_ENV_CTRL_2_26}}};
+  assign _zz__zz_decode_ENV_CTRL_2_5 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_ENV_CTRL_2_6 = 32'h00001050;
+  assign _zz__zz_decode_ENV_CTRL_2_7 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_ENV_CTRL_2_8 = 32'h00002050;
+  assign _zz__zz_decode_ENV_CTRL_2_11 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_ENV_CTRL_2_13 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_ENV_CTRL_2_15 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_16) == 32'h00005010);
+  assign _zz__zz_decode_ENV_CTRL_2_17 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_18 = ({_zz__zz_decode_ENV_CTRL_2_19,_zz__zz_decode_ENV_CTRL_2_20} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_21 = ({_zz__zz_decode_ENV_CTRL_2_22,_zz__zz_decode_ENV_CTRL_2_24} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_26 = {(_zz__zz_decode_ENV_CTRL_2_27 != _zz__zz_decode_ENV_CTRL_2_29),{_zz__zz_decode_ENV_CTRL_2_30,{_zz__zz_decode_ENV_CTRL_2_33,_zz__zz_decode_ENV_CTRL_2_38}}};
+  assign _zz__zz_decode_ENV_CTRL_2_16 = 32'h00007054;
+  assign _zz__zz_decode_ENV_CTRL_2_19 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_ENV_CTRL_2_20 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00001010);
+  assign _zz__zz_decode_ENV_CTRL_2_22 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_23) == 32'h00000024);
+  assign _zz__zz_decode_ENV_CTRL_2_24 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_25) == 32'h00001010);
+  assign _zz__zz_decode_ENV_CTRL_2_27 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_28) == 32'h00001000);
+  assign _zz__zz_decode_ENV_CTRL_2_29 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_30 = ((_zz__zz_decode_ENV_CTRL_2_31 == _zz__zz_decode_ENV_CTRL_2_32) != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_33 = ({_zz__zz_decode_ENV_CTRL_2_34,_zz__zz_decode_ENV_CTRL_2_36} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_38 = {(_zz__zz_decode_ENV_CTRL_2_39 != _zz__zz_decode_ENV_CTRL_2_44),{_zz__zz_decode_ENV_CTRL_2_45,{_zz__zz_decode_ENV_CTRL_2_51,_zz__zz_decode_ENV_CTRL_2_53}}};
+  assign _zz__zz_decode_ENV_CTRL_2_23 = 32'h00000064;
+  assign _zz__zz_decode_ENV_CTRL_2_25 = 32'h00003054;
+  assign _zz__zz_decode_ENV_CTRL_2_28 = 32'h00001000;
+  assign _zz__zz_decode_ENV_CTRL_2_31 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_ENV_CTRL_2_32 = 32'h00002000;
+  assign _zz__zz_decode_ENV_CTRL_2_34 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_35) == 32'h00002000);
+  assign _zz__zz_decode_ENV_CTRL_2_36 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_37) == 32'h00001000);
+  assign _zz__zz_decode_ENV_CTRL_2_39 = {(_zz__zz_decode_ENV_CTRL_2_40 == _zz__zz_decode_ENV_CTRL_2_41),(_zz__zz_decode_ENV_CTRL_2_42 == _zz__zz_decode_ENV_CTRL_2_43)};
+  assign _zz__zz_decode_ENV_CTRL_2_44 = 2'b00;
+  assign _zz__zz_decode_ENV_CTRL_2_45 = ({_zz__zz_decode_ENV_CTRL_2_46,{_zz__zz_decode_ENV_CTRL_2_47,_zz__zz_decode_ENV_CTRL_2_49}} != 3'b000);
+  assign _zz__zz_decode_ENV_CTRL_2_51 = (_zz__zz_decode_ENV_CTRL_2_52 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_53 = {(_zz__zz_decode_ENV_CTRL_2_54 != _zz__zz_decode_ENV_CTRL_2_56),{_zz__zz_decode_ENV_CTRL_2_57,{_zz__zz_decode_ENV_CTRL_2_58,_zz__zz_decode_ENV_CTRL_2_69}}};
+  assign _zz__zz_decode_ENV_CTRL_2_35 = 32'h00002010;
+  assign _zz__zz_decode_ENV_CTRL_2_37 = 32'h00005000;
+  assign _zz__zz_decode_ENV_CTRL_2_40 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_ENV_CTRL_2_41 = 32'h00000020;
+  assign _zz__zz_decode_ENV_CTRL_2_42 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_ENV_CTRL_2_43 = 32'h00000020;
+  assign _zz__zz_decode_ENV_CTRL_2_46 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_ENV_CTRL_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_48) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_50) == 32'h00000040);
+  assign _zz__zz_decode_ENV_CTRL_2_52 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_ENV_CTRL_2_54 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_55) == 32'h00000010);
+  assign _zz__zz_decode_ENV_CTRL_2_56 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_57 = (_zz_decode_ENV_CTRL_5 != 1'b0);
+  assign _zz__zz_decode_ENV_CTRL_2_58 = ({_zz__zz_decode_ENV_CTRL_2_59,_zz__zz_decode_ENV_CTRL_2_60} != 6'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_69 = {(_zz__zz_decode_ENV_CTRL_2_70 != _zz__zz_decode_ENV_CTRL_2_73),{_zz__zz_decode_ENV_CTRL_2_74,{_zz__zz_decode_ENV_CTRL_2_77,_zz__zz_decode_ENV_CTRL_2_84}}};
+  assign _zz__zz_decode_ENV_CTRL_2_48 = 32'h00000038;
+  assign _zz__zz_decode_ENV_CTRL_2_50 = 32'h00103040;
+  assign _zz__zz_decode_ENV_CTRL_2_55 = 32'h00000010;
+  assign _zz__zz_decode_ENV_CTRL_2_59 = _zz_decode_ENV_CTRL_6;
+  assign _zz__zz_decode_ENV_CTRL_2_60 = {(_zz__zz_decode_ENV_CTRL_2_61 == _zz__zz_decode_ENV_CTRL_2_62),{_zz__zz_decode_ENV_CTRL_2_63,{_zz__zz_decode_ENV_CTRL_2_65,_zz__zz_decode_ENV_CTRL_2_66}}};
+  assign _zz__zz_decode_ENV_CTRL_2_70 = {_zz_decode_ENV_CTRL_4,(_zz__zz_decode_ENV_CTRL_2_71 == _zz__zz_decode_ENV_CTRL_2_72)};
+  assign _zz__zz_decode_ENV_CTRL_2_73 = 2'b00;
+  assign _zz__zz_decode_ENV_CTRL_2_74 = ({_zz_decode_ENV_CTRL_4,_zz__zz_decode_ENV_CTRL_2_75} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_77 = ({_zz__zz_decode_ENV_CTRL_2_78,_zz__zz_decode_ENV_CTRL_2_81} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_84 = {(_zz__zz_decode_ENV_CTRL_2_85 != _zz__zz_decode_ENV_CTRL_2_88),{_zz__zz_decode_ENV_CTRL_2_89,{_zz__zz_decode_ENV_CTRL_2_97,_zz__zz_decode_ENV_CTRL_2_101}}};
+  assign _zz__zz_decode_ENV_CTRL_2_61 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_ENV_CTRL_2_62 = 32'h00001010;
+  assign _zz__zz_decode_ENV_CTRL_2_63 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_64) == 32'h00002010);
+  assign _zz__zz_decode_ENV_CTRL_2_65 = _zz_decode_ENV_CTRL_5;
+  assign _zz__zz_decode_ENV_CTRL_2_66 = {_zz__zz_decode_ENV_CTRL_2_67,_zz__zz_decode_ENV_CTRL_2_68};
+  assign _zz__zz_decode_ENV_CTRL_2_71 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_ENV_CTRL_2_72 = 32'h00000020;
+  assign _zz__zz_decode_ENV_CTRL_2_75 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_76) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_78 = (_zz__zz_decode_ENV_CTRL_2_79 == _zz__zz_decode_ENV_CTRL_2_80);
+  assign _zz__zz_decode_ENV_CTRL_2_81 = (_zz__zz_decode_ENV_CTRL_2_82 == _zz__zz_decode_ENV_CTRL_2_83);
+  assign _zz__zz_decode_ENV_CTRL_2_85 = (_zz__zz_decode_ENV_CTRL_2_86 == _zz__zz_decode_ENV_CTRL_2_87);
+  assign _zz__zz_decode_ENV_CTRL_2_88 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_89 = ({_zz__zz_decode_ENV_CTRL_2_90,_zz__zz_decode_ENV_CTRL_2_92} != 4'b0000);
+  assign _zz__zz_decode_ENV_CTRL_2_97 = (_zz__zz_decode_ENV_CTRL_2_98 != _zz__zz_decode_ENV_CTRL_2_100);
+  assign _zz__zz_decode_ENV_CTRL_2_101 = {_zz__zz_decode_ENV_CTRL_2_102,{_zz__zz_decode_ENV_CTRL_2_106,_zz__zz_decode_ENV_CTRL_2_109}};
+  assign _zz__zz_decode_ENV_CTRL_2_64 = 32'h00002010;
+  assign _zz__zz_decode_ENV_CTRL_2_67 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_ENV_CTRL_2_68 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_76 = 32'h00000020;
+  assign _zz__zz_decode_ENV_CTRL_2_79 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_ENV_CTRL_2_80 = 32'h00006010;
+  assign _zz__zz_decode_ENV_CTRL_2_82 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz__zz_decode_ENV_CTRL_2_83 = 32'h00004010;
+  assign _zz__zz_decode_ENV_CTRL_2_86 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_ENV_CTRL_2_87 = 32'h00002010;
+  assign _zz__zz_decode_ENV_CTRL_2_90 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_91) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_92 = {(_zz__zz_decode_ENV_CTRL_2_93 == _zz__zz_decode_ENV_CTRL_2_94),{_zz__zz_decode_ENV_CTRL_2_95,_zz__zz_decode_ENV_CTRL_2_96}};
+  assign _zz__zz_decode_ENV_CTRL_2_98 = ((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2_99) == 32'h0);
+  assign _zz__zz_decode_ENV_CTRL_2_100 = 1'b0;
+  assign _zz__zz_decode_ENV_CTRL_2_102 = ({_zz__zz_decode_ENV_CTRL_2_103,{_zz__zz_decode_ENV_CTRL_2_104,_zz__zz_decode_ENV_CTRL_2_105}} != 3'b000);
+  assign _zz__zz_decode_ENV_CTRL_2_106 = ({_zz__zz_decode_ENV_CTRL_2_107,_zz__zz_decode_ENV_CTRL_2_108} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_109 = ({_zz__zz_decode_ENV_CTRL_2_110,_zz__zz_decode_ENV_CTRL_2_111} != 2'b00);
+  assign _zz__zz_decode_ENV_CTRL_2_91 = 32'h00000044;
+  assign _zz__zz_decode_ENV_CTRL_2_93 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_ENV_CTRL_2_94 = 32'h0;
+  assign _zz__zz_decode_ENV_CTRL_2_95 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_ENV_CTRL_2_96 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_ENV_CTRL_2_99 = 32'h00000058;
+  assign _zz__zz_decode_ENV_CTRL_2_103 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_ENV_CTRL_2_104 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_ENV_CTRL_2_105 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_ENV_CTRL_2_107 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_ENV_CTRL_2_108 = _zz_decode_ENV_CTRL_3;
+  assign _zz__zz_decode_ENV_CTRL_2_110 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_ENV_CTRL_2_111 = _zz_decode_ENV_CTRL_3;
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_204) begin
-      _zz_124 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_39) begin
+  always @(posedge clk) begin
+    if(_zz_1) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
-    .io_push_valid            (iBus_rsp_valid                                                  ), //i
-    .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready              ), //o
-    .io_push_payload_error    (iBus_rsp_payload_error                                          ), //i
-    .io_push_payload_inst     (iBus_rsp_payload_inst[31:0]                                     ), //i
-    .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid               ), //o
-    .io_pop_ready             (_zz_121                                                         ), //i
-    .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error       ), //o
-    .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]  ), //o
-    .io_flush                 (_zz_122                                                         ), //i
-    .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy               ), //o
-    .clk                      (clk                                                             ), //i
-    .reset                    (reset                                                           )  //i
+    .io_push_valid            (iBus_rsp_valid                                             ), //i
+    .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready         ), //o
+    .io_push_payload_error    (iBus_rsp_payload_error                                     ), //i
+    .io_push_payload_inst     (iBus_rsp_payload_inst                                      ), //i
+    .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid          ), //o
+    .io_pop_ready             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready          ), //i
+    .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error  ), //o
+    .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst   ), //o
+    .io_flush                 (1'b0                                                       ), //i
+    .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy          ), //o
+    .clk                      (clk                                                        ), //i
+    .reset                    (reset                                                      )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1213,27 +1280,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1246,98 +1313,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
-      default : _zz_10_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
-      default : _zz_14_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1350,30 +1417,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
-      default : _zz_17_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -1385,27 +1452,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
-      default : _zz_20_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1418,30 +1485,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
-      default : _zz_23_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1453,11 +1520,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
-      default : _zz_26_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1469,11 +1536,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1485,11 +1552,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1502,30 +1569,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_29_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_29_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_29_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_29_string = "JALR";
-      default : _zz_29_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_31)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
-      default : _zz_31_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -1538,12 +1605,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
-      default : _zz_33_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -1556,12 +1623,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
-      default : _zz_34_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1573,147 +1640,147 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
-      default : _zz_35_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
-      default : _zz_36_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_40)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
-      default : _zz_40_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
-      default : _zz_41_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
-      default : _zz_42_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
-      default : _zz_44_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
-      default : _zz_45_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
-      default : _zz_46_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_73)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_73_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_73_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_73_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_73_string = "URS1        ";
-      default : _zz_73_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_74)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_74_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_74_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_74_string = "BITWISE ";
-      default : _zz_74_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_75)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_75_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_75_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_75_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_75_string = "PC ";
-      default : _zz_75_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_76)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_76_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_76_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_76_string = "AND_1";
-      default : _zz_76_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_77)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_77_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_77_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_77_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_77_string = "SRA_1    ";
-      default : _zz_77_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_78)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_78_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_78_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_78_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_78_string = "JALR";
-      default : _zz_78_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_79)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_79_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_79_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_79_string = "ECALL";
-      default : _zz_79_string = "?????";
+    case(_zz_decode_ENV_CTRL_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_7_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_7_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1744,19 +1811,19 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -1796,9 +1863,9 @@ module VexRiscv (
 
   assign memory_MEMORY_READ_DATA = dBus_rsp_data;
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = _zz_95;
+  assign execute_BRANCH_DO = _zz_execute_BRANCH_DO_1;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_81;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
@@ -1807,103 +1874,103 @@ module VexRiscv (
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_RS2 = decode_RegFilePlugin_rs2Data;
   assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_152[0];
-  assign decode_BRANCH_CTRL = _zz_8;
-  assign _zz_9 = _zz_10;
-  assign decode_SHIFT_CTRL = _zz_11;
-  assign _zz_12 = _zz_13;
-  assign decode_ALU_BITWISE_CTRL = _zz_14;
-  assign _zz_15 = _zz_16;
-  assign decode_SRC_LESS_UNSIGNED = _zz_153[0];
-  assign decode_MEMORY_STORE = _zz_154[0];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_ENV_CTRL_2[23];
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_ENV_CTRL_2[15];
+  assign decode_MEMORY_STORE = _zz_decode_ENV_CTRL_2[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_155[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_156[0];
-  assign decode_SRC2_CTRL = _zz_17;
-  assign _zz_18 = _zz_19;
-  assign decode_ALU_CTRL = _zz_20;
-  assign _zz_21 = _zz_22;
-  assign decode_MEMORY_ENABLE = _zz_157[0];
-  assign decode_SRC1_CTRL = _zz_23;
-  assign _zz_24 = _zz_25;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_ENV_CTRL_2[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_ENV_CTRL_2[10];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_MEMORY_ENABLE = _zz_decode_ENV_CTRL_2[3];
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_158[0];
+  assign decode_IS_EBREAK = _zz_decode_ENV_CTRL_2[26];
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_26;
-  assign execute_ENV_CTRL = _zz_27;
-  assign writeBack_ENV_CTRL = _zz_28;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_29;
-  assign decode_RS2_USE = _zz_159[0];
-  assign decode_RS1_USE = _zz_160[0];
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_ENV_CTRL_2[14];
+  assign decode_RS1_USE = _zz_decode_ENV_CTRL_2[4];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_30 = execute_REGFILE_WRITE_DATA;
-    if(_zz_125)begin
-      _zz_30 = _zz_88;
+  always @(*) begin
+    _zz_execute_to_memory_REGFILE_WRITE_DATA = execute_REGFILE_WRITE_DATA;
+    if(when_ShiftPlugins_l169) begin
+      _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(_zz_126)begin
-      _zz_30 = execute_CsrPlugin_readData;
+    if(when_CsrPlugin_l1176) begin
+      _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33;
-  assign execute_SRC1_CTRL = _zz_34;
-  assign decode_SRC_USE_SUB_LESS = _zz_161[0];
-  assign decode_SRC_ADD_ZERO = _zz_162[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_ENV_CTRL_2[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_ENV_CTRL_2[18];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35;
-  assign execute_SRC2 = _zz_87;
-  assign execute_SRC1 = _zz_82;
-  assign execute_ALU_BITWISE_CTRL = _zz_36;
-  assign _zz_37 = writeBack_INSTRUCTION;
-  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_39 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_39 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_1 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_163[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_ENV_CTRL_2[9];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_205) == 32'h00001073),{(_zz_206 == _zz_207),{_zz_208,{_zz_209,_zz_210}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
-  always @ (*) begin
-    _zz_47 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
+  always @(*) begin
+    _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusSimplePlugin_l558) begin
+      _zz_lastStageRegFileWrite_payload_data = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
@@ -1920,10 +1987,10 @@ module VexRiscv (
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
-  always @ (*) begin
-    _zz_48 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_48 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
@@ -1931,9 +1998,9 @@ module VexRiscv (
   assign decode_INSTRUCTION = IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    case(_zz_111)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -1942,137 +2009,137 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_89 || _zz_90)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61)))begin
+    if(when_DBusSimplePlugin_l426) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_125)begin
-      if((! execute_LightShifterPlugin_done))begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l184) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_126)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_127)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_127)begin
-      if(_zz_128)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_127)begin
-      if(_zz_128)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
+    if(when_DBusSimplePlugin_l479) begin
       memory_arbitration_haltItself = 1'b1;
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_129)begin
+    if(_zz_when) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_129)begin
+    if(_zz_when) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltItself = 1'b0;
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
   assign writeBack_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_130)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_131)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2081,65 +2148,67 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_130)begin
+    if(when_CsrPlugin_l1019) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_131)begin
+    if(when_CsrPlugin_l1064) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_127)begin
-      if(_zz_128)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusSimplePlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_132)begin
+    if(when_DebugPlugin_l300) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_incomingInstruction = 1'b0;
-    if(IBusSimplePlugin_iBusRsp_stages_1_input_valid)begin
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_valid) begin
       IBusSimplePlugin_incomingInstruction = 1'b1;
     end
-    if(IBusSimplePlugin_injector_decodeInput_valid)begin
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+  assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_130)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_131)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_130)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_131)begin
-      case(_zz_133)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2149,114 +2218,132 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
-  assign _zz_49 = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
-  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_164[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
-  always @ (*) begin
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
+  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_IBusSimplePlugin_jump_pcLoad_payload_1[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
+  always @(*) begin
     IBusSimplePlugin_fetchPc_correction = 1'b0;
-    if(IBusSimplePlugin_jump_pcLoad_valid)begin
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
       IBusSimplePlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
   assign IBusSimplePlugin_fetchPc_corrected = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusSimplePlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_ready) begin
       IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_167);
-    if(IBusSimplePlugin_jump_pcLoad_valid)begin
+  assign when_Fetcher_l131 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
       IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_jump_pcLoad_payload;
     end
     IBusSimplePlugin_fetchPc_pc[0] = 1'b0;
     IBusSimplePlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_fetchPc_flushed = 1'b0;
-    if(IBusSimplePlugin_jump_pcLoad_valid)begin
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
       IBusSimplePlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_valid = IBusSimplePlugin_fetchPc_output_valid;
   assign IBusSimplePlugin_fetchPc_output_ready = IBusSimplePlugin_iBusRsp_stages_0_input_ready;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
-    if((IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready))))begin
+    if(when_IBusSimplePlugin_l304) begin
       IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_50 = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_50);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_50);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_payload = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
   assign IBusSimplePlugin_iBusRsp_stages_1_halt = 1'b0;
-  assign _zz_51 = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_51);
-  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_51);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_52;
-  assign _zz_52 = ((1'b0 && (! _zz_53)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_53 = _zz_54;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_53;
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
-    if(IBusSimplePlugin_injector_decodeInput_valid)begin
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
-    if((! IBusSimplePlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
   assign IBusSimplePlugin_iBusRsp_output_ready = ((1'b0 && (! IBusSimplePlugin_injector_decodeInput_valid)) || IBusSimplePlugin_injector_decodeInput_ready);
-  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_55;
-  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_56;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_57;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_58;
-  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_59;
+  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  assign when_Fetcher_l320 = (! IBusSimplePlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
   assign IBusSimplePlugin_pcValids_3 = IBusSimplePlugin_injector_nextPcCalc_valids_4;
   assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
-    case(_zz_111)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -2271,8 +2358,9 @@ module VexRiscv (
   assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
   assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
   assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
-  assign IBusSimplePlugin_pending_next = (_zz_168 - _zz_172);
+  assign IBusSimplePlugin_pending_next = (_zz_IBusSimplePlugin_pending_next - _zz_IBusSimplePlugin_pending_next_3);
   assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
+  assign when_IBusSimplePlugin_l304 = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready)));
   assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
   assign IBusSimplePlugin_pending_inc = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
   assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
@@ -2280,17 +2368,18 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
-  assign _zz_121 = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && _zz_121);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
+  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
-    if((! IBusSimplePlugin_rspJoin_rspBuffer_output_valid))begin
+    if(when_IBusSimplePlugin_l375) begin
       IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = 1'b0;
     end
   end
 
   assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
+  assign when_IBusSimplePlugin_l375 = (! IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
   assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
@@ -2299,80 +2388,84 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready) : IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign _zz_60 = (! IBusSimplePlugin_rspJoin_exceptionDetected);
-  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_60);
-  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_60);
+  assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
+  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
+  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
   assign IBusSimplePlugin_iBusRsp_output_payload_pc = IBusSimplePlugin_rspJoin_join_payload_pc;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_error = IBusSimplePlugin_rspJoin_join_payload_rsp_error;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_inst = IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   assign IBusSimplePlugin_iBusRsp_output_payload_isRvc = IBusSimplePlugin_rspJoin_join_payload_isRvc;
-  assign _zz_61 = 1'b0;
-  always @ (*) begin
+  assign _zz_dBus_cmd_valid = 1'b0;
+  always @(*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
-    if(execute_ALIGNEMENT_FAULT)begin
+    if(execute_ALIGNEMENT_FAULT) begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_62 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_dBus_cmd_payload_data = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_62 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_dBus_cmd_payload_data = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_62 = execute_RS2[31 : 0];
+        _zz_dBus_cmd_payload_data = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_62;
-  always @ (*) begin
+  assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
+  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_63 = 4'b0001;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0001;
       end
       2'b01 : begin
-        _zz_63 = 4'b0011;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b0011;
       end
       default : begin
-        _zz_63 = 4'b1111;
+        _zz_execute_DBusSimplePlugin_formalMask = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_63 <<< dBus_cmd_payload_address[1 : 0]);
+  assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_134)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
+    if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
+    if(when_DBusSimplePlugin_l512) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_134)begin
+    if(when_DBusSimplePlugin_l486) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
-    if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_177};
+    if(memory_ALIGNEMENT_FAULT) begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_DBusSimplePlugin_memoryExceptionPort_payload_code};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusSimplePlugin_l486 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l512 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
@@ -2389,63 +2482,64 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_64 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_65[31] = _zz_64;
-    _zz_65[30] = _zz_64;
-    _zz_65[29] = _zz_64;
-    _zz_65[28] = _zz_64;
-    _zz_65[27] = _zz_64;
-    _zz_65[26] = _zz_64;
-    _zz_65[25] = _zz_64;
-    _zz_65[24] = _zz_64;
-    _zz_65[23] = _zz_64;
-    _zz_65[22] = _zz_64;
-    _zz_65[21] = _zz_64;
-    _zz_65[20] = _zz_64;
-    _zz_65[19] = _zz_64;
-    _zz_65[18] = _zz_64;
-    _zz_65[17] = _zz_64;
-    _zz_65[16] = _zz_64;
-    _zz_65[15] = _zz_64;
-    _zz_65[14] = _zz_64;
-    _zz_65[13] = _zz_64;
-    _zz_65[12] = _zz_64;
-    _zz_65[11] = _zz_64;
-    _zz_65[10] = _zz_64;
-    _zz_65[9] = _zz_64;
-    _zz_65[8] = _zz_64;
-    _zz_65[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[30] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[29] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[28] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[27] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[26] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[25] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[24] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[23] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[22] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[21] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[20] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[19] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[18] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[17] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[16] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[15] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[14] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[13] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[12] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[11] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[10] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[9] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[8] = _zz_writeBack_DBusSimplePlugin_rspFormated;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_1[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_66 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_67[31] = _zz_66;
-    _zz_67[30] = _zz_66;
-    _zz_67[29] = _zz_66;
-    _zz_67[28] = _zz_66;
-    _zz_67[27] = _zz_66;
-    _zz_67[26] = _zz_66;
-    _zz_67[25] = _zz_66;
-    _zz_67[24] = _zz_66;
-    _zz_67[23] = _zz_66;
-    _zz_67[22] = _zz_66;
-    _zz_67[21] = _zz_66;
-    _zz_67[20] = _zz_66;
-    _zz_67[19] = _zz_66;
-    _zz_67[18] = _zz_66;
-    _zz_67[17] = _zz_66;
-    _zz_67[16] = _zz_66;
-    _zz_67[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusSimplePlugin_rspFormated_2 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[31] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[30] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[29] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[28] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[27] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[26] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[25] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[24] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[23] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[22] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[21] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[20] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[19] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[18] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[17] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[16] = _zz_writeBack_DBusSimplePlugin_rspFormated_2;
+    _zz_writeBack_DBusSimplePlugin_rspFormated_3[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_150)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_65;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_67;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_3;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2453,59 +2547,61 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_69 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_70 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_71 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_72 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_68 = {(((decode_INSTRUCTION & _zz_223) == 32'h00100050) != 1'b0),{((_zz_224 == _zz_225) != 1'b0),{(_zz_226 != 1'b0),{(_zz_227 != _zz_228),{_zz_229,{_zz_230,_zz_231}}}}}};
-  assign _zz_73 = _zz_68[1 : 0];
-  assign _zz_46 = _zz_73;
-  assign _zz_74 = _zz_68[6 : 5];
-  assign _zz_45 = _zz_74;
-  assign _zz_75 = _zz_68[8 : 7];
-  assign _zz_44 = _zz_75;
-  assign _zz_76 = _zz_68[17 : 16];
-  assign _zz_43 = _zz_76;
-  assign _zz_77 = _zz_68[20 : 19];
-  assign _zz_42 = _zz_77;
-  assign _zz_78 = _zz_68[22 : 21];
-  assign _zz_41 = _zz_78;
-  assign _zz_79 = _zz_68[25 : 24];
-  assign _zz_40 = _zz_79;
+  assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_decode_ENV_CTRL_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_ENV_CTRL_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_ENV_CTRL_5 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_decode_ENV_CTRL_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_ENV_CTRL_2 = {(((decode_INSTRUCTION & _zz__zz_decode_ENV_CTRL_2) == 32'h00100050) != 1'b0),{((_zz__zz_decode_ENV_CTRL_2_1 == _zz__zz_decode_ENV_CTRL_2_2) != 1'b0),{(_zz__zz_decode_ENV_CTRL_2_3 != 1'b0),{(_zz__zz_decode_ENV_CTRL_2_4 != _zz__zz_decode_ENV_CTRL_2_9),{_zz__zz_decode_ENV_CTRL_2_10,{_zz__zz_decode_ENV_CTRL_2_12,_zz__zz_decode_ENV_CTRL_2_14}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_ENV_CTRL_2[1 : 0];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_ENV_CTRL_2[6 : 5];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_ENV_CTRL_2[8 : 7];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_ENV_CTRL_2[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_ENV_CTRL_2[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_ENV_CTRL_2[22 : 21];
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_7 = _zz_decode_ENV_CTRL_2[25 : 24];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_7;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_123;
-  assign decode_RegFilePlugin_rs2Data = _zz_124;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
-    if(_zz_80)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_2) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
-    if(_zz_80)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_47;
-    if(_zz_80)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_lastStageRegFileWrite_payload_data;
+    if(_zz_2) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -2514,392 +2610,434 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_81 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_81 = {31'd0, _zz_178};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_81 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_82 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_82 = {29'd0, _zz_179};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_82 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_82 = {27'd0, _zz_180};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_83 = _zz_181[11];
-  always @ (*) begin
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7] = _zz_83;
-    _zz_84[6] = _zz_83;
-    _zz_84[5] = _zz_83;
-    _zz_84[4] = _zz_83;
-    _zz_84[3] = _zz_83;
-    _zz_84[2] = _zz_83;
-    _zz_84[1] = _zz_83;
-    _zz_84[0] = _zz_83;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_85 = _zz_182[11];
-  always @ (*) begin
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15] = _zz_85;
-    _zz_86[14] = _zz_85;
-    _zz_86[13] = _zz_85;
-    _zz_86[12] = _zz_85;
-    _zz_86[11] = _zz_85;
-    _zz_86[10] = _zz_85;
-    _zz_86[9] = _zz_85;
-    _zz_86[8] = _zz_85;
-    _zz_86[7] = _zz_85;
-    _zz_86[6] = _zz_85;
-    _zz_86[5] = _zz_85;
-    _zz_86[4] = _zz_85;
-    _zz_86[3] = _zz_85;
-    _zz_86[2] = _zz_85;
-    _zz_86[1] = _zz_85;
-    _zz_86[0] = _zz_85;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_87 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_87 = {_zz_84,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_87 = {_zz_86,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_87 = _zz_32;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_183;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
-  always @ (*) begin
+  assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_88 = (execute_LightShifterPlugin_shiftInput <<< 1);
+      `ShiftCtrlEnum_defaultEncoding_SLL : begin
+        _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_88 = _zz_190;
+        _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1;
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_89 = 1'b0;
-    if(_zz_91)begin
-      if((_zz_92 == decode_INSTRUCTION[19 : 15]))begin
-        _zz_89 = 1'b1;
+  assign when_ShiftPlugins_l175 = (! execute_arbitration_isStuckByOthers);
+  assign when_ShiftPlugins_l184 = (! execute_LightShifterPlugin_done);
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        HazardSimplePlugin_src0Hazard = 1'b1;
       end
     end
-    if(_zz_135)begin
-      if(_zz_136)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l59) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_137)begin
-      if(_zz_138)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l59_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_139)begin
-      if(_zz_140)begin
-        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_89 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l59_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_89 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  always @ (*) begin
-    _zz_90 = 1'b0;
-    if(_zz_91)begin
-      if((_zz_92 == decode_INSTRUCTION[24 : 20]))begin
-        _zz_90 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        HazardSimplePlugin_src1Hazard = 1'b1;
       end
     end
-    if(_zz_135)begin
-      if(_zz_136)begin
-        if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l62) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_137)begin
-      if(_zz_138)begin
-        if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l62_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if(_zz_139)begin
-      if(_zz_140)begin
-        if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_90 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l62_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS2_USE))begin
-      _zz_90 = 1'b0;
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
     end
   end
 
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_lastStageRegFileWrite_payload_data;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l59 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b1 || (! 1'b1));
+  assign when_HazardSimplePlugin_l59_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l59_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l62_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_93 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_93 == 3'b000)) begin
-        _zz_94 = execute_BranchPlugin_eq;
-    end else if((_zz_93 == 3'b001)) begin
-        _zz_94 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_93 & 3'b101) == 3'b101))) begin
-        _zz_94 = (! execute_SRC_LESS);
-    end else begin
-        _zz_94 = execute_SRC_LESS;
-    end
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_95 = 1'b0;
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_95 = 1'b1;
+      3'b001 : begin
+        _zz_execute_BRANCH_DO = (! execute_BranchPlugin_eq);
       end
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_95 = 1'b1;
+      3'b1?1 : begin
+        _zz_execute_BRANCH_DO = (! execute_SRC_LESS);
       end
       default : begin
-        _zz_95 = _zz_94;
+        _zz_execute_BRANCH_DO = execute_SRC_LESS;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : begin
+        _zz_execute_BRANCH_DO_1 = 1'b0;
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_execute_BRANCH_DO_1 = 1'b1;
+      end
+      default : begin
+        _zz_execute_BRANCH_DO_1 = _zz_execute_BRANCH_DO;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_96 = _zz_192[19];
-  always @ (*) begin
-    _zz_97[10] = _zz_96;
-    _zz_97[9] = _zz_96;
-    _zz_97[8] = _zz_96;
-    _zz_97[7] = _zz_96;
-    _zz_97[6] = _zz_96;
-    _zz_97[5] = _zz_96;
-    _zz_97[4] = _zz_96;
-    _zz_97[3] = _zz_96;
-    _zz_97[2] = _zz_96;
-    _zz_97[1] = _zz_96;
-    _zz_97[0] = _zz_96;
+  assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  assign _zz_98 = _zz_193[11];
-  always @ (*) begin
-    _zz_99[19] = _zz_98;
-    _zz_99[18] = _zz_98;
-    _zz_99[17] = _zz_98;
-    _zz_99[16] = _zz_98;
-    _zz_99[15] = _zz_98;
-    _zz_99[14] = _zz_98;
-    _zz_99[13] = _zz_98;
-    _zz_99[12] = _zz_98;
-    _zz_99[11] = _zz_98;
-    _zz_99[10] = _zz_98;
-    _zz_99[9] = _zz_98;
-    _zz_99[8] = _zz_98;
-    _zz_99[7] = _zz_98;
-    _zz_99[6] = _zz_98;
-    _zz_99[5] = _zz_98;
-    _zz_99[4] = _zz_98;
-    _zz_99[3] = _zz_98;
-    _zz_99[2] = _zz_98;
-    _zz_99[1] = _zz_98;
-    _zz_99[0] = _zz_98;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[19] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[18] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[17] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[16] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[15] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[14] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[13] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[12] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[11] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_100 = _zz_194[11];
-  always @ (*) begin
-    _zz_101[18] = _zz_100;
-    _zz_101[17] = _zz_100;
-    _zz_101[16] = _zz_100;
-    _zz_101[15] = _zz_100;
-    _zz_101[14] = _zz_100;
-    _zz_101[13] = _zz_100;
-    _zz_101[12] = _zz_100;
-    _zz_101[11] = _zz_100;
-    _zz_101[10] = _zz_100;
-    _zz_101[9] = _zz_100;
-    _zz_101[8] = _zz_100;
-    _zz_101[7] = _zz_100;
-    _zz_101[6] = _zz_100;
-    _zz_101[5] = _zz_100;
-    _zz_101[4] = _zz_100;
-    _zz_101[3] = _zz_100;
-    _zz_101[2] = _zz_100;
-    _zz_101[1] = _zz_100;
-    _zz_101[0] = _zz_100;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_102 = {{_zz_97,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_102 = {_zz_99,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_102 = {{_zz_101,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_102;
+  assign execute_BranchPlugin_branch_src2 = _zz_execute_BranchPlugin_branch_src2_6;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_privilege = 2'b11;
-    if(CsrPlugin_forceMachineWire)begin
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_103 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_104 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_105 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_106 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_107 = _zz_195[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_129)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -2910,8 +3048,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -2921,72 +3059,79 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CSR_WRITE_OPCODE)begin
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CSR_WRITE_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_141)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_142)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_142)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -2999,43 +3144,53 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_141)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_141)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_151)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_109 = (_zz_108 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_109 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_143)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusSimplePlugin_injectionPort_ready;
           end
         end
@@ -3045,9 +3200,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_110))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3056,12 +3211,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusSimplePlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_143)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusSimplePlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -3072,33 +3228,92 @@ module VexRiscv (
   end
 
   assign IBusSimplePlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_25 = decode_SRC1_CTRL;
-  assign _zz_23 = _zz_46;
-  assign _zz_34 = decode_to_execute_SRC1_CTRL;
-  assign _zz_22 = decode_ALU_CTRL;
-  assign _zz_20 = _zz_45;
-  assign _zz_35 = decode_to_execute_ALU_CTRL;
-  assign _zz_19 = decode_SRC2_CTRL;
-  assign _zz_17 = _zz_44;
-  assign _zz_33 = decode_to_execute_SRC2_CTRL;
-  assign _zz_16 = decode_ALU_BITWISE_CTRL;
-  assign _zz_14 = _zz_43;
-  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_13 = decode_SHIFT_CTRL;
-  assign _zz_11 = _zz_42;
-  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_10 = decode_BRANCH_CTRL;
-  assign _zz_8 = _zz_41;
-  assign _zz_29 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_40;
-  assign _zz_27 = decode_to_execute_ENV_CTRL;
-  assign _zz_26 = execute_to_memory_ENV_CTRL;
-  assign _zz_28 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_14 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_17 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_43 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3119,9 +3334,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusSimplePlugin_injectionPort_ready = 1'b0;
-    case(_zz_111)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusSimplePlugin_injectionPort_ready = 1'b1;
       end
@@ -3130,85 +3351,99 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_112 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_112[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_112[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_112[3 : 3] = CsrPlugin_mstatus_MIE;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  assign when_Fetcher_l398 = (switch_Fetcher_l362 != 3'b000);
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_113 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_113[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_113[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_113[3 : 3] = CsrPlugin_mip_MSIP;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_114 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_114[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_114[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_114[3 : 3] = CsrPlugin_mie_MSIE;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_4[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_115 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_115[31 : 0] = CsrPlugin_mepc;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_116 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_116[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_116[3 : 0] = CsrPlugin_mcause_exceptionCode;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_117 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_117[31 : 0] = CsrPlugin_mtval;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_118 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_118[31 : 0] = _zz_108;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_119 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_119[31 : 0] = _zz_109;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_112 | _zz_113) | (_zz_114 | _zz_115)) | ((_zz_116 | _zz_117) | (_zz_118 | _zz_119)));
+  assign CsrPlugin_csrMapping_readDataInit = (((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9)));
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBus_cmd_ready = ((1'b1 && (! iBus_cmd_m2sPipe_valid)) || iBus_cmd_m2sPipe_ready);
-  assign iBus_cmd_m2sPipe_valid = iBus_cmd_m2sPipe_rValid;
-  assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_m2sPipe_rData_pc;
+  assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
+  assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
   assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
   assign iBusWishbone_CTI = 3'b000;
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
   assign iBusWishbone_CYC = iBus_cmd_m2sPipe_valid;
   assign iBusWishbone_STB = iBus_cmd_m2sPipe_valid;
   assign iBus_cmd_m2sPipe_ready = (iBus_cmd_m2sPipe_valid && iBusWishbone_ACK);
   assign iBus_rsp_valid = (iBusWishbone_CYC && iBusWishbone_ACK);
   assign iBus_rsp_payload_inst = iBusWishbone_DAT_MISO;
   assign iBus_rsp_payload_error = 1'b0;
+  assign when_Stream_l399 = (! dBus_cmd_halfPipe_regs_valid);
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
   assign dBus_cmd_halfPipe_payload_wr = dBus_cmd_halfPipe_regs_payload_wr;
   assign dBus_cmd_halfPipe_payload_address = dBus_cmd_halfPipe_regs_payload_address;
@@ -3218,27 +3453,28 @@ module VexRiscv (
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
   assign dBusWishbone_CTI = 3'b000;
   assign dBusWishbone_BTE = 2'b00;
-  always @ (*) begin
+  always @(*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_120 = 4'b0001;
+        _zz_dBusWishbone_SEL = 4'b0001;
       end
       2'b01 : begin
-        _zz_120 = 4'b0011;
+        _zz_dBusWishbone_SEL = 4'b0011;
       end
       default : begin
-        _zz_120 = 4'b1111;
+        _zz_dBusWishbone_SEL = 4'b1111;
       end
     endcase
   end
 
-  always @ (*) begin
-    dBusWishbone_SEL = (_zz_120 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
-    if((! dBus_cmd_halfPipe_payload_wr))begin
+  always @(*) begin
+    dBusWishbone_SEL = (_zz_dBusWishbone_SEL <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    if(when_DBusSimplePlugin_l189) begin
       dBusWishbone_SEL = 4'b1111;
     end
   end
 
+  assign when_DBusSimplePlugin_l189 = (! dBus_cmd_halfPipe_payload_wr);
   assign dBusWishbone_WE = dBus_cmd_halfPipe_payload_wr;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_halfPipe_payload_data;
   assign dBus_cmd_halfPipe_ready = (dBus_cmd_halfPipe_valid && dBusWishbone_ACK);
@@ -3247,15 +3483,14 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
-  assign _zz_122 = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_54 <= 1'b0;
-      _zz_55 <= 1'b0;
+      _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
@@ -3263,9 +3498,9 @@ module VexRiscv (
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusSimplePlugin_pending_value <= 3'b000;
       IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
-      _zz_80 <= 1'b1;
+      _zz_2 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_91 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
       CsrPlugin_mstatus_MPP <= 2'b11;
@@ -3282,92 +3517,92 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_108 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_111 <= 3'b000;
-      iBus_cmd_m2sPipe_rValid <= 1'b0;
+      switch_Fetcher_l362 <= 3'b000;
+      iBus_cmd_rValid <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
-      if(IBusSimplePlugin_fetchPc_correction)begin
+      if(IBusSimplePlugin_fetchPc_correction) begin
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusSimplePlugin_fetchPc_booted <= 1'b1;
-      if((IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
-      if(IBusSimplePlugin_iBusRsp_flush)begin
-        _zz_54 <= 1'b0;
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_52)begin
-        _zz_54 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready_2 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(decode_arbitration_removeIt)begin
-        _zz_55 <= 1'b0;
+      if(decode_arbitration_removeIt) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       end
-      if(IBusSimplePlugin_iBusRsp_output_ready)begin
-        _zz_55 <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
+      if(IBusSimplePlugin_iBusRsp_output_ready) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusSimplePlugin_injector_decodeInput_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= IBusSimplePlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusSimplePlugin_fetchPc_flushed)begin
+      if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
       IBusSimplePlugin_pending_value <= IBusSimplePlugin_pending_next;
-      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_174);
-      if(IBusSimplePlugin_iBusRsp_flush)begin
-        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_176);
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter);
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
@@ -3389,72 +3624,72 @@ module VexRiscv (
           end
         `endif
       `endif
-      _zz_80 <= 1'b0;
-      if(_zz_125)begin
-        if(_zz_144)begin
+      _zz_2 <= 1'b0;
+      if(when_ShiftPlugins_l169) begin
+        if(when_ShiftPlugins_l175) begin
           execute_LightShifterPlugin_isActive <= 1'b1;
-          if(execute_LightShifterPlugin_done)begin
+          if(execute_LightShifterPlugin_done) begin
             execute_LightShifterPlugin_isActive <= 1'b0;
           end
         end
       end
-      if(execute_arbitration_removeIt)begin
+      if(execute_arbitration_removeIt) begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_91 <= (_zz_38 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_145)begin
-        if(_zz_146)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_147)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_148)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_130)begin
+      if(when_CsrPlugin_l1019) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3465,8 +3700,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_131)begin
-        case(_zz_133)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3476,71 +3711,71 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_105,{_zz_104,_zz_103}} != 3'b000) || CsrPlugin_thirdPartyWake);
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_111)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusSimplePlugin_injectionPort_valid)begin
-            _zz_111 <= 3'b001;
+          if(IBusSimplePlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_111 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_111 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_111 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_111 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_197[0];
-          CsrPlugin_mstatus_MIE <= _zz_198[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_200[0];
-          CsrPlugin_mie_MTIE <= _zz_201[0];
-          CsrPlugin_mie_MSIE <= _zz_202[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_108 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(iBus_cmd_ready)begin
-        iBus_cmd_m2sPipe_rValid <= iBus_cmd_valid;
+      if(iBus_cmd_ready) begin
+        iBus_cmd_rValid <= iBus_cmd_valid;
       end
-      if(_zz_149)begin
+      if(when_Stream_l399) begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3550,62 +3785,63 @@ module VexRiscv (
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusSimplePlugin_iBusRsp_output_ready)begin
-      _zz_56 <= IBusSimplePlugin_iBusRsp_output_payload_pc;
-      _zz_57 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
-      _zz_58 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
-      _zz_59 <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+  always @(posedge clk) begin
+    if(IBusSimplePlugin_iBusRsp_output_ready) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_pc <= IBusSimplePlugin_iBusRsp_output_payload_pc;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
     end
-    if(IBusSimplePlugin_injector_decodeInput_ready)begin
+    if(IBusSimplePlugin_injector_decodeInput_ready) begin
       IBusSimplePlugin_injector_formal_rawInDecode <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
     end
-    if(_zz_125)begin
-      if(_zz_144)begin
+    if(when_ShiftPlugins_l169) begin
+      if(when_ShiftPlugins_l175) begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_92 <= _zz_37[11 : 7];
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(decodeExceptionPort_valid)begin
+    if(decodeExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_129)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_145)begin
-      if(_zz_146)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_147)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_148)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_130)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -3614,197 +3850,197 @@ module VexRiscv (
       endcase
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_6) begin
       decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_48;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_24;
+    if(when_Pipeline_l124_9) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_10) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_21;
+    if(when_Pipeline_l124_14) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_18;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_16) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15;
+    if(when_Pipeline_l124_26) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_12;
+    if(when_Pipeline_l124_27) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_9;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_30) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_31) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_32) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_33) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_34) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_35) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    if(when_Pipeline_l124_42) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if((_zz_111 != 3'b000))begin
-      _zz_58 <= IBusSimplePlugin_injectionPort_payload;
+    if(when_Fetcher_l398) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_injectionPort_payload;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_199[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(iBus_cmd_ready)begin
-      iBus_cmd_m2sPipe_rData_pc <= iBus_cmd_payload_pc;
+    if(iBus_cmd_ready) begin
+      iBus_cmd_rData_pc <= iBus_cmd_payload_pc;
     end
-    if(_zz_149)begin
+    if(when_Stream_l399) begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -3812,56 +4048,67 @@ module VexRiscv (
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusSimplePlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_47;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_lastStageRegFileWrite_payload_data;
     end
-    _zz_110 <= debug_bus_cmd_payload_address[2];
-    if(_zz_127)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_143)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -3869,14 +4116,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_127)begin
-        if(_zz_128)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_132)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -3900,9 +4147,7 @@ module StreamFifoLowLatency (
   input               clk,
   input               reset
 );
-  wire                _zz_4;
-  wire       [0:0]    _zz_5;
-  reg                 _zz_1;
+  reg                 when_Phase_l623;
   reg                 pushPtr_willIncrement;
   reg                 pushPtr_willClear;
   wire                pushPtr_willOverflowIfInc;
@@ -3917,44 +4162,44 @@ module StreamFifoLowLatency (
   wire                full;
   wire                pushing;
   wire                popping;
-  wire       [32:0]   _zz_2;
-  reg        [32:0]   _zz_3;
+  wire                when_Stream_l1017;
+  wire       [32:0]   _zz_io_pop_payload_error;
+  wire                when_Stream_l1030;
+  reg        [32:0]   _zz_io_pop_payload_error_1;
 
-  assign _zz_4 = (! empty);
-  assign _zz_5 = _zz_2[0 : 0];
-  always @ (*) begin
-    _zz_1 = 1'b0;
-    if(pushing)begin
-      _zz_1 = 1'b1;
+  always @(*) begin
+    when_Phase_l623 = 1'b0;
+    if(pushing) begin
+      when_Phase_l623 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     pushPtr_willIncrement = 1'b0;
-    if(pushing)begin
+    if(pushing) begin
       pushPtr_willIncrement = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     pushPtr_willClear = 1'b0;
-    if(io_flush)begin
+    if(io_flush) begin
       pushPtr_willClear = 1'b1;
     end
   end
 
   assign pushPtr_willOverflowIfInc = 1'b1;
   assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @ (*) begin
+  always @(*) begin
     popPtr_willIncrement = 1'b0;
-    if(popping)begin
+    if(popping) begin
       popPtr_willIncrement = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     popPtr_willClear = 1'b0;
-    if(io_flush)begin
+    if(io_flush) begin
       popPtr_willClear = 1'b1;
     end
   end
@@ -3967,48 +4212,50 @@ module StreamFifoLowLatency (
   assign pushing = (io_push_valid && io_push_ready);
   assign popping = (io_pop_valid && io_pop_ready);
   assign io_push_ready = (! full);
-  always @ (*) begin
-    if(_zz_4)begin
+  assign when_Stream_l1017 = (! empty);
+  always @(*) begin
+    if(when_Stream_l1017) begin
       io_pop_valid = 1'b1;
     end else begin
       io_pop_valid = io_push_valid;
     end
   end
 
-  assign _zz_2 = _zz_3;
-  always @ (*) begin
-    if(_zz_4)begin
-      io_pop_payload_error = _zz_5[0];
+  assign _zz_io_pop_payload_error = _zz_io_pop_payload_error_1;
+  always @(*) begin
+    if(when_Stream_l1017) begin
+      io_pop_payload_error = _zz_io_pop_payload_error[0];
     end else begin
       io_pop_payload_error = io_push_payload_error;
     end
   end
 
-  always @ (*) begin
-    if(_zz_4)begin
-      io_pop_payload_inst = _zz_2[32 : 1];
+  always @(*) begin
+    if(when_Stream_l1017) begin
+      io_pop_payload_inst = _zz_io_pop_payload_error[32 : 1];
     end else begin
       io_pop_payload_inst = io_push_payload_inst;
     end
   end
 
+  assign when_Stream_l1030 = (pushing != popping);
   assign io_occupancy = (risingOccupancy && ptrMatch);
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       risingOccupancy <= 1'b0;
     end else begin
-      if((pushing != popping))begin
+      if(when_Stream_l1030) begin
         risingOccupancy <= pushing;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         risingOccupancy <= 1'b0;
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_1)begin
-      _zz_3 <= {io_push_payload_inst,io_push_payload_error};
+  always @(posedge clk) begin
+    if(when_Phase_l623) begin
+      _zz_io_pop_payload_error_1 <= {io_push_payload_inst,io_push_payload_error};
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Secure.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Secure.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -42,6 +42,13 @@
 `define Src1CtrlEnum_defaultEncoding_IMU 2'b01
 `define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
 `define Src1CtrlEnum_defaultEncoding_URS1 2'b11
+
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_type [2:0]
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT 3'b000
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle 3'b001
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite 3'b010
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg 3'b011
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr 3'b100
 
 
 module VexRiscv (
@@ -74,55 +81,42 @@ module VexRiscv (
   input               clk,
   input               reset
 );
-  wire                _zz_622;
-  wire                _zz_623;
-  wire                _zz_624;
-  wire                _zz_625;
-  wire                _zz_626;
-  wire                _zz_627;
-  wire                _zz_628;
-  wire                _zz_629;
-  reg                 _zz_630;
-  wire                _zz_631;
-  wire       [31:0]   _zz_632;
-  wire                _zz_633;
-  wire       [31:0]   _zz_634;
-  reg                 _zz_635;
-  wire                _zz_636;
-  wire                _zz_637;
-  wire       [31:0]   _zz_638;
-  wire                _zz_639;
-  wire                _zz_640;
-  wire                _zz_641;
-  wire                _zz_642;
-  wire                _zz_643;
-  wire                _zz_644;
-  wire                _zz_645;
-  wire                _zz_646;
-  wire       [3:0]    _zz_647;
-  wire                _zz_648;
-  wire                _zz_649;
-  reg        [31:0]   _zz_650;
-  reg        [31:0]   _zz_651;
-  reg        [31:0]   _zz_652;
-  reg        [4:0]    _zz_653;
-  reg        [4:0]    _zz_654;
-  reg        [4:0]    _zz_655;
-  reg        [4:0]    _zz_656;
-  reg        [4:0]    _zz_657;
-  reg        [4:0]    _zz_658;
-  reg                 _zz_659;
-  reg                 _zz_660;
-  reg                 _zz_661;
-  reg        [4:0]    _zz_662;
-  reg        [4:0]    _zz_663;
-  reg        [4:0]    _zz_664;
-  reg        [4:0]    _zz_665;
-  reg        [4:0]    _zz_666;
-  reg        [4:0]    _zz_667;
-  reg                 _zz_668;
-  reg                 _zz_669;
-  reg                 _zz_670;
+  reg        [31:0]   PmpPlugin_setter_io_addr;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port0;
+  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port2;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
+  wire       [24:0]   PmpPlugin_setter_io_base;
+  wire       [24:0]   PmpPlugin_setter_io_mask;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -145,6 +139,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -153,524 +148,450 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_671;
-  wire                _zz_672;
-  wire                _zz_673;
-  wire                _zz_674;
-  wire                _zz_675;
-  wire                _zz_676;
-  wire                _zz_677;
-  wire                _zz_678;
-  wire                _zz_679;
-  wire                _zz_680;
-  wire                _zz_681;
-  wire                _zz_682;
-  wire                _zz_683;
-  wire                _zz_684;
-  wire       [1:0]    _zz_685;
-  wire                _zz_686;
-  wire                _zz_687;
-  wire                _zz_688;
-  wire                _zz_689;
-  wire                _zz_690;
-  wire                _zz_691;
-  wire                _zz_692;
-  wire                _zz_693;
-  wire                _zz_694;
-  wire                _zz_695;
-  wire                _zz_696;
-  wire                _zz_697;
-  wire       [1:0]    _zz_698;
-  wire                _zz_699;
-  wire                _zz_700;
-  wire                _zz_701;
-  wire                _zz_702;
-  wire                _zz_703;
-  wire                _zz_704;
-  wire                _zz_705;
-  wire                _zz_706;
-  wire                _zz_707;
-  wire                _zz_708;
-  wire                _zz_709;
-  wire                _zz_710;
-  wire                _zz_711;
-  wire                _zz_712;
-  wire                _zz_713;
-  wire                _zz_714;
-  wire                _zz_715;
-  wire                _zz_716;
-  wire                _zz_717;
-  wire                _zz_718;
-  wire                _zz_719;
-  wire                _zz_720;
-  wire                _zz_721;
-  wire                _zz_722;
-  wire       [1:0]    _zz_723;
-  wire                _zz_724;
-  wire       [1:0]    _zz_725;
-  wire       [51:0]   _zz_726;
-  wire       [51:0]   _zz_727;
-  wire       [51:0]   _zz_728;
-  wire       [32:0]   _zz_729;
-  wire       [51:0]   _zz_730;
-  wire       [49:0]   _zz_731;
-  wire       [51:0]   _zz_732;
-  wire       [49:0]   _zz_733;
-  wire       [51:0]   _zz_734;
-  wire       [32:0]   _zz_735;
-  wire       [31:0]   _zz_736;
-  wire       [32:0]   _zz_737;
-  wire       [0:0]    _zz_738;
-  wire       [0:0]    _zz_739;
-  wire       [0:0]    _zz_740;
-  wire       [0:0]    _zz_741;
-  wire       [0:0]    _zz_742;
-  wire       [0:0]    _zz_743;
-  wire       [0:0]    _zz_744;
-  wire       [0:0]    _zz_745;
-  wire       [0:0]    _zz_746;
-  wire       [0:0]    _zz_747;
-  wire       [0:0]    _zz_748;
-  wire       [0:0]    _zz_749;
-  wire       [0:0]    _zz_750;
-  wire       [0:0]    _zz_751;
-  wire       [0:0]    _zz_752;
-  wire       [0:0]    _zz_753;
-  wire       [0:0]    _zz_754;
-  wire       [3:0]    _zz_755;
-  wire       [2:0]    _zz_756;
-  wire       [31:0]   _zz_757;
-  wire       [11:0]   _zz_758;
-  wire       [31:0]   _zz_759;
-  wire       [19:0]   _zz_760;
-  wire       [11:0]   _zz_761;
-  wire       [31:0]   _zz_762;
-  wire       [31:0]   _zz_763;
-  wire       [19:0]   _zz_764;
-  wire       [11:0]   _zz_765;
-  wire       [2:0]    _zz_766;
-  wire       [2:0]    _zz_767;
-  wire       [31:0]   _zz_768;
-  wire       [31:0]   _zz_769;
-  wire       [31:0]   _zz_770;
-  wire       [31:0]   _zz_771;
-  wire       [31:0]   _zz_772;
-  wire       [31:0]   _zz_773;
-  wire       [31:0]   _zz_774;
-  wire       [31:0]   _zz_775;
-  wire       [31:0]   _zz_776;
-  wire       [31:0]   _zz_777;
-  wire       [31:0]   _zz_778;
-  wire       [31:0]   _zz_779;
-  wire       [31:0]   _zz_780;
-  wire       [31:0]   _zz_781;
-  wire       [31:0]   _zz_782;
-  wire       [31:0]   _zz_783;
-  wire       [31:0]   _zz_784;
-  wire       [31:0]   _zz_785;
-  wire       [31:0]   _zz_786;
-  wire       [31:0]   _zz_787;
-  wire       [31:0]   _zz_788;
-  wire       [31:0]   _zz_789;
-  wire       [31:0]   _zz_790;
-  wire       [31:0]   _zz_791;
-  wire       [31:0]   _zz_792;
-  wire       [31:0]   _zz_793;
-  wire       [31:0]   _zz_794;
-  wire       [31:0]   _zz_795;
-  wire       [31:0]   _zz_796;
-  wire       [31:0]   _zz_797;
-  wire       [31:0]   _zz_798;
-  wire       [31:0]   _zz_799;
-  wire       [31:0]   _zz_800;
-  wire       [31:0]   _zz_801;
-  wire       [31:0]   _zz_802;
-  wire       [31:0]   _zz_803;
-  wire       [31:0]   _zz_804;
-  wire       [31:0]   _zz_805;
-  wire       [31:0]   _zz_806;
-  wire       [31:0]   _zz_807;
-  wire       [31:0]   _zz_808;
-  wire       [31:0]   _zz_809;
-  wire       [31:0]   _zz_810;
-  wire       [31:0]   _zz_811;
-  wire       [31:0]   _zz_812;
-  wire       [31:0]   _zz_813;
-  wire       [31:0]   _zz_814;
-  wire       [31:0]   _zz_815;
-  wire       [4:0]    _zz_816;
-  wire       [4:0]    _zz_817;
-  wire       [4:0]    _zz_818;
-  wire       [4:0]    _zz_819;
-  wire       [4:0]    _zz_820;
-  wire       [0:0]    _zz_821;
-  wire       [2:0]    _zz_822;
-  wire       [15:0]   _zz_823;
-  wire       [15:0]   _zz_824;
-  wire       [15:0]   _zz_825;
-  wire       [4:0]    _zz_826;
-  wire       [4:0]    _zz_827;
-  wire       [4:0]    _zz_828;
-  wire       [4:0]    _zz_829;
-  wire       [4:0]    _zz_830;
-  wire       [0:0]    _zz_831;
-  wire       [2:0]    _zz_832;
-  wire       [15:0]   _zz_833;
-  wire       [15:0]   _zz_834;
-  wire       [15:0]   _zz_835;
-  wire       [0:0]    _zz_836;
-  wire       [2:0]    _zz_837;
-  wire       [4:0]    _zz_838;
-  wire       [11:0]   _zz_839;
-  wire       [11:0]   _zz_840;
-  wire       [31:0]   _zz_841;
-  wire       [31:0]   _zz_842;
-  wire       [31:0]   _zz_843;
-  wire       [31:0]   _zz_844;
-  wire       [31:0]   _zz_845;
-  wire       [31:0]   _zz_846;
-  wire       [31:0]   _zz_847;
-  wire       [11:0]   _zz_848;
-  wire       [19:0]   _zz_849;
-  wire       [11:0]   _zz_850;
-  wire       [31:0]   _zz_851;
-  wire       [31:0]   _zz_852;
-  wire       [31:0]   _zz_853;
-  wire       [11:0]   _zz_854;
-  wire       [19:0]   _zz_855;
-  wire       [11:0]   _zz_856;
-  wire       [2:0]    _zz_857;
-  wire       [1:0]    _zz_858;
-  wire       [1:0]    _zz_859;
-  wire       [65:0]   _zz_860;
-  wire       [65:0]   _zz_861;
-  wire       [31:0]   _zz_862;
-  wire       [31:0]   _zz_863;
-  wire       [0:0]    _zz_864;
-  wire       [5:0]    _zz_865;
-  wire       [32:0]   _zz_866;
-  wire       [31:0]   _zz_867;
-  wire       [31:0]   _zz_868;
-  wire       [32:0]   _zz_869;
-  wire       [32:0]   _zz_870;
-  wire       [32:0]   _zz_871;
-  wire       [32:0]   _zz_872;
-  wire       [0:0]    _zz_873;
-  wire       [32:0]   _zz_874;
-  wire       [0:0]    _zz_875;
-  wire       [32:0]   _zz_876;
-  wire       [0:0]    _zz_877;
-  wire       [31:0]   _zz_878;
-  wire       [0:0]    _zz_879;
-  wire       [0:0]    _zz_880;
-  wire       [0:0]    _zz_881;
-  wire       [0:0]    _zz_882;
-  wire       [0:0]    _zz_883;
-  wire       [0:0]    _zz_884;
-  wire       [0:0]    _zz_885;
-  wire       [0:0]    _zz_886;
-  wire       [0:0]    _zz_887;
-  wire       [0:0]    _zz_888;
-  wire       [0:0]    _zz_889;
-  wire       [0:0]    _zz_890;
-  wire       [0:0]    _zz_891;
-  wire       [0:0]    _zz_892;
-  wire       [0:0]    _zz_893;
-  wire       [0:0]    _zz_894;
-  wire       [0:0]    _zz_895;
-  wire       [0:0]    _zz_896;
-  wire       [0:0]    _zz_897;
-  wire       [0:0]    _zz_898;
-  wire       [0:0]    _zz_899;
-  wire       [0:0]    _zz_900;
-  wire       [0:0]    _zz_901;
-  wire       [0:0]    _zz_902;
-  wire       [0:0]    _zz_903;
-  wire       [0:0]    _zz_904;
-  wire       [0:0]    _zz_905;
-  wire       [0:0]    _zz_906;
-  wire       [0:0]    _zz_907;
-  wire       [0:0]    _zz_908;
-  wire       [0:0]    _zz_909;
-  wire       [0:0]    _zz_910;
-  wire       [0:0]    _zz_911;
-  wire       [0:0]    _zz_912;
-  wire       [0:0]    _zz_913;
-  wire       [0:0]    _zz_914;
-  wire       [0:0]    _zz_915;
-  wire       [0:0]    _zz_916;
-  wire       [0:0]    _zz_917;
-  wire       [0:0]    _zz_918;
-  wire       [0:0]    _zz_919;
-  wire       [0:0]    _zz_920;
-  wire       [0:0]    _zz_921;
-  wire       [0:0]    _zz_922;
-  wire       [0:0]    _zz_923;
-  wire       [0:0]    _zz_924;
-  wire       [0:0]    _zz_925;
-  wire       [0:0]    _zz_926;
-  wire       [0:0]    _zz_927;
-  wire       [0:0]    _zz_928;
-  wire       [0:0]    _zz_929;
-  wire       [0:0]    _zz_930;
-  wire       [0:0]    _zz_931;
-  wire       [0:0]    _zz_932;
-  wire       [0:0]    _zz_933;
-  wire       [0:0]    _zz_934;
-  wire       [0:0]    _zz_935;
-  wire       [0:0]    _zz_936;
-  wire       [0:0]    _zz_937;
-  wire       [0:0]    _zz_938;
-  wire       [0:0]    _zz_939;
-  wire       [0:0]    _zz_940;
-  wire       [0:0]    _zz_941;
-  wire       [0:0]    _zz_942;
-  wire       [0:0]    _zz_943;
-  wire       [0:0]    _zz_944;
-  wire       [0:0]    _zz_945;
-  wire       [0:0]    _zz_946;
-  wire       [0:0]    _zz_947;
-  wire       [0:0]    _zz_948;
-  wire       [0:0]    _zz_949;
-  wire       [26:0]   _zz_950;
-  wire                _zz_951;
-  wire                _zz_952;
-  wire       [1:0]    _zz_953;
-  wire       [2:0]    _zz_954;
-  wire       [2:0]    _zz_955;
-  wire       [2:0]    _zz_956;
-  wire       [2:0]    _zz_957;
-  wire       [2:0]    _zz_958;
-  wire       [3:0]    _zz_959;
-  wire       [3:0]    _zz_960;
-  wire       [3:0]    _zz_961;
-  wire       [2:0]    _zz_962;
-  wire       [2:0]    _zz_963;
-  wire       [2:0]    _zz_964;
-  wire       [2:0]    _zz_965;
-  wire       [2:0]    _zz_966;
-  wire       [3:0]    _zz_967;
-  wire       [3:0]    _zz_968;
-  wire       [3:0]    _zz_969;
-  wire       [31:0]   _zz_970;
-  wire       [31:0]   _zz_971;
-  wire       [31:0]   _zz_972;
-  wire                _zz_973;
-  wire       [0:0]    _zz_974;
-  wire       [13:0]   _zz_975;
-  wire       [31:0]   _zz_976;
-  wire       [31:0]   _zz_977;
-  wire       [31:0]   _zz_978;
-  wire                _zz_979;
-  wire       [0:0]    _zz_980;
-  wire       [7:0]    _zz_981;
-  wire       [31:0]   _zz_982;
-  wire       [31:0]   _zz_983;
-  wire       [31:0]   _zz_984;
-  wire                _zz_985;
-  wire       [0:0]    _zz_986;
-  wire       [1:0]    _zz_987;
-  wire                _zz_988;
-  wire                _zz_989;
-  wire                _zz_990;
-  wire       [0:0]    _zz_991;
-  wire       [4:0]    _zz_992;
-  wire       [0:0]    _zz_993;
-  wire       [4:0]    _zz_994;
-  wire       [0:0]    _zz_995;
-  wire       [4:0]    _zz_996;
-  wire       [0:0]    _zz_997;
-  wire       [4:0]    _zz_998;
-  wire       [0:0]    _zz_999;
-  wire       [4:0]    _zz_1000;
-  wire       [0:0]    _zz_1001;
-  wire       [4:0]    _zz_1002;
-  wire       [31:0]   _zz_1003;
-  wire       [31:0]   _zz_1004;
-  wire                _zz_1005;
-  wire       [0:0]    _zz_1006;
-  wire       [0:0]    _zz_1007;
-  wire                _zz_1008;
-  wire       [0:0]    _zz_1009;
-  wire       [24:0]   _zz_1010;
-  wire       [31:0]   _zz_1011;
-  wire                _zz_1012;
-  wire                _zz_1013;
-  wire       [0:0]    _zz_1014;
-  wire       [0:0]    _zz_1015;
-  wire       [0:0]    _zz_1016;
-  wire       [0:0]    _zz_1017;
-  wire                _zz_1018;
-  wire       [0:0]    _zz_1019;
-  wire       [20:0]   _zz_1020;
-  wire       [31:0]   _zz_1021;
-  wire       [31:0]   _zz_1022;
-  wire                _zz_1023;
-  wire                _zz_1024;
-  wire       [0:0]    _zz_1025;
-  wire       [1:0]    _zz_1026;
-  wire       [0:0]    _zz_1027;
-  wire       [0:0]    _zz_1028;
-  wire                _zz_1029;
-  wire       [0:0]    _zz_1030;
-  wire       [17:0]   _zz_1031;
-  wire       [31:0]   _zz_1032;
-  wire       [31:0]   _zz_1033;
-  wire       [31:0]   _zz_1034;
-  wire       [31:0]   _zz_1035;
-  wire       [31:0]   _zz_1036;
-  wire       [31:0]   _zz_1037;
-  wire       [31:0]   _zz_1038;
-  wire       [31:0]   _zz_1039;
-  wire                _zz_1040;
-  wire       [1:0]    _zz_1041;
-  wire       [1:0]    _zz_1042;
-  wire                _zz_1043;
-  wire       [0:0]    _zz_1044;
-  wire       [14:0]   _zz_1045;
-  wire       [31:0]   _zz_1046;
-  wire       [31:0]   _zz_1047;
-  wire       [31:0]   _zz_1048;
-  wire       [31:0]   _zz_1049;
-  wire       [31:0]   _zz_1050;
-  wire       [31:0]   _zz_1051;
-  wire       [0:0]    _zz_1052;
-  wire       [0:0]    _zz_1053;
-  wire       [4:0]    _zz_1054;
-  wire       [4:0]    _zz_1055;
-  wire                _zz_1056;
-  wire       [0:0]    _zz_1057;
-  wire       [11:0]   _zz_1058;
-  wire       [31:0]   _zz_1059;
-  wire       [31:0]   _zz_1060;
-  wire       [31:0]   _zz_1061;
-  wire       [31:0]   _zz_1062;
-  wire                _zz_1063;
-  wire       [0:0]    _zz_1064;
-  wire       [1:0]    _zz_1065;
-  wire       [31:0]   _zz_1066;
-  wire       [31:0]   _zz_1067;
-  wire       [0:0]    _zz_1068;
-  wire       [3:0]    _zz_1069;
-  wire       [4:0]    _zz_1070;
-  wire       [4:0]    _zz_1071;
-  wire                _zz_1072;
-  wire       [0:0]    _zz_1073;
-  wire       [8:0]    _zz_1074;
-  wire       [31:0]   _zz_1075;
-  wire       [31:0]   _zz_1076;
-  wire       [31:0]   _zz_1077;
-  wire                _zz_1078;
-  wire                _zz_1079;
-  wire       [31:0]   _zz_1080;
-  wire       [31:0]   _zz_1081;
-  wire       [0:0]    _zz_1082;
-  wire       [1:0]    _zz_1083;
-  wire       [0:0]    _zz_1084;
-  wire       [2:0]    _zz_1085;
-  wire       [0:0]    _zz_1086;
-  wire       [4:0]    _zz_1087;
-  wire       [1:0]    _zz_1088;
-  wire       [1:0]    _zz_1089;
-  wire                _zz_1090;
-  wire       [0:0]    _zz_1091;
-  wire       [6:0]    _zz_1092;
-  wire       [31:0]   _zz_1093;
-  wire       [31:0]   _zz_1094;
-  wire       [31:0]   _zz_1095;
-  wire       [31:0]   _zz_1096;
-  wire                _zz_1097;
-  wire                _zz_1098;
-  wire       [31:0]   _zz_1099;
-  wire       [31:0]   _zz_1100;
-  wire                _zz_1101;
-  wire       [0:0]    _zz_1102;
-  wire       [0:0]    _zz_1103;
-  wire                _zz_1104;
-  wire       [0:0]    _zz_1105;
-  wire       [2:0]    _zz_1106;
-  wire                _zz_1107;
-  wire       [0:0]    _zz_1108;
-  wire       [0:0]    _zz_1109;
-  wire       [0:0]    _zz_1110;
-  wire       [0:0]    _zz_1111;
-  wire                _zz_1112;
-  wire       [0:0]    _zz_1113;
-  wire       [4:0]    _zz_1114;
-  wire       [31:0]   _zz_1115;
-  wire       [31:0]   _zz_1116;
-  wire       [31:0]   _zz_1117;
-  wire       [31:0]   _zz_1118;
-  wire       [31:0]   _zz_1119;
-  wire       [31:0]   _zz_1120;
-  wire       [31:0]   _zz_1121;
-  wire       [31:0]   _zz_1122;
-  wire       [31:0]   _zz_1123;
-  wire       [31:0]   _zz_1124;
-  wire                _zz_1125;
-  wire       [0:0]    _zz_1126;
-  wire       [0:0]    _zz_1127;
-  wire       [31:0]   _zz_1128;
-  wire       [31:0]   _zz_1129;
-  wire       [31:0]   _zz_1130;
-  wire       [31:0]   _zz_1131;
-  wire       [31:0]   _zz_1132;
-  wire                _zz_1133;
-  wire       [3:0]    _zz_1134;
-  wire       [3:0]    _zz_1135;
-  wire                _zz_1136;
-  wire       [0:0]    _zz_1137;
-  wire       [2:0]    _zz_1138;
-  wire       [31:0]   _zz_1139;
-  wire       [31:0]   _zz_1140;
-  wire       [31:0]   _zz_1141;
-  wire       [31:0]   _zz_1142;
-  wire       [31:0]   _zz_1143;
-  wire       [31:0]   _zz_1144;
-  wire                _zz_1145;
-  wire       [0:0]    _zz_1146;
-  wire       [1:0]    _zz_1147;
-  wire                _zz_1148;
-  wire       [2:0]    _zz_1149;
-  wire       [2:0]    _zz_1150;
-  wire                _zz_1151;
-  wire       [0:0]    _zz_1152;
-  wire       [0:0]    _zz_1153;
-  wire       [31:0]   _zz_1154;
-  wire       [31:0]   _zz_1155;
-  wire       [31:0]   _zz_1156;
-  wire       [31:0]   _zz_1157;
-  wire       [31:0]   _zz_1158;
-  wire       [31:0]   _zz_1159;
-  wire       [31:0]   _zz_1160;
-  wire                _zz_1161;
-  wire                _zz_1162;
-  wire                _zz_1163;
-  wire       [0:0]    _zz_1164;
-  wire       [0:0]    _zz_1165;
-  wire                _zz_1166;
-  wire                _zz_1167;
-  wire                _zz_1168;
-  wire                _zz_1169;
-  wire       [31:0]   _zz_1170;
-  wire       [31:0]   _zz_1171;
-  wire       [31:0]   _zz_1172;
-  wire       [31:0]   _zz_1173;
-  wire       [31:0]   _zz_1174;
-  wire       [31:0]   _zz_1175;
-  wire       [31:0]   _zz_1176;
-  wire       [31:0]   _zz_1177;
-  wire       [31:0]   _zz_1178;
-  wire       [31:0]   _zz_1179;
-  wire       [31:0]   _zz_1180;
-  wire       [31:0]   _zz_1181;
-  wire       [31:0]   _zz_1182;
-  wire       [31:0]   _zz_1183;
-  wire       [31:0]   _zz_1184;
-  wire       [31:0]   _zz_1185;
-  wire       [31:0]   _zz_1186;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_3;
+  wire       [11:0]   _zz__zz_5;
+  wire       [31:0]   _zz__zz_7;
+  wire       [31:0]   _zz__zz_7_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  reg        [7:0]    _zz_when_PmpPlugin_l246;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_1;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_2;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_3;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_4;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_3;
+  wire       [0:0]    _zz_when_PmpPlugin_l277;
+  wire       [5:0]    _zz_when_PmpPlugin_l277_1;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2;
+  wire       [8:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6;
+  wire       [1:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+  wire       [8:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+  wire       [1:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_1;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_2;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_3;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_4;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_3;
+  wire       [0:0]    _zz_when_PmpPlugin_l299;
+  wire       [5:0]    _zz_when_PmpPlugin_l299_1;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  wire       [0:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+  wire       [8:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+  wire       [0:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+  wire       [1:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port;
+  reg        [7:0]    _zz_when_PmpPlugin_l209;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_1;
+  reg        [7:0]    _zz_when_PmpPlugin_l209_1_1;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_1_2;
+  reg        [7:0]    _zz_when_PmpPlugin_l209_2;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_2_1;
+  reg        [7:0]    _zz_when_PmpPlugin_l209_3;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_3_1;
+  reg        [7:0]    _zz_when_PmpPlugin_l216;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_1;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_2;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_3;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_4;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_5;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_6;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_7;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
+  reg                 _zz_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -681,8 +602,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
@@ -693,27 +614,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -722,17 +643,17 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -753,11 +674,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -765,10 +686,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -778,45 +699,45 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_2;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -835,10 +756,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -910,8 +831,8 @@ module VexRiscv (
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
   wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
-  reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
-  reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
@@ -925,7 +846,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -940,7 +861,7 @@ module VexRiscv (
   wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
-  reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
   wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
@@ -959,6 +880,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  reg        [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -976,28 +902,34 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   wire                CsrPlugin_allowInterrupts;
   wire                CsrPlugin_allowException;
+  wire                CsrPlugin_allowEbreakException;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_54;
-  wire       [3:0]    _zz_55;
-  wire                _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -1020,16 +952,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_59;
-  wire                _zz_60;
-  wire                _zz_61;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_62;
-  wire                _zz_63;
-  reg                 _zz_64;
-  wire                _zz_65;
-  reg                 _zz_66;
-  reg        [31:0]   _zz_67;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1037,22 +971,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_68;
-  reg        [18:0]   _zz_69;
-  wire                _zz_70;
-  reg        [10:0]   _zz_71;
-  wire                _zz_72;
-  reg        [18:0]   _zz_73;
-  reg                 _zz_74;
-  wire                _zz_75;
-  reg        [10:0]   _zz_76;
-  wire                _zz_77;
-  reg        [18:0]   _zz_78;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_3;
+  reg        [10:0]   _zz_4;
+  wire                _zz_5;
+  reg        [18:0]   _zz_6;
+  reg                 _zz_7;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1060,7 +1001,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_79;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1068,6 +1009,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -1075,7 +1021,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -1083,8 +1029,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -1092,492 +1039,157 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_80;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_81;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_82;
-  reg        [31:0]   _zz_83;
-  wire                _zz_84;
-  reg        [31:0]   _zz_85;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  reg                 _zz_86;
-  reg                 _zz_87;
-  reg                 _zz_88;
-  reg                 _zz_89;
-  reg        [1:0]    _zz_90;
-  reg        [31:0]   _zz_91;
-  reg                 _zz_92;
-  reg                 _zz_93;
-  reg                 _zz_94;
-  reg                 _zz_95;
-  reg        [1:0]    _zz_96;
-  reg        [31:0]   _zz_97;
-  reg                 _zz_98;
-  wire                _zz_99;
-  reg        [31:0]   _zz_100;
-  reg        [31:0]   _zz_101;
-  wire       [31:0]   _zz_102;
-  wire       [31:0]   _zz_103;
-  wire       [31:0]   _zz_104;
-  reg                 _zz_105;
-  reg                 _zz_106;
-  reg                 _zz_107;
-  reg                 _zz_108;
-  reg        [1:0]    _zz_109;
-  reg        [31:0]   _zz_110;
-  reg                 _zz_111;
-  reg                 _zz_112;
-  reg                 _zz_113;
-  reg                 _zz_114;
-  reg        [1:0]    _zz_115;
-  reg        [31:0]   _zz_116;
-  reg                 _zz_117;
-  wire                _zz_118;
-  reg        [31:0]   _zz_119;
-  reg        [31:0]   _zz_120;
-  wire       [31:0]   _zz_121;
-  wire       [31:0]   _zz_122;
-  wire       [31:0]   _zz_123;
-  reg                 _zz_124;
-  reg                 _zz_125;
-  reg                 _zz_126;
-  reg                 _zz_127;
-  reg        [1:0]    _zz_128;
-  reg        [31:0]   _zz_129;
-  reg                 _zz_130;
-  reg                 _zz_131;
-  reg                 _zz_132;
-  reg                 _zz_133;
-  reg        [1:0]    _zz_134;
-  reg        [31:0]   _zz_135;
-  reg                 _zz_136;
-  wire                _zz_137;
-  reg        [31:0]   _zz_138;
-  reg        [31:0]   _zz_139;
-  wire       [31:0]   _zz_140;
-  wire       [31:0]   _zz_141;
-  wire       [31:0]   _zz_142;
-  reg                 _zz_143;
-  reg                 _zz_144;
-  reg                 _zz_145;
-  reg                 _zz_146;
-  reg        [1:0]    _zz_147;
-  reg        [31:0]   _zz_148;
-  reg                 _zz_149;
-  reg                 _zz_150;
-  reg                 _zz_151;
-  reg                 _zz_152;
-  reg        [1:0]    _zz_153;
-  reg        [31:0]   _zz_154;
-  reg                 _zz_155;
-  wire                _zz_156;
-  reg        [31:0]   _zz_157;
-  reg        [31:0]   _zz_158;
-  wire       [31:0]   _zz_159;
-  wire       [31:0]   _zz_160;
-  wire       [31:0]   _zz_161;
-  reg                 _zz_162;
-  reg                 _zz_163;
-  reg                 _zz_164;
-  reg                 _zz_165;
-  reg        [1:0]    _zz_166;
-  reg        [31:0]   _zz_167;
-  reg                 _zz_168;
-  reg                 _zz_169;
-  reg                 _zz_170;
-  reg                 _zz_171;
-  reg        [1:0]    _zz_172;
-  reg        [31:0]   _zz_173;
-  reg                 _zz_174;
-  wire                _zz_175;
-  reg        [31:0]   _zz_176;
-  reg        [31:0]   _zz_177;
-  wire       [31:0]   _zz_178;
-  wire       [31:0]   _zz_179;
-  wire       [31:0]   _zz_180;
-  reg                 _zz_181;
-  reg                 _zz_182;
-  reg                 _zz_183;
-  reg                 _zz_184;
-  reg        [1:0]    _zz_185;
-  reg        [31:0]   _zz_186;
-  reg                 _zz_187;
-  reg                 _zz_188;
-  reg                 _zz_189;
-  reg                 _zz_190;
-  reg        [1:0]    _zz_191;
-  reg        [31:0]   _zz_192;
-  reg                 _zz_193;
-  wire                _zz_194;
-  reg        [31:0]   _zz_195;
-  reg        [31:0]   _zz_196;
-  wire       [31:0]   _zz_197;
-  wire       [31:0]   _zz_198;
-  wire       [31:0]   _zz_199;
-  reg                 _zz_200;
-  reg                 _zz_201;
-  reg                 _zz_202;
-  reg                 _zz_203;
-  reg        [1:0]    _zz_204;
-  reg        [31:0]   _zz_205;
-  reg                 _zz_206;
-  reg                 _zz_207;
-  reg                 _zz_208;
-  reg                 _zz_209;
-  reg        [1:0]    _zz_210;
-  reg        [31:0]   _zz_211;
-  reg                 _zz_212;
-  wire                _zz_213;
-  reg        [31:0]   _zz_214;
-  reg        [31:0]   _zz_215;
-  wire       [31:0]   _zz_216;
-  wire       [31:0]   _zz_217;
-  wire       [31:0]   _zz_218;
-  reg                 _zz_219;
-  reg                 _zz_220;
-  reg                 _zz_221;
-  reg                 _zz_222;
-  reg        [1:0]    _zz_223;
-  reg        [31:0]   _zz_224;
-  reg                 _zz_225;
-  reg                 _zz_226;
-  reg                 _zz_227;
-  reg                 _zz_228;
-  reg        [1:0]    _zz_229;
-  reg        [31:0]   _zz_230;
-  reg                 _zz_231;
-  wire                _zz_232;
-  reg        [31:0]   _zz_233;
-  reg        [31:0]   _zz_234;
-  wire       [31:0]   _zz_235;
-  wire       [31:0]   _zz_236;
-  wire       [31:0]   _zz_237;
-  reg                 _zz_238;
-  reg                 _zz_239;
-  reg                 _zz_240;
-  reg                 _zz_241;
-  reg        [1:0]    _zz_242;
-  reg        [31:0]   _zz_243;
-  reg                 _zz_244;
-  reg                 _zz_245;
-  reg                 _zz_246;
-  reg                 _zz_247;
-  reg        [1:0]    _zz_248;
-  reg        [31:0]   _zz_249;
-  reg                 _zz_250;
-  wire                _zz_251;
-  reg        [31:0]   _zz_252;
-  reg        [31:0]   _zz_253;
-  wire       [31:0]   _zz_254;
-  wire       [31:0]   _zz_255;
-  wire       [31:0]   _zz_256;
-  reg                 _zz_257;
-  reg                 _zz_258;
-  reg                 _zz_259;
-  reg                 _zz_260;
-  reg        [1:0]    _zz_261;
-  reg        [31:0]   _zz_262;
-  reg                 _zz_263;
-  reg                 _zz_264;
-  reg                 _zz_265;
-  reg                 _zz_266;
-  reg        [1:0]    _zz_267;
-  reg        [31:0]   _zz_268;
-  reg                 _zz_269;
-  wire                _zz_270;
-  reg        [31:0]   _zz_271;
-  reg        [31:0]   _zz_272;
-  wire       [31:0]   _zz_273;
-  wire       [31:0]   _zz_274;
-  wire       [31:0]   _zz_275;
-  reg                 _zz_276;
-  reg                 _zz_277;
-  reg                 _zz_278;
-  reg                 _zz_279;
-  reg        [1:0]    _zz_280;
-  reg        [31:0]   _zz_281;
-  reg                 _zz_282;
-  reg                 _zz_283;
-  reg                 _zz_284;
-  reg                 _zz_285;
-  reg        [1:0]    _zz_286;
-  reg        [31:0]   _zz_287;
-  reg                 _zz_288;
-  wire                _zz_289;
-  reg        [31:0]   _zz_290;
-  reg        [31:0]   _zz_291;
-  wire       [31:0]   _zz_292;
-  wire       [31:0]   _zz_293;
-  wire       [31:0]   _zz_294;
-  reg                 _zz_295;
-  reg                 _zz_296;
-  reg                 _zz_297;
-  reg                 _zz_298;
-  reg        [1:0]    _zz_299;
-  reg        [31:0]   _zz_300;
-  reg                 _zz_301;
-  reg                 _zz_302;
-  reg                 _zz_303;
-  reg                 _zz_304;
-  reg        [1:0]    _zz_305;
-  reg        [31:0]   _zz_306;
-  reg                 _zz_307;
-  wire                _zz_308;
-  reg        [31:0]   _zz_309;
-  reg        [31:0]   _zz_310;
-  wire       [31:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  reg                 _zz_314;
-  reg                 _zz_315;
-  reg                 _zz_316;
-  reg                 _zz_317;
-  reg        [1:0]    _zz_318;
-  reg        [31:0]   _zz_319;
-  reg                 _zz_320;
-  reg                 _zz_321;
-  reg                 _zz_322;
-  reg                 _zz_323;
-  reg        [1:0]    _zz_324;
-  reg        [31:0]   _zz_325;
-  reg                 _zz_326;
-  wire                _zz_327;
-  reg        [31:0]   _zz_328;
-  reg        [31:0]   _zz_329;
-  wire       [31:0]   _zz_330;
-  wire       [31:0]   _zz_331;
-  wire       [31:0]   _zz_332;
-  reg                 _zz_333;
-  reg                 _zz_334;
-  reg                 _zz_335;
-  reg                 _zz_336;
-  reg        [1:0]    _zz_337;
-  reg        [31:0]   _zz_338;
-  reg                 _zz_339;
-  reg                 _zz_340;
-  reg                 _zz_341;
-  reg                 _zz_342;
-  reg        [1:0]    _zz_343;
-  reg        [31:0]   _zz_344;
-  reg                 _zz_345;
-  wire                _zz_346;
-  reg        [31:0]   _zz_347;
-  reg        [31:0]   _zz_348;
-  wire       [31:0]   _zz_349;
-  wire       [31:0]   _zz_350;
-  wire       [31:0]   _zz_351;
-  reg                 _zz_352;
-  reg                 _zz_353;
-  reg                 _zz_354;
-  reg                 _zz_355;
-  reg        [1:0]    _zz_356;
-  reg        [31:0]   _zz_357;
-  reg                 _zz_358;
-  reg                 _zz_359;
-  reg                 _zz_360;
-  reg                 _zz_361;
-  reg        [1:0]    _zz_362;
-  reg        [31:0]   _zz_363;
-  reg                 _zz_364;
-  wire                _zz_365;
-  reg        [31:0]   _zz_366;
-  reg        [31:0]   _zz_367;
-  wire       [31:0]   _zz_368;
-  wire       [31:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  reg                 _zz_371;
-  reg                 _zz_372;
-  reg                 _zz_373;
-  reg                 _zz_374;
-  reg        [1:0]    _zz_375;
-  reg        [31:0]   _zz_376;
-  reg                 _zz_377;
-  reg                 _zz_378;
-  reg                 _zz_379;
-  reg                 _zz_380;
-  reg        [1:0]    _zz_381;
-  reg        [31:0]   _zz_382;
-  reg                 _zz_383;
-  wire                _zz_384;
-  reg        [31:0]   _zz_385;
-  reg        [31:0]   _zz_386;
-  wire       [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
-  wire                PmpPlugin_ports_0_hits_0;
-  wire                PmpPlugin_ports_0_hits_1;
-  wire                PmpPlugin_ports_0_hits_2;
-  wire                PmpPlugin_ports_0_hits_3;
-  wire                PmpPlugin_ports_0_hits_4;
-  wire                PmpPlugin_ports_0_hits_5;
-  wire                PmpPlugin_ports_0_hits_6;
-  wire                PmpPlugin_ports_0_hits_7;
-  wire                PmpPlugin_ports_0_hits_8;
-  wire                PmpPlugin_ports_0_hits_9;
-  wire                PmpPlugin_ports_0_hits_10;
-  wire                PmpPlugin_ports_0_hits_11;
-  wire                PmpPlugin_ports_0_hits_12;
-  wire                PmpPlugin_ports_0_hits_13;
-  wire                PmpPlugin_ports_0_hits_14;
-  wire                PmpPlugin_ports_0_hits_15;
-  wire       [4:0]    _zz_390;
-  wire       [4:0]    _zz_391;
-  wire       [4:0]    _zz_392;
-  wire       [4:0]    _zz_393;
-  wire       [4:0]    _zz_394;
-  wire       [4:0]    _zz_395;
-  wire       [4:0]    _zz_396;
-  wire       [4:0]    _zz_397;
-  wire       [15:0]   _zz_398;
-  wire       [15:0]   _zz_399;
-  wire                _zz_400;
-  wire                _zz_401;
-  wire                _zz_402;
-  wire                _zz_403;
-  wire                _zz_404;
-  wire                _zz_405;
-  wire                _zz_406;
-  wire                _zz_407;
-  wire                _zz_408;
-  wire                _zz_409;
-  wire                _zz_410;
-  wire                _zz_411;
-  wire                _zz_412;
-  wire                _zz_413;
-  wire                _zz_414;
-  wire       [15:0]   _zz_415;
-  wire       [15:0]   _zz_416;
-  wire                _zz_417;
-  wire                _zz_418;
-  wire                _zz_419;
-  wire                _zz_420;
-  wire                _zz_421;
-  wire                _zz_422;
-  wire                _zz_423;
-  wire                _zz_424;
-  wire                _zz_425;
-  wire                _zz_426;
-  wire                _zz_427;
-  wire                _zz_428;
-  wire                _zz_429;
-  wire                _zz_430;
-  wire                _zz_431;
-  wire       [15:0]   _zz_432;
-  wire       [15:0]   _zz_433;
-  wire                _zz_434;
-  wire                _zz_435;
-  wire                _zz_436;
-  wire                _zz_437;
-  wire                _zz_438;
-  wire                _zz_439;
-  wire                _zz_440;
-  wire                _zz_441;
-  wire                _zz_442;
-  wire                _zz_443;
-  wire                _zz_444;
-  wire                _zz_445;
-  wire                _zz_446;
-  wire                _zz_447;
-  wire                _zz_448;
-  wire                PmpPlugin_ports_1_hits_0;
-  wire                PmpPlugin_ports_1_hits_1;
-  wire                PmpPlugin_ports_1_hits_2;
-  wire                PmpPlugin_ports_1_hits_3;
-  wire                PmpPlugin_ports_1_hits_4;
-  wire                PmpPlugin_ports_1_hits_5;
-  wire                PmpPlugin_ports_1_hits_6;
-  wire                PmpPlugin_ports_1_hits_7;
-  wire                PmpPlugin_ports_1_hits_8;
-  wire                PmpPlugin_ports_1_hits_9;
-  wire                PmpPlugin_ports_1_hits_10;
-  wire                PmpPlugin_ports_1_hits_11;
-  wire                PmpPlugin_ports_1_hits_12;
-  wire                PmpPlugin_ports_1_hits_13;
-  wire                PmpPlugin_ports_1_hits_14;
-  wire                PmpPlugin_ports_1_hits_15;
-  wire       [4:0]    _zz_449;
-  wire       [4:0]    _zz_450;
-  wire       [4:0]    _zz_451;
-  wire       [4:0]    _zz_452;
-  wire       [4:0]    _zz_453;
-  wire       [4:0]    _zz_454;
-  wire       [4:0]    _zz_455;
-  wire       [4:0]    _zz_456;
-  wire       [15:0]   _zz_457;
-  wire       [15:0]   _zz_458;
-  wire                _zz_459;
-  wire                _zz_460;
-  wire                _zz_461;
-  wire                _zz_462;
-  wire                _zz_463;
-  wire                _zz_464;
-  wire                _zz_465;
-  wire                _zz_466;
-  wire                _zz_467;
-  wire                _zz_468;
-  wire                _zz_469;
-  wire                _zz_470;
-  wire                _zz_471;
-  wire                _zz_472;
-  wire                _zz_473;
-  wire       [15:0]   _zz_474;
-  wire       [15:0]   _zz_475;
-  wire                _zz_476;
-  wire                _zz_477;
-  wire                _zz_478;
-  wire                _zz_479;
-  wire                _zz_480;
-  wire                _zz_481;
-  wire                _zz_482;
-  wire                _zz_483;
-  wire                _zz_484;
-  wire                _zz_485;
-  wire                _zz_486;
-  wire                _zz_487;
-  wire                _zz_488;
-  wire                _zz_489;
-  wire                _zz_490;
-  wire       [15:0]   _zz_491;
-  wire       [15:0]   _zz_492;
-  wire                _zz_493;
-  wire                _zz_494;
-  wire                _zz_495;
-  wire                _zz_496;
-  wire                _zz_497;
-  wire                _zz_498;
-  wire                _zz_499;
-  wire                _zz_500;
-  wire                _zz_501;
-  wire                _zz_502;
-  wire                _zz_503;
-  wire                _zz_504;
-  wire                _zz_505;
-  wire                _zz_506;
-  wire                _zz_507;
-  wire       [31:0]   _zz_508;
-  wire                _zz_509;
-  wire                _zz_510;
-  wire                _zz_511;
-  wire                _zz_512;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_513;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_514;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_515;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_516;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_517;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_518;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_519;
+  wire                when_DBusCachedPlugin_l484;
+  reg        [7:0]    PmpPlugin_pmpcfg_0;
+  reg        [7:0]    PmpPlugin_pmpcfg_1;
+  reg        [7:0]    PmpPlugin_pmpcfg_2;
+  reg        [7:0]    PmpPlugin_pmpcfg_3;
+  reg        [7:0]    PmpPlugin_pmpcfg_4;
+  reg        [7:0]    PmpPlugin_pmpcfg_5;
+  reg        [7:0]    PmpPlugin_pmpcfg_6;
+  reg        [7:0]    PmpPlugin_pmpcfg_7;
+  reg        [7:0]    PmpPlugin_pmpcfg_8;
+  reg        [7:0]    PmpPlugin_pmpcfg_9;
+  reg        [7:0]    PmpPlugin_pmpcfg_10;
+  reg        [7:0]    PmpPlugin_pmpcfg_11;
+  reg        [7:0]    PmpPlugin_pmpcfg_12;
+  reg        [7:0]    PmpPlugin_pmpcfg_13;
+  reg        [7:0]    PmpPlugin_pmpcfg_14;
+  reg        [7:0]    PmpPlugin_pmpcfg_15;
+  reg        [24:0]   PmpPlugin_base_0;
+  reg        [24:0]   PmpPlugin_base_1;
+  reg        [24:0]   PmpPlugin_base_2;
+  reg        [24:0]   PmpPlugin_base_3;
+  reg        [24:0]   PmpPlugin_base_4;
+  reg        [24:0]   PmpPlugin_base_5;
+  reg        [24:0]   PmpPlugin_base_6;
+  reg        [24:0]   PmpPlugin_base_7;
+  reg        [24:0]   PmpPlugin_base_8;
+  reg        [24:0]   PmpPlugin_base_9;
+  reg        [24:0]   PmpPlugin_base_10;
+  reg        [24:0]   PmpPlugin_base_11;
+  reg        [24:0]   PmpPlugin_base_12;
+  reg        [24:0]   PmpPlugin_base_13;
+  reg        [24:0]   PmpPlugin_base_14;
+  reg        [24:0]   PmpPlugin_base_15;
+  reg        [24:0]   PmpPlugin_mask_0;
+  reg        [24:0]   PmpPlugin_mask_1;
+  reg        [24:0]   PmpPlugin_mask_2;
+  reg        [24:0]   PmpPlugin_mask_3;
+  reg        [24:0]   PmpPlugin_mask_4;
+  reg        [24:0]   PmpPlugin_mask_5;
+  reg        [24:0]   PmpPlugin_mask_6;
+  reg        [24:0]   PmpPlugin_mask_7;
+  reg        [24:0]   PmpPlugin_mask_8;
+  reg        [24:0]   PmpPlugin_mask_9;
+  reg        [24:0]   PmpPlugin_mask_10;
+  reg        [24:0]   PmpPlugin_mask_11;
+  reg        [24:0]   PmpPlugin_mask_12;
+  reg        [24:0]   PmpPlugin_mask_13;
+  reg        [24:0]   PmpPlugin_mask_14;
+  reg        [24:0]   PmpPlugin_mask_15;
+  reg                 execute_PmpPlugin_fsmPending;
+  wire                when_PmpPlugin_l138;
+  reg                 execute_PmpPlugin_fsmComplete;
+  wire       [11:0]   execute_PmpPlugin_csrAddress;
+  wire       [3:0]    execute_PmpPlugin_pmpNcfg;
+  wire       [1:0]    execute_PmpPlugin_pmpcfgN;
+  wire                execute_PmpPlugin_pmpcfgCsr;
+  wire                execute_PmpPlugin_pmpaddrCsr;
+  reg        [3:0]    execute_PmpPlugin_pmpNcfg_;
+  reg        [1:0]    execute_PmpPlugin_pmpcfgN_;
+  reg                 execute_PmpPlugin_pmpcfgCsr_;
+  reg                 execute_PmpPlugin_pmpaddrCsr_;
+  reg        [31:0]   execute_PmpPlugin_writeData_;
+  wire                execute_PmpPlugin_fsm_wantExit;
+  reg                 execute_PmpPlugin_fsm_wantStart;
+  wire                execute_PmpPlugin_fsm_wantKill;
+  reg                 execute_PmpPlugin_fsm_fsmEnable;
+  reg        [3:0]    execute_PmpPlugin_fsm_fsmCounter;
+  wire                when_PmpPlugin_l246;
+  wire       [15:0]   _zz_8;
+  wire       [15:0]   _zz_9;
+  wire       [24:0]   _zz_PmpPlugin_dGuard_hits_0;
+  wire                PmpPlugin_dGuard_hits_0;
+  wire                PmpPlugin_dGuard_hits_1;
+  wire                PmpPlugin_dGuard_hits_2;
+  wire                PmpPlugin_dGuard_hits_3;
+  wire                PmpPlugin_dGuard_hits_4;
+  wire                PmpPlugin_dGuard_hits_5;
+  wire                PmpPlugin_dGuard_hits_6;
+  wire                PmpPlugin_dGuard_hits_7;
+  wire                PmpPlugin_dGuard_hits_8;
+  wire                PmpPlugin_dGuard_hits_9;
+  wire                PmpPlugin_dGuard_hits_10;
+  wire                PmpPlugin_dGuard_hits_11;
+  wire                PmpPlugin_dGuard_hits_12;
+  wire                PmpPlugin_dGuard_hits_13;
+  wire                PmpPlugin_dGuard_hits_14;
+  wire                PmpPlugin_dGuard_hits_15;
+  wire                when_PmpPlugin_l277;
+  wire       [24:0]   _zz_PmpPlugin_iGuard_hits_0;
+  wire                PmpPlugin_iGuard_hits_0;
+  wire                PmpPlugin_iGuard_hits_1;
+  wire                PmpPlugin_iGuard_hits_2;
+  wire                PmpPlugin_iGuard_hits_3;
+  wire                PmpPlugin_iGuard_hits_4;
+  wire                PmpPlugin_iGuard_hits_5;
+  wire                PmpPlugin_iGuard_hits_6;
+  wire                PmpPlugin_iGuard_hits_7;
+  wire                PmpPlugin_iGuard_hits_8;
+  wire                PmpPlugin_iGuard_hits_9;
+  wire                PmpPlugin_iGuard_hits_10;
+  wire                PmpPlugin_iGuard_hits_11;
+  wire                PmpPlugin_iGuard_hits_12;
+  wire                PmpPlugin_iGuard_hits_13;
+  wire                PmpPlugin_iGuard_hits_14;
+  wire                PmpPlugin_iGuard_hits_15;
+  wire                when_PmpPlugin_l299;
+  wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1585,54 +1197,72 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_520;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_521;
-  reg        [31:0]   _zz_522;
-  wire                _zz_523;
-  reg        [19:0]   _zz_524;
-  wire                _zz_525;
-  reg        [19:0]   _zz_526;
-  reg        [31:0]   _zz_527;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_528;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_529;
-  reg                 _zz_530;
-  reg                 _zz_531;
-  reg                 _zz_532;
-  reg        [4:0]    _zz_533;
-  reg        [31:0]   _zz_534;
-  wire                _zz_535;
-  wire                _zz_536;
-  wire                _zz_537;
-  wire                _zz_538;
-  wire                _zz_539;
-  wire                _zz_540;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_541;
-  reg                 _zz_542;
-  reg                 _zz_543;
-  wire                _zz_544;
-  reg        [19:0]   _zz_545;
-  wire                _zz_546;
-  reg        [10:0]   _zz_547;
-  wire                _zz_548;
-  reg        [18:0]   _zz_549;
-  reg                 _zz_550;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_551;
-  reg        [19:0]   _zz_552;
-  wire                _zz_553;
-  reg        [10:0]   _zz_554;
-  wire                _zz_555;
-  reg        [18:0]   _zz_556;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_557;
+  reg        [1:0]    _zz_CsrPlugin_privilege;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1653,9 +1283,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_558;
-  wire                _zz_559;
-  wire                _zz_560;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1668,40 +1298,67 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_561;
-  wire                _zz_562;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1709,6 +1366,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1721,1617 +1380,4850 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_563;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_564;
-  wire                _zz_565;
-  wire                _zz_566;
-  reg        [32:0]   _zz_567;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_568;
-  wire       [31:0]   _zz_569;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_49;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_50;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_51;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_54;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_55;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_57;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_type execute_PmpPlugin_fsm_stateReg;
+  reg        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_type execute_PmpPlugin_fsm_stateNext;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_1;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_2;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_3;
+  wire                when_PmpPlugin_l209;
+  wire       [15:0]   _zz_11;
+  wire                when_PmpPlugin_l209_1;
+  wire       [15:0]   _zz_12;
+  wire                when_PmpPlugin_l209_2;
+  wire       [15:0]   _zz_13;
+  wire                when_PmpPlugin_l209_3;
+  wire       [15:0]   _zz_14;
+  wire                when_PmpPlugin_l216;
+  wire                when_PmpPlugin_l229;
+  wire                when_StateMachine_l214;
+  wire                when_StateMachine_l230;
+  wire                when_StateMachine_l230_1;
+  wire                when_StateMachine_l230_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
-  reg                 execute_CsrPlugin_csr_944;
-  reg                 execute_CsrPlugin_csr_945;
-  reg                 execute_CsrPlugin_csr_946;
-  reg                 execute_CsrPlugin_csr_947;
-  reg                 execute_CsrPlugin_csr_948;
-  reg                 execute_CsrPlugin_csr_949;
-  reg                 execute_CsrPlugin_csr_950;
-  reg                 execute_CsrPlugin_csr_951;
-  reg                 execute_CsrPlugin_csr_952;
-  reg                 execute_CsrPlugin_csr_953;
-  reg                 execute_CsrPlugin_csr_954;
-  reg                 execute_CsrPlugin_csr_955;
-  reg                 execute_CsrPlugin_csr_956;
-  reg                 execute_CsrPlugin_csr_957;
-  reg                 execute_CsrPlugin_csr_958;
-  reg                 execute_CsrPlugin_csr_959;
-  reg                 execute_CsrPlugin_csr_928;
-  reg                 execute_CsrPlugin_csr_929;
-  reg                 execute_CsrPlugin_csr_930;
-  reg                 execute_CsrPlugin_csr_931;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_570;
-  reg        [31:0]   _zz_571;
-  reg        [31:0]   _zz_572;
-  reg        [31:0]   _zz_573;
-  reg        [31:0]   _zz_574;
-  reg        [31:0]   _zz_575;
-  reg        [31:0]   _zz_576;
-  reg        [31:0]   _zz_577;
-  reg        [31:0]   _zz_578;
-  reg        [31:0]   _zz_579;
-  reg        [31:0]   _zz_580;
-  reg        [31:0]   _zz_581;
-  reg        [31:0]   _zz_582;
-  reg        [31:0]   _zz_583;
-  reg        [31:0]   _zz_584;
-  reg        [31:0]   _zz_585;
-  reg        [31:0]   _zz_586;
-  reg        [31:0]   _zz_587;
-  reg        [31:0]   _zz_588;
-  reg        [31:0]   _zz_589;
-  reg        [31:0]   _zz_590;
-  reg        [31:0]   _zz_591;
-  reg        [31:0]   _zz_592;
-  reg        [31:0]   _zz_593;
-  reg        [31:0]   _zz_594;
-  reg        [31:0]   _zz_595;
-  reg        [31:0]   _zz_596;
-  reg        [31:0]   _zz_597;
-  reg        [31:0]   _zz_598;
-  reg        [31:0]   _zz_599;
-  reg        [31:0]   _zz_600;
-  reg        [31:0]   _zz_601;
-  reg        [31:0]   _zz_602;
-  reg        [31:0]   _zz_603;
-  reg        [31:0]   _zz_604;
-  reg        [31:0]   _zz_605;
-  reg        [31:0]   _zz_606;
-  reg        [31:0]   _zz_607;
-  reg        [31:0]   _zz_608;
-  reg        [31:0]   _zz_609;
-  reg        [31:0]   _zz_610;
-  reg        [31:0]   _zz_611;
-  reg        [31:0]   _zz_612;
-  reg        [2:0]    _zz_613;
-  reg                 _zz_614;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_PmpPlugin_l155;
+  wire                when_PmpPlugin_l172;
+  wire                when_PmpPlugin_l175;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_615;
-  wire                _zz_616;
-  wire                _zz_617;
-  wire                _zz_618;
-  wire                _zz_619;
-  wire                _zz_620;
-  reg                 _zz_621;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_51_string;
-  reg [95:0] _zz_513_string;
-  reg [63:0] _zz_514_string;
-  reg [23:0] _zz_515_string;
-  reg [39:0] _zz_516_string;
-  reg [71:0] _zz_517_string;
-  reg [31:0] _zz_518_string;
-  reg [39:0] _zz_519_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [255:0] execute_PmpPlugin_fsm_stateReg_string;
+  reg [255:0] execute_PmpPlugin_fsm_stateNext_string;
   `endif
 
+  (* ram_style = "distributed" *) reg [31:0] PmpPlugin_pmpaddr [0:15];
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_671 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_672 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_673 = 1'b1;
-  assign _zz_674 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_675 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_676 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_677 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_678 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_679 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_680 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_681 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_682 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_683 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_684 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_685 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_686 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_687 = (_zz_816 == 5'h0);
-  assign _zz_688 = (_zz_826 == 5'h0);
-  assign _zz_689 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_690 = (1'b0 || (! 1'b1));
-  assign _zz_691 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_692 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_693 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_694 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_695 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_696 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_697 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_698 = execute_INSTRUCTION[13 : 12];
-  assign _zz_699 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_700 = (! memory_arbitration_isStuck);
-  assign _zz_701 = (iBus_cmd_valid || (_zz_613 != 3'b000));
-  assign _zz_702 = (_zz_649 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_703 = (! _zz_89);
-  assign _zz_704 = (! _zz_108);
-  assign _zz_705 = (! _zz_127);
-  assign _zz_706 = (! _zz_146);
-  assign _zz_707 = (! _zz_165);
-  assign _zz_708 = (! _zz_184);
-  assign _zz_709 = (! _zz_203);
-  assign _zz_710 = (! _zz_222);
-  assign _zz_711 = (! _zz_241);
-  assign _zz_712 = (! _zz_260);
-  assign _zz_713 = (! _zz_279);
-  assign _zz_714 = (! _zz_298);
-  assign _zz_715 = (! _zz_317);
-  assign _zz_716 = (! _zz_336);
-  assign _zz_717 = (! _zz_355);
-  assign _zz_718 = (! _zz_374);
-  assign _zz_719 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_720 = ((_zz_558 && 1'b1) && (! 1'b0));
-  assign _zz_721 = ((_zz_559 && 1'b1) && (! 1'b0));
-  assign _zz_722 = ((_zz_560 && 1'b1) && (! 1'b0));
-  assign _zz_723 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_724 = execute_INSTRUCTION[13];
-  assign _zz_725 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_726 = ($signed(_zz_727) + $signed(_zz_732));
-  assign _zz_727 = ($signed(_zz_728) + $signed(_zz_730));
-  assign _zz_728 = 52'h0;
-  assign _zz_729 = {1'b0,memory_MUL_LL};
-  assign _zz_730 = {{19{_zz_729[32]}}, _zz_729};
-  assign _zz_731 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_732 = {{2{_zz_731[49]}}, _zz_731};
-  assign _zz_733 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_734 = {{2{_zz_733[49]}}, _zz_733};
-  assign _zz_735 = ($signed(_zz_737) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_736 = _zz_735[31 : 0];
-  assign _zz_737 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_738 = _zz_508[31 : 31];
-  assign _zz_739 = _zz_508[30 : 30];
-  assign _zz_740 = _zz_508[29 : 29];
-  assign _zz_741 = _zz_508[28 : 28];
-  assign _zz_742 = _zz_508[25 : 25];
-  assign _zz_743 = _zz_508[17 : 17];
-  assign _zz_744 = _zz_508[16 : 16];
-  assign _zz_745 = _zz_508[13 : 13];
-  assign _zz_746 = _zz_508[12 : 12];
-  assign _zz_747 = _zz_508[11 : 11];
-  assign _zz_748 = _zz_508[15 : 15];
-  assign _zz_749 = _zz_508[5 : 5];
-  assign _zz_750 = _zz_508[3 : 3];
-  assign _zz_751 = _zz_508[20 : 20];
-  assign _zz_752 = _zz_508[10 : 10];
-  assign _zz_753 = _zz_508[4 : 4];
-  assign _zz_754 = _zz_508[0 : 0];
-  assign _zz_755 = (_zz_54 - 4'b0001);
-  assign _zz_756 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_757 = {29'd0, _zz_756};
-  assign _zz_758 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_759 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_760 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_761 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_762 = {{_zz_71,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_763 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_764 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_765 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_766 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_767 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_768 = (_zz_91 + 32'h00000001);
-  assign _zz_769 = (_zz_770 <<< 3);
-  assign _zz_770 = (_zz_103 + 32'h00000001);
-  assign _zz_771 = (_zz_110 + 32'h00000001);
-  assign _zz_772 = (_zz_773 <<< 3);
-  assign _zz_773 = (_zz_122 + 32'h00000001);
-  assign _zz_774 = (_zz_129 + 32'h00000001);
-  assign _zz_775 = (_zz_776 <<< 3);
-  assign _zz_776 = (_zz_141 + 32'h00000001);
-  assign _zz_777 = (_zz_148 + 32'h00000001);
-  assign _zz_778 = (_zz_779 <<< 3);
-  assign _zz_779 = (_zz_160 + 32'h00000001);
-  assign _zz_780 = (_zz_167 + 32'h00000001);
-  assign _zz_781 = (_zz_782 <<< 3);
-  assign _zz_782 = (_zz_179 + 32'h00000001);
-  assign _zz_783 = (_zz_186 + 32'h00000001);
-  assign _zz_784 = (_zz_785 <<< 3);
-  assign _zz_785 = (_zz_198 + 32'h00000001);
-  assign _zz_786 = (_zz_205 + 32'h00000001);
-  assign _zz_787 = (_zz_788 <<< 3);
-  assign _zz_788 = (_zz_217 + 32'h00000001);
-  assign _zz_789 = (_zz_224 + 32'h00000001);
-  assign _zz_790 = (_zz_791 <<< 3);
-  assign _zz_791 = (_zz_236 + 32'h00000001);
-  assign _zz_792 = (_zz_243 + 32'h00000001);
-  assign _zz_793 = (_zz_794 <<< 3);
-  assign _zz_794 = (_zz_255 + 32'h00000001);
-  assign _zz_795 = (_zz_262 + 32'h00000001);
-  assign _zz_796 = (_zz_797 <<< 3);
-  assign _zz_797 = (_zz_274 + 32'h00000001);
-  assign _zz_798 = (_zz_281 + 32'h00000001);
-  assign _zz_799 = (_zz_800 <<< 3);
-  assign _zz_800 = (_zz_293 + 32'h00000001);
-  assign _zz_801 = (_zz_300 + 32'h00000001);
-  assign _zz_802 = (_zz_803 <<< 3);
-  assign _zz_803 = (_zz_312 + 32'h00000001);
-  assign _zz_804 = (_zz_319 + 32'h00000001);
-  assign _zz_805 = (_zz_806 <<< 3);
-  assign _zz_806 = (_zz_331 + 32'h00000001);
-  assign _zz_807 = (_zz_338 + 32'h00000001);
-  assign _zz_808 = (_zz_809 <<< 3);
-  assign _zz_809 = (_zz_350 + 32'h00000001);
-  assign _zz_810 = (_zz_357 + 32'h00000001);
-  assign _zz_811 = (_zz_812 <<< 3);
-  assign _zz_812 = (_zz_369 + 32'h00000001);
-  assign _zz_813 = (_zz_376 + 32'h00000001);
-  assign _zz_814 = (_zz_815 <<< 3);
-  assign _zz_815 = (_zz_388 + 32'h00000001);
-  assign _zz_816 = (_zz_817 + _zz_820);
-  assign _zz_817 = (_zz_818 + _zz_819);
-  assign _zz_818 = (_zz_653 + _zz_654);
-  assign _zz_819 = (_zz_655 + _zz_656);
-  assign _zz_820 = (_zz_657 + _zz_658);
-  assign _zz_821 = PmpPlugin_ports_0_hits_15;
-  assign _zz_822 = {2'd0, _zz_821};
-  assign _zz_823 = (_zz_398 - 16'h0001);
-  assign _zz_824 = (_zz_415 - 16'h0001);
-  assign _zz_825 = (_zz_432 - 16'h0001);
-  assign _zz_826 = (_zz_827 + _zz_830);
-  assign _zz_827 = (_zz_828 + _zz_829);
-  assign _zz_828 = (_zz_662 + _zz_663);
-  assign _zz_829 = (_zz_664 + _zz_665);
-  assign _zz_830 = (_zz_666 + _zz_667);
-  assign _zz_831 = PmpPlugin_ports_1_hits_15;
-  assign _zz_832 = {2'd0, _zz_831};
-  assign _zz_833 = (_zz_457 - 16'h0001);
-  assign _zz_834 = (_zz_474 - 16'h0001);
-  assign _zz_835 = (_zz_491 - 16'h0001);
-  assign _zz_836 = execute_SRC_LESS;
-  assign _zz_837 = 3'b100;
-  assign _zz_838 = execute_INSTRUCTION[19 : 15];
-  assign _zz_839 = execute_INSTRUCTION[31 : 20];
-  assign _zz_840 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_841 = ($signed(_zz_842) + $signed(_zz_845));
-  assign _zz_842 = ($signed(_zz_843) + $signed(_zz_844));
-  assign _zz_843 = execute_SRC1;
-  assign _zz_844 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_845 = (execute_SRC_USE_SUB_LESS ? _zz_846 : _zz_847);
-  assign _zz_846 = 32'h00000001;
-  assign _zz_847 = 32'h0;
-  assign _zz_848 = execute_INSTRUCTION[31 : 20];
-  assign _zz_849 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_850 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_851 = {_zz_545,execute_INSTRUCTION[31 : 20]};
-  assign _zz_852 = {{_zz_547,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_853 = {{_zz_549,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_854 = execute_INSTRUCTION[31 : 20];
-  assign _zz_855 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_856 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_857 = 3'b100;
-  assign _zz_858 = (_zz_561 & (~ _zz_859));
-  assign _zz_859 = (_zz_561 - 2'b01);
-  assign _zz_860 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_861 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_862 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_863 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_864 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_865 = {5'd0, _zz_864};
-  assign _zz_866 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_867 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_868 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_869 = {_zz_563,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_870 = _zz_871;
-  assign _zz_871 = _zz_872;
-  assign _zz_872 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_564) : _zz_564)} + _zz_874);
-  assign _zz_873 = memory_DivPlugin_div_needRevert;
-  assign _zz_874 = {32'd0, _zz_873};
-  assign _zz_875 = _zz_566;
-  assign _zz_876 = {32'd0, _zz_875};
-  assign _zz_877 = _zz_565;
-  assign _zz_878 = {31'd0, _zz_877};
-  assign _zz_879 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_880 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_881 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_882 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_883 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_884 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_885 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_886 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_887 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_888 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_889 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_890 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_891 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_892 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_893 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_894 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_895 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_896 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_897 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_898 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_899 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_900 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_901 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_902 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_903 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_904 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_905 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_906 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_907 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_908 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_909 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_910 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_911 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_912 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_913 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_914 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_915 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_916 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_917 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_918 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_919 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_920 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_921 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_922 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_923 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_924 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_925 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_926 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_927 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_928 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_929 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_930 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_931 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_932 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_933 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_934 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_935 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_936 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_937 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_938 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_939 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_940 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_941 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_942 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_943 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_944 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_945 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_946 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_947 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_948 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_949 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_950 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_951 = 1'b1;
-  assign _zz_952 = 1'b1;
-  assign _zz_953 = {_zz_58,_zz_57};
-  assign _zz_954 = {PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}};
-  assign _zz_955 = {PmpPlugin_ports_0_hits_5,{PmpPlugin_ports_0_hits_4,PmpPlugin_ports_0_hits_3}};
-  assign _zz_956 = {PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,PmpPlugin_ports_0_hits_6}};
-  assign _zz_957 = {PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,PmpPlugin_ports_0_hits_9}};
-  assign _zz_958 = {PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,PmpPlugin_ports_0_hits_12}};
-  assign _zz_959 = {_zz_414,{_zz_413,{_zz_412,_zz_411}}};
-  assign _zz_960 = {_zz_431,{_zz_430,{_zz_429,_zz_428}}};
-  assign _zz_961 = {_zz_448,{_zz_447,{_zz_446,_zz_445}}};
-  assign _zz_962 = {PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}};
-  assign _zz_963 = {PmpPlugin_ports_1_hits_5,{PmpPlugin_ports_1_hits_4,PmpPlugin_ports_1_hits_3}};
-  assign _zz_964 = {PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,PmpPlugin_ports_1_hits_6}};
-  assign _zz_965 = {PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,PmpPlugin_ports_1_hits_9}};
-  assign _zz_966 = {PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,PmpPlugin_ports_1_hits_12}};
-  assign _zz_967 = {_zz_473,{_zz_472,{_zz_471,_zz_470}}};
-  assign _zz_968 = {_zz_490,{_zz_489,{_zz_488,_zz_487}}};
-  assign _zz_969 = {_zz_507,{_zz_506,{_zz_505,_zz_504}}};
-  assign _zz_970 = 32'h0000107f;
-  assign _zz_971 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_972 = 32'h00002073;
-  assign _zz_973 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_974 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_975 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_976) == 32'h00000003),{(_zz_977 == _zz_978),{_zz_979,{_zz_980,_zz_981}}}}}};
-  assign _zz_976 = 32'h0000505f;
-  assign _zz_977 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_978 = 32'h00000063;
-  assign _zz_979 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_980 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_981 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_982) == 32'h00001013),{(_zz_983 == _zz_984),{_zz_985,{_zz_986,_zz_987}}}}}};
-  assign _zz_982 = 32'hfc00307f;
-  assign _zz_983 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_984 = 32'h00005033;
-  assign _zz_985 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_986 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_987 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_988 = decode_INSTRUCTION[31];
-  assign _zz_989 = decode_INSTRUCTION[31];
-  assign _zz_990 = decode_INSTRUCTION[7];
-  assign _zz_991 = PmpPlugin_ports_0_hits_5;
-  assign _zz_992 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_993 = PmpPlugin_ports_0_hits_5;
-  assign _zz_994 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_995 = PmpPlugin_ports_0_hits_5;
-  assign _zz_996 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_997 = PmpPlugin_ports_1_hits_5;
-  assign _zz_998 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_999 = PmpPlugin_ports_1_hits_5;
-  assign _zz_1000 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_1001 = PmpPlugin_ports_1_hits_5;
-  assign _zz_1002 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_1003 = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_1004 = 32'h02004020;
-  assign _zz_1005 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_1006 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
-  assign _zz_1007 = 1'b0;
-  assign _zz_1008 = (((decode_INSTRUCTION & _zz_1011) == 32'h00000050) != 1'b0);
-  assign _zz_1009 = ({_zz_1012,_zz_1013} != 2'b00);
-  assign _zz_1010 = {({_zz_1014,_zz_1015} != 2'b00),{(_zz_1016 != _zz_1017),{_zz_1018,{_zz_1019,_zz_1020}}}};
-  assign _zz_1011 = 32'h00403050;
-  assign _zz_1012 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_1013 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_1014 = _zz_511;
-  assign _zz_1015 = ((decode_INSTRUCTION & _zz_1021) == 32'h00000004);
-  assign _zz_1016 = ((decode_INSTRUCTION & _zz_1022) == 32'h00000040);
-  assign _zz_1017 = 1'b0;
-  assign _zz_1018 = ({_zz_1023,_zz_1024} != 2'b00);
-  assign _zz_1019 = ({_zz_1025,_zz_1026} != 3'b000);
-  assign _zz_1020 = {(_zz_1027 != _zz_1028),{_zz_1029,{_zz_1030,_zz_1031}}};
-  assign _zz_1021 = 32'h0000001c;
-  assign _zz_1022 = 32'h00000058;
-  assign _zz_1023 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz_1024 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz_1025 = ((decode_INSTRUCTION & _zz_1032) == 32'h40001010);
-  assign _zz_1026 = {(_zz_1033 == _zz_1034),(_zz_1035 == _zz_1036)};
-  assign _zz_1027 = ((decode_INSTRUCTION & _zz_1037) == 32'h00000024);
-  assign _zz_1028 = 1'b0;
-  assign _zz_1029 = ((_zz_1038 == _zz_1039) != 1'b0);
-  assign _zz_1030 = (_zz_1040 != 1'b0);
-  assign _zz_1031 = {(_zz_1041 != _zz_1042),{_zz_1043,{_zz_1044,_zz_1045}}};
-  assign _zz_1032 = 32'h40003054;
-  assign _zz_1033 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_1034 = 32'h00001010;
-  assign _zz_1035 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_1036 = 32'h00001010;
-  assign _zz_1037 = 32'h00000064;
-  assign _zz_1038 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_1039 = 32'h00001000;
-  assign _zz_1040 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_1041 = {(_zz_1046 == _zz_1047),(_zz_1048 == _zz_1049)};
-  assign _zz_1042 = 2'b00;
-  assign _zz_1043 = ((_zz_1050 == _zz_1051) != 1'b0);
-  assign _zz_1044 = ({_zz_1052,_zz_1053} != 2'b00);
-  assign _zz_1045 = {(_zz_1054 != _zz_1055),{_zz_1056,{_zz_1057,_zz_1058}}};
-  assign _zz_1046 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_1047 = 32'h00002000;
-  assign _zz_1048 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_1049 = 32'h00001000;
-  assign _zz_1050 = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_1051 = 32'h00004008;
-  assign _zz_1052 = ((decode_INSTRUCTION & _zz_1059) == 32'h00000020);
-  assign _zz_1053 = ((decode_INSTRUCTION & _zz_1060) == 32'h00000020);
-  assign _zz_1054 = {(_zz_1061 == _zz_1062),{_zz_1063,{_zz_1064,_zz_1065}}};
-  assign _zz_1055 = 5'h0;
-  assign _zz_1056 = ((_zz_1066 == _zz_1067) != 1'b0);
-  assign _zz_1057 = ({_zz_1068,_zz_1069} != 5'h0);
-  assign _zz_1058 = {(_zz_1070 != _zz_1071),{_zz_1072,{_zz_1073,_zz_1074}}};
-  assign _zz_1059 = 32'h00000034;
-  assign _zz_1060 = 32'h00000064;
-  assign _zz_1061 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_1062 = 32'h00002040;
-  assign _zz_1063 = ((decode_INSTRUCTION & _zz_1075) == 32'h00001040);
-  assign _zz_1064 = (_zz_1076 == _zz_1077);
-  assign _zz_1065 = {_zz_1078,_zz_1079};
-  assign _zz_1066 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_1067 = 32'h00000020;
-  assign _zz_1068 = (_zz_1080 == _zz_1081);
-  assign _zz_1069 = {_zz_510,{_zz_1082,_zz_1083}};
-  assign _zz_1070 = {_zz_510,{_zz_1084,_zz_1085}};
-  assign _zz_1071 = 5'h0;
-  assign _zz_1072 = ({_zz_1086,_zz_1087} != 6'h0);
-  assign _zz_1073 = (_zz_1088 != _zz_1089);
-  assign _zz_1074 = {_zz_1090,{_zz_1091,_zz_1092}};
-  assign _zz_1075 = 32'h00001040;
-  assign _zz_1076 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_1077 = 32'h00000040;
-  assign _zz_1078 = ((decode_INSTRUCTION & _zz_1093) == 32'h00000040);
-  assign _zz_1079 = ((decode_INSTRUCTION & _zz_1094) == 32'h0);
-  assign _zz_1080 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_1081 = 32'h00000040;
-  assign _zz_1082 = (_zz_1095 == _zz_1096);
-  assign _zz_1083 = {_zz_1097,_zz_1098};
-  assign _zz_1084 = (_zz_1099 == _zz_1100);
-  assign _zz_1085 = {_zz_1101,{_zz_1102,_zz_1103}};
-  assign _zz_1086 = _zz_511;
-  assign _zz_1087 = {_zz_1104,{_zz_1105,_zz_1106}};
-  assign _zz_1088 = {_zz_510,_zz_1107};
-  assign _zz_1089 = 2'b00;
-  assign _zz_1090 = ({_zz_1108,_zz_1109} != 2'b00);
-  assign _zz_1091 = (_zz_1110 != _zz_1111);
-  assign _zz_1092 = {_zz_1112,{_zz_1113,_zz_1114}};
-  assign _zz_1093 = 32'h00400040;
-  assign _zz_1094 = 32'h00000038;
-  assign _zz_1095 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_1096 = 32'h00004020;
-  assign _zz_1097 = ((decode_INSTRUCTION & _zz_1115) == 32'h00000010);
-  assign _zz_1098 = ((decode_INSTRUCTION & _zz_1116) == 32'h00000020);
-  assign _zz_1099 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_1100 = 32'h00002010;
-  assign _zz_1101 = ((decode_INSTRUCTION & _zz_1117) == 32'h00000010);
-  assign _zz_1102 = (_zz_1118 == _zz_1119);
-  assign _zz_1103 = (_zz_1120 == _zz_1121);
-  assign _zz_1104 = ((decode_INSTRUCTION & _zz_1122) == 32'h00001010);
-  assign _zz_1105 = (_zz_1123 == _zz_1124);
-  assign _zz_1106 = {_zz_1125,{_zz_1126,_zz_1127}};
-  assign _zz_1107 = ((decode_INSTRUCTION & _zz_1128) == 32'h00000020);
-  assign _zz_1108 = _zz_510;
-  assign _zz_1109 = (_zz_1129 == _zz_1130);
-  assign _zz_1110 = (_zz_1131 == _zz_1132);
-  assign _zz_1111 = 1'b0;
-  assign _zz_1112 = (_zz_1133 != 1'b0);
-  assign _zz_1113 = (_zz_1134 != _zz_1135);
-  assign _zz_1114 = {_zz_1136,{_zz_1137,_zz_1138}};
-  assign _zz_1115 = 32'h00000030;
-  assign _zz_1116 = 32'h02000020;
-  assign _zz_1117 = 32'h00001030;
-  assign _zz_1118 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_1119 = 32'h00002020;
-  assign _zz_1120 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_1121 = 32'h00000020;
-  assign _zz_1122 = 32'h00001010;
-  assign _zz_1123 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_1124 = 32'h00002010;
-  assign _zz_1125 = ((decode_INSTRUCTION & _zz_1139) == 32'h00000010);
-  assign _zz_1126 = (_zz_1140 == _zz_1141);
-  assign _zz_1127 = (_zz_1142 == _zz_1143);
-  assign _zz_1128 = 32'h00000070;
-  assign _zz_1129 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_1130 = 32'h0;
-  assign _zz_1131 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_1132 = 32'h00004010;
-  assign _zz_1133 = ((decode_INSTRUCTION & _zz_1144) == 32'h00002010);
-  assign _zz_1134 = {_zz_1145,{_zz_1146,_zz_1147}};
-  assign _zz_1135 = 4'b0000;
-  assign _zz_1136 = (_zz_1148 != 1'b0);
-  assign _zz_1137 = (_zz_1149 != _zz_1150);
-  assign _zz_1138 = {_zz_1151,{_zz_1152,_zz_1153}};
-  assign _zz_1139 = 32'h00000050;
-  assign _zz_1140 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_1141 = 32'h00000004;
-  assign _zz_1142 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_1143 = 32'h0;
-  assign _zz_1144 = 32'h00006014;
-  assign _zz_1145 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz_1146 = ((decode_INSTRUCTION & _zz_1154) == 32'h0);
-  assign _zz_1147 = {(_zz_1155 == _zz_1156),(_zz_1157 == _zz_1158)};
-  assign _zz_1148 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_1149 = {(_zz_1159 == _zz_1160),{_zz_1161,_zz_1162}};
-  assign _zz_1150 = 3'b000;
-  assign _zz_1151 = ({_zz_1163,_zz_509} != 2'b00);
-  assign _zz_1152 = ({_zz_1164,_zz_1165} != 2'b00);
-  assign _zz_1153 = (_zz_1166 != 1'b0);
-  assign _zz_1154 = 32'h00000018;
-  assign _zz_1155 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_1156 = 32'h00002000;
-  assign _zz_1157 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_1158 = 32'h00001000;
-  assign _zz_1159 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_1160 = 32'h00000040;
-  assign _zz_1161 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_1162 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz_1163 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_1164 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_1165 = _zz_509;
-  assign _zz_1166 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_1167 = execute_INSTRUCTION[31];
-  assign _zz_1168 = execute_INSTRUCTION[31];
-  assign _zz_1169 = execute_INSTRUCTION[7];
-  assign _zz_1170 = (_zz_570 | _zz_571);
-  assign _zz_1171 = (_zz_572 | _zz_573);
-  assign _zz_1172 = (_zz_574 | _zz_575);
-  assign _zz_1173 = (_zz_576 | _zz_577);
-  assign _zz_1174 = (_zz_578 | _zz_579);
-  assign _zz_1175 = (_zz_580 | _zz_581);
-  assign _zz_1176 = (_zz_582 | _zz_583);
-  assign _zz_1177 = (_zz_584 | _zz_585);
-  assign _zz_1178 = (_zz_586 | _zz_587);
-  assign _zz_1179 = (_zz_588 | _zz_589);
-  assign _zz_1180 = (_zz_590 | _zz_591);
-  assign _zz_1181 = (_zz_592 | _zz_593);
-  assign _zz_1182 = (_zz_1186 | _zz_594);
-  assign _zz_1183 = (_zz_595 | _zz_596);
-  assign _zz_1184 = (_zz_597 | _zz_598);
-  assign _zz_1185 = (_zz_599 | _zz_600);
-  assign _zz_1186 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_951) begin
-      _zz_650 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_3 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_5 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_7 = {{_zz_4,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_7_1 = {{_zz_6,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_PmpPlugin_pmpaddr_port = execute_PmpPlugin_writeData_;
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_PmpPlugin_dGuard_hits_0_2 = 4'b0000;
+  assign _zz_PmpPlugin_dGuard_hits_0_4 = 4'b0000;
+  assign _zz_PmpPlugin_dGuard_hits_1_1 = 4'b0001;
+  assign _zz_PmpPlugin_dGuard_hits_1_3 = 4'b0001;
+  assign _zz_PmpPlugin_dGuard_hits_2_1 = 4'b0010;
+  assign _zz_PmpPlugin_dGuard_hits_2_3 = 4'b0010;
+  assign _zz_PmpPlugin_dGuard_hits_3_1 = 4'b0011;
+  assign _zz_PmpPlugin_dGuard_hits_3_3 = 4'b0011;
+  assign _zz_PmpPlugin_dGuard_hits_4_1 = 4'b0100;
+  assign _zz_PmpPlugin_dGuard_hits_4_3 = 4'b0100;
+  assign _zz_PmpPlugin_dGuard_hits_5_1 = 4'b0101;
+  assign _zz_PmpPlugin_dGuard_hits_5_3 = 4'b0101;
+  assign _zz_PmpPlugin_dGuard_hits_6_1 = 4'b0110;
+  assign _zz_PmpPlugin_dGuard_hits_6_3 = 4'b0110;
+  assign _zz_PmpPlugin_dGuard_hits_7_1 = 4'b0111;
+  assign _zz_PmpPlugin_dGuard_hits_7_3 = 4'b0111;
+  assign _zz_PmpPlugin_dGuard_hits_8_1 = 4'b1000;
+  assign _zz_PmpPlugin_dGuard_hits_8_3 = 4'b1000;
+  assign _zz_PmpPlugin_dGuard_hits_9_1 = 4'b1001;
+  assign _zz_PmpPlugin_dGuard_hits_9_3 = 4'b1001;
+  assign _zz_PmpPlugin_dGuard_hits_10_1 = 4'b1010;
+  assign _zz_PmpPlugin_dGuard_hits_10_3 = 4'b1010;
+  assign _zz_PmpPlugin_dGuard_hits_11_1 = 4'b1011;
+  assign _zz_PmpPlugin_dGuard_hits_11_3 = 4'b1011;
+  assign _zz_PmpPlugin_dGuard_hits_12_1 = 4'b1100;
+  assign _zz_PmpPlugin_dGuard_hits_12_3 = 4'b1100;
+  assign _zz_PmpPlugin_dGuard_hits_13_1 = 4'b1101;
+  assign _zz_PmpPlugin_dGuard_hits_13_3 = 4'b1101;
+  assign _zz_PmpPlugin_dGuard_hits_14_1 = 4'b1110;
+  assign _zz_PmpPlugin_dGuard_hits_14_3 = 4'b1110;
+  assign _zz_PmpPlugin_dGuard_hits_15_1 = 4'b1111;
+  assign _zz_PmpPlugin_dGuard_hits_15_3 = 4'b1111;
+  assign _zz_PmpPlugin_iGuard_hits_0_2 = 4'b0000;
+  assign _zz_PmpPlugin_iGuard_hits_0_4 = 4'b0000;
+  assign _zz_PmpPlugin_iGuard_hits_1_1 = 4'b0001;
+  assign _zz_PmpPlugin_iGuard_hits_1_3 = 4'b0001;
+  assign _zz_PmpPlugin_iGuard_hits_2_1 = 4'b0010;
+  assign _zz_PmpPlugin_iGuard_hits_2_3 = 4'b0010;
+  assign _zz_PmpPlugin_iGuard_hits_3_1 = 4'b0011;
+  assign _zz_PmpPlugin_iGuard_hits_3_3 = 4'b0011;
+  assign _zz_PmpPlugin_iGuard_hits_4_1 = 4'b0100;
+  assign _zz_PmpPlugin_iGuard_hits_4_3 = 4'b0100;
+  assign _zz_PmpPlugin_iGuard_hits_5_1 = 4'b0101;
+  assign _zz_PmpPlugin_iGuard_hits_5_3 = 4'b0101;
+  assign _zz_PmpPlugin_iGuard_hits_6_1 = 4'b0110;
+  assign _zz_PmpPlugin_iGuard_hits_6_3 = 4'b0110;
+  assign _zz_PmpPlugin_iGuard_hits_7_1 = 4'b0111;
+  assign _zz_PmpPlugin_iGuard_hits_7_3 = 4'b0111;
+  assign _zz_PmpPlugin_iGuard_hits_8_1 = 4'b1000;
+  assign _zz_PmpPlugin_iGuard_hits_8_3 = 4'b1000;
+  assign _zz_PmpPlugin_iGuard_hits_9_1 = 4'b1001;
+  assign _zz_PmpPlugin_iGuard_hits_9_3 = 4'b1001;
+  assign _zz_PmpPlugin_iGuard_hits_10_1 = 4'b1010;
+  assign _zz_PmpPlugin_iGuard_hits_10_3 = 4'b1010;
+  assign _zz_PmpPlugin_iGuard_hits_11_1 = 4'b1011;
+  assign _zz_PmpPlugin_iGuard_hits_11_3 = 4'b1011;
+  assign _zz_PmpPlugin_iGuard_hits_12_1 = 4'b1100;
+  assign _zz_PmpPlugin_iGuard_hits_12_3 = 4'b1100;
+  assign _zz_PmpPlugin_iGuard_hits_13_1 = 4'b1101;
+  assign _zz_PmpPlugin_iGuard_hits_13_3 = 4'b1101;
+  assign _zz_PmpPlugin_iGuard_hits_14_1 = 4'b1110;
+  assign _zz_PmpPlugin_iGuard_hits_14_3 = 4'b1110;
+  assign _zz_PmpPlugin_iGuard_hits_15_1 = 4'b1111;
+  assign _zz_PmpPlugin_iGuard_hits_15_3 = 4'b1111;
+  assign _zz_when_PmpPlugin_l209_1 = {execute_PmpPlugin_pmpcfgN_,2'b00};
+  assign _zz_when_PmpPlugin_l209_1_2 = {execute_PmpPlugin_pmpcfgN_,2'b01};
+  assign _zz_when_PmpPlugin_l209_2_1 = {execute_PmpPlugin_pmpcfgN_,2'b10};
+  assign _zz_when_PmpPlugin_l209_3_1 = {execute_PmpPlugin_pmpcfgN_,2'b11};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_1 = {execute_PmpPlugin_pmpcfgN,2'b11};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_3 = {execute_PmpPlugin_pmpcfgN,2'b10};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_5 = {execute_PmpPlugin_pmpcfgN,2'b01};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_7 = {execute_PmpPlugin_pmpcfgN,2'b00};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz_when_PmpPlugin_l277 = PmpPlugin_dGuard_hits_6;
+  assign _zz_when_PmpPlugin_l277_1 = {PmpPlugin_dGuard_hits_5,{PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead = PmpPlugin_pmpcfg_11[0];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = (PmpPlugin_dGuard_hits_10 && PmpPlugin_pmpcfg_10[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2 = (PmpPlugin_dGuard_hits_9 && PmpPlugin_pmpcfg_9[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3 = {(PmpPlugin_dGuard_hits_8 && PmpPlugin_pmpcfg_8[0]),{(PmpPlugin_dGuard_hits_7 && PmpPlugin_pmpcfg_7[0]),{(PmpPlugin_dGuard_hits_6 && PmpPlugin_pmpcfg_6[0]),{(PmpPlugin_dGuard_hits_5 && PmpPlugin_pmpcfg_5[0]),{(PmpPlugin_dGuard_hits_4 && _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4),{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6,_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4 = PmpPlugin_pmpcfg_4[0];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5 = (PmpPlugin_dGuard_hits_3 && PmpPlugin_pmpcfg_3[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6 = (PmpPlugin_dGuard_hits_2 && PmpPlugin_pmpcfg_2[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7 = {(PmpPlugin_dGuard_hits_1 && PmpPlugin_pmpcfg_1[0]),(PmpPlugin_dGuard_hits_0 && PmpPlugin_pmpcfg_0[0])};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = PmpPlugin_pmpcfg_11[1];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = (PmpPlugin_dGuard_hits_10 && PmpPlugin_pmpcfg_10[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2 = (PmpPlugin_dGuard_hits_9 && PmpPlugin_pmpcfg_9[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3 = {(PmpPlugin_dGuard_hits_8 && PmpPlugin_pmpcfg_8[1]),{(PmpPlugin_dGuard_hits_7 && PmpPlugin_pmpcfg_7[1]),{(PmpPlugin_dGuard_hits_6 && PmpPlugin_pmpcfg_6[1]),{(PmpPlugin_dGuard_hits_5 && PmpPlugin_pmpcfg_5[1]),{(PmpPlugin_dGuard_hits_4 && _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4),{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6,_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4 = PmpPlugin_pmpcfg_4[1];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5 = (PmpPlugin_dGuard_hits_3 && PmpPlugin_pmpcfg_3[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6 = (PmpPlugin_dGuard_hits_2 && PmpPlugin_pmpcfg_2[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7 = {(PmpPlugin_dGuard_hits_1 && PmpPlugin_pmpcfg_1[1]),(PmpPlugin_dGuard_hits_0 && PmpPlugin_pmpcfg_0[1])};
+  assign _zz_when_PmpPlugin_l299 = PmpPlugin_iGuard_hits_6;
+  assign _zz_when_PmpPlugin_l299_1 = {PmpPlugin_iGuard_hits_5,{PmpPlugin_iGuard_hits_4,{PmpPlugin_iGuard_hits_3,{PmpPlugin_iGuard_hits_2,{PmpPlugin_iGuard_hits_1,PmpPlugin_iGuard_hits_0}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute = PmpPlugin_pmpcfg_11[2];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = (PmpPlugin_iGuard_hits_10 && PmpPlugin_pmpcfg_10[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2 = (PmpPlugin_iGuard_hits_9 && PmpPlugin_pmpcfg_9[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = {(PmpPlugin_iGuard_hits_8 && PmpPlugin_pmpcfg_8[2]),{(PmpPlugin_iGuard_hits_7 && PmpPlugin_pmpcfg_7[2]),{(PmpPlugin_iGuard_hits_6 && PmpPlugin_pmpcfg_6[2]),{(PmpPlugin_iGuard_hits_5 && PmpPlugin_pmpcfg_5[2]),{(PmpPlugin_iGuard_hits_4 && _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4),{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4 = PmpPlugin_pmpcfg_4[2];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = (PmpPlugin_iGuard_hits_3 && PmpPlugin_pmpcfg_3[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6 = (PmpPlugin_iGuard_hits_2 && PmpPlugin_pmpcfg_2[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = {(PmpPlugin_iGuard_hits_1 && PmpPlugin_pmpcfg_1[2]),(PmpPlugin_iGuard_hits_0 && PmpPlugin_pmpcfg_0[2])};
+  assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_6) == 32'h00000050) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ({_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {({_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_12} != 2'b00),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_16),{_zz__zz_decode_IS_RS2_SIGNED_17,{_zz__zz_decode_IS_RS2_SIGNED_20,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h00403050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_15) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ({_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25),(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (_zz__zz_decode_IS_RS2_SIGNED_36 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(_zz__zz_decode_IS_RS2_SIGNED_38 != _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_52}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40),(_zz__zz_decode_IS_RS2_SIGNED_41 == _zz__zz_decode_IS_RS2_SIGNED_42)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ({_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_50} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = {(_zz__zz_decode_IS_RS2_SIGNED_53 != _zz__zz_decode_IS_RS2_SIGNED_66),{_zz__zz_decode_IS_RS2_SIGNED_67,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_83}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00004008;
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = {(_zz__zz_decode_IS_RS2_SIGNED_54 == _zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_58,_zz__zz_decode_IS_RS2_SIGNED_61}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = ((_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ({_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_74} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(_zz__zz_decode_IS_RS2_SIGNED_84 != _zz__zz_decode_IS_RS2_SIGNED_97),{_zz__zz_decode_IS_RS2_SIGNED_98,{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_120}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_57) == 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (_zz__zz_decode_IS_RS2_SIGNED_59 == _zz__zz_decode_IS_RS2_SIGNED_60);
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_64};
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (_zz__zz_decode_IS_RS2_SIGNED_72 == _zz__zz_decode_IS_RS2_SIGNED_73);
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 5'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ({_zz__zz_decode_IS_RS2_SIGNED_99,_zz__zz_decode_IS_RS2_SIGNED_100} != 6'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (_zz__zz_decode_IS_RS2_SIGNED_116 != _zz__zz_decode_IS_RS2_SIGNED_119);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = {_zz__zz_decode_IS_RS2_SIGNED_121,{_zz__zz_decode_IS_RS2_SIGNED_126,_zz__zz_decode_IS_RS2_SIGNED_131}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_81};
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_94}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {_zz__zz_decode_IS_RS2_SIGNED_101,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_117};
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ({_zz__zz_decode_IS_RS2_SIGNED_122,_zz__zz_decode_IS_RS2_SIGNED_123} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (_zz__zz_decode_IS_RS2_SIGNED_127 != _zz__zz_decode_IS_RS2_SIGNED_130);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = {_zz__zz_decode_IS_RS2_SIGNED_132,{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_146}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00400040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000038;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (_zz__zz_decode_IS_RS2_SIGNED_92 == _zz__zz_decode_IS_RS2_SIGNED_93);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (_zz__zz_decode_IS_RS2_SIGNED_95 == _zz__zz_decode_IS_RS2_SIGNED_96);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_112}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (_zz__zz_decode_IS_RS2_SIGNED_124 == _zz__zz_decode_IS_RS2_SIGNED_125);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (_zz__zz_decode_IS_RS2_SIGNED_128 == _zz__zz_decode_IS_RS2_SIGNED_129);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (_zz__zz_decode_IS_RS2_SIGNED_133 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (_zz__zz_decode_IS_RS2_SIGNED_136 != _zz__zz_decode_IS_RS2_SIGNED_145);
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz__zz_decode_IS_RS2_SIGNED_147,{_zz__zz_decode_IS_RS2_SIGNED_149,_zz__zz_decode_IS_RS2_SIGNED_156}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00000030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h02000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00001030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00002020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111);
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00000070;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00004010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_134) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {_zz__zz_decode_IS_RS2_SIGNED_137,{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_140}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = 4'b0000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (_zz__zz_decode_IS_RS2_SIGNED_148 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = (_zz__zz_decode_IS_RS2_SIGNED_150 != _zz__zz_decode_IS_RS2_SIGNED_155);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = {_zz__zz_decode_IS_RS2_SIGNED_157,{_zz__zz_decode_IS_RS2_SIGNED_159,_zz__zz_decode_IS_RS2_SIGNED_162}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = 32'h00006014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {(_zz__zz_decode_IS_RS2_SIGNED_141 == _zz__zz_decode_IS_RS2_SIGNED_142),(_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {(_zz__zz_decode_IS_RS2_SIGNED_151 == _zz__zz_decode_IS_RS2_SIGNED_152),{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_154}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 3'b000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = ({_zz__zz_decode_IS_RS2_SIGNED_158,_zz_decode_IS_RS2_SIGNED_1} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = ({_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_161} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = (_zz__zz_decode_IS_RS2_SIGNED_163 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000018;
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_PmpPlugin_pmpaddr_port0 = PmpPlugin_pmpaddr[execute_PmpPlugin_fsm_fsmCounter];
+  always @(posedge clk) begin
+    if(_zz_1) begin
+      PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg_] <= _zz_PmpPlugin_pmpaddr_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_952) begin
-      _zz_651 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  assign _zz_PmpPlugin_pmpaddr_port2 = PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_2) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
+  PmpSetter PmpPlugin_setter (
+    .io_addr    (PmpPlugin_setter_io_addr  ), //i
+    .io_base    (PmpPlugin_setter_io_base  ), //o
+    .io_mask    (PmpPlugin_setter_io_mask  )  //o
+  );
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_622                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_623                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_624                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_625                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_626                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_627                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_628                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_629                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_630                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_631                                            ), //i
-    .io_cpu_execute_address                    (_zz_632[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_81[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_633                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_634[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_635                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_636                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_637                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_638[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_639                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_640                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_641                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_642                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_643                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_644                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_645                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_646                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_647[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_648                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_649                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_953)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_652 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_652 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_652 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_652 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_954)
-      3'b000 : begin
-        _zz_653 = _zz_390;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
       end
-      3'b001 : begin
-        _zz_653 = _zz_391;
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
       end
-      3'b010 : begin
-        _zz_653 = _zz_392;
-      end
-      3'b011 : begin
-        _zz_653 = _zz_393;
-      end
-      3'b100 : begin
-        _zz_653 = _zz_394;
-      end
-      3'b101 : begin
-        _zz_653 = _zz_395;
-      end
-      3'b110 : begin
-        _zz_653 = _zz_396;
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
       end
       default : begin
-        _zz_653 = _zz_397;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_955)
-      3'b000 : begin
-        _zz_654 = _zz_390;
-      end
-      3'b001 : begin
-        _zz_654 = _zz_391;
-      end
-      3'b010 : begin
-        _zz_654 = _zz_392;
-      end
-      3'b011 : begin
-        _zz_654 = _zz_393;
-      end
-      3'b100 : begin
-        _zz_654 = _zz_394;
-      end
-      3'b101 : begin
-        _zz_654 = _zz_395;
-      end
-      3'b110 : begin
-        _zz_654 = _zz_396;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       default : begin
-        _zz_654 = _zz_397;
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_956)
-      3'b000 : begin
-        _zz_655 = _zz_390;
-      end
-      3'b001 : begin
-        _zz_655 = _zz_391;
-      end
-      3'b010 : begin
-        _zz_655 = _zz_392;
-      end
-      3'b011 : begin
-        _zz_655 = _zz_393;
-      end
-      3'b100 : begin
-        _zz_655 = _zz_394;
-      end
-      3'b101 : begin
-        _zz_655 = _zz_395;
-      end
-      3'b110 : begin
-        _zz_655 = _zz_396;
-      end
-      default : begin
-        _zz_655 = _zz_397;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_957)
-      3'b000 : begin
-        _zz_656 = _zz_390;
-      end
-      3'b001 : begin
-        _zz_656 = _zz_391;
-      end
-      3'b010 : begin
-        _zz_656 = _zz_392;
-      end
-      3'b011 : begin
-        _zz_656 = _zz_393;
-      end
-      3'b100 : begin
-        _zz_656 = _zz_394;
-      end
-      3'b101 : begin
-        _zz_656 = _zz_395;
-      end
-      3'b110 : begin
-        _zz_656 = _zz_396;
-      end
-      default : begin
-        _zz_656 = _zz_397;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_958)
-      3'b000 : begin
-        _zz_657 = _zz_390;
-      end
-      3'b001 : begin
-        _zz_657 = _zz_391;
-      end
-      3'b010 : begin
-        _zz_657 = _zz_392;
-      end
-      3'b011 : begin
-        _zz_657 = _zz_393;
-      end
-      3'b100 : begin
-        _zz_657 = _zz_394;
-      end
-      3'b101 : begin
-        _zz_657 = _zz_395;
-      end
-      3'b110 : begin
-        _zz_657 = _zz_396;
-      end
-      default : begin
-        _zz_657 = _zz_397;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_822)
-      3'b000 : begin
-        _zz_658 = _zz_390;
-      end
-      3'b001 : begin
-        _zz_658 = _zz_391;
-      end
-      3'b010 : begin
-        _zz_658 = _zz_392;
-      end
-      3'b011 : begin
-        _zz_658 = _zz_393;
-      end
-      3'b100 : begin
-        _zz_658 = _zz_394;
-      end
-      3'b101 : begin
-        _zz_658 = _zz_395;
-      end
-      3'b110 : begin
-        _zz_658 = _zz_396;
-      end
-      default : begin
-        _zz_658 = _zz_397;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_959)
+    case(execute_PmpPlugin_fsm_fsmCounter)
       4'b0000 : begin
-        _zz_659 = _zz_86;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_0;
       end
       4'b0001 : begin
-        _zz_659 = _zz_105;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_1;
       end
       4'b0010 : begin
-        _zz_659 = _zz_124;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_2;
       end
       4'b0011 : begin
-        _zz_659 = _zz_143;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_3;
       end
       4'b0100 : begin
-        _zz_659 = _zz_162;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_4;
       end
       4'b0101 : begin
-        _zz_659 = _zz_181;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_5;
       end
       4'b0110 : begin
-        _zz_659 = _zz_200;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_6;
       end
       4'b0111 : begin
-        _zz_659 = _zz_219;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_7;
       end
       4'b1000 : begin
-        _zz_659 = _zz_238;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_8;
       end
       4'b1001 : begin
-        _zz_659 = _zz_257;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_9;
       end
       4'b1010 : begin
-        _zz_659 = _zz_276;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_10;
       end
       4'b1011 : begin
-        _zz_659 = _zz_295;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_11;
       end
       4'b1100 : begin
-        _zz_659 = _zz_314;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_12;
       end
       4'b1101 : begin
-        _zz_659 = _zz_333;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_13;
       end
       4'b1110 : begin
-        _zz_659 = _zz_352;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_14;
       end
       default : begin
-        _zz_659 = _zz_371;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_960)
+    case(_zz_PmpPlugin_dGuard_hits_0_2)
       4'b0000 : begin
-        _zz_660 = _zz_87;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_0;
       end
       4'b0001 : begin
-        _zz_660 = _zz_106;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_1;
       end
       4'b0010 : begin
-        _zz_660 = _zz_125;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_2;
       end
       4'b0011 : begin
-        _zz_660 = _zz_144;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_3;
       end
       4'b0100 : begin
-        _zz_660 = _zz_163;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_4;
       end
       4'b0101 : begin
-        _zz_660 = _zz_182;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_5;
       end
       4'b0110 : begin
-        _zz_660 = _zz_201;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_6;
       end
       4'b0111 : begin
-        _zz_660 = _zz_220;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_7;
       end
       4'b1000 : begin
-        _zz_660 = _zz_239;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_8;
       end
       4'b1001 : begin
-        _zz_660 = _zz_258;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_9;
       end
       4'b1010 : begin
-        _zz_660 = _zz_277;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_10;
       end
       4'b1011 : begin
-        _zz_660 = _zz_296;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_11;
       end
       4'b1100 : begin
-        _zz_660 = _zz_315;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_12;
       end
       4'b1101 : begin
-        _zz_660 = _zz_334;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_13;
       end
       4'b1110 : begin
-        _zz_660 = _zz_353;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_14;
       end
       default : begin
-        _zz_660 = _zz_372;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_961)
+    case(_zz_PmpPlugin_dGuard_hits_0_4)
       4'b0000 : begin
-        _zz_661 = _zz_88;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_0;
       end
       4'b0001 : begin
-        _zz_661 = _zz_107;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_1;
       end
       4'b0010 : begin
-        _zz_661 = _zz_126;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_2;
       end
       4'b0011 : begin
-        _zz_661 = _zz_145;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_3;
       end
       4'b0100 : begin
-        _zz_661 = _zz_164;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_4;
       end
       4'b0101 : begin
-        _zz_661 = _zz_183;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_5;
       end
       4'b0110 : begin
-        _zz_661 = _zz_202;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_6;
       end
       4'b0111 : begin
-        _zz_661 = _zz_221;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_7;
       end
       4'b1000 : begin
-        _zz_661 = _zz_240;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_8;
       end
       4'b1001 : begin
-        _zz_661 = _zz_259;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_9;
       end
       4'b1010 : begin
-        _zz_661 = _zz_278;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_10;
       end
       4'b1011 : begin
-        _zz_661 = _zz_297;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_11;
       end
       4'b1100 : begin
-        _zz_661 = _zz_316;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_12;
       end
       4'b1101 : begin
-        _zz_661 = _zz_335;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_13;
       end
       4'b1110 : begin
-        _zz_661 = _zz_354;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_14;
       end
       default : begin
-        _zz_661 = _zz_373;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_962)
-      3'b000 : begin
-        _zz_662 = _zz_449;
-      end
-      3'b001 : begin
-        _zz_662 = _zz_450;
-      end
-      3'b010 : begin
-        _zz_662 = _zz_451;
-      end
-      3'b011 : begin
-        _zz_662 = _zz_452;
-      end
-      3'b100 : begin
-        _zz_662 = _zz_453;
-      end
-      3'b101 : begin
-        _zz_662 = _zz_454;
-      end
-      3'b110 : begin
-        _zz_662 = _zz_455;
-      end
-      default : begin
-        _zz_662 = _zz_456;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_963)
-      3'b000 : begin
-        _zz_663 = _zz_449;
-      end
-      3'b001 : begin
-        _zz_663 = _zz_450;
-      end
-      3'b010 : begin
-        _zz_663 = _zz_451;
-      end
-      3'b011 : begin
-        _zz_663 = _zz_452;
-      end
-      3'b100 : begin
-        _zz_663 = _zz_453;
-      end
-      3'b101 : begin
-        _zz_663 = _zz_454;
-      end
-      3'b110 : begin
-        _zz_663 = _zz_455;
-      end
-      default : begin
-        _zz_663 = _zz_456;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_964)
-      3'b000 : begin
-        _zz_664 = _zz_449;
-      end
-      3'b001 : begin
-        _zz_664 = _zz_450;
-      end
-      3'b010 : begin
-        _zz_664 = _zz_451;
-      end
-      3'b011 : begin
-        _zz_664 = _zz_452;
-      end
-      3'b100 : begin
-        _zz_664 = _zz_453;
-      end
-      3'b101 : begin
-        _zz_664 = _zz_454;
-      end
-      3'b110 : begin
-        _zz_664 = _zz_455;
-      end
-      default : begin
-        _zz_664 = _zz_456;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_965)
-      3'b000 : begin
-        _zz_665 = _zz_449;
-      end
-      3'b001 : begin
-        _zz_665 = _zz_450;
-      end
-      3'b010 : begin
-        _zz_665 = _zz_451;
-      end
-      3'b011 : begin
-        _zz_665 = _zz_452;
-      end
-      3'b100 : begin
-        _zz_665 = _zz_453;
-      end
-      3'b101 : begin
-        _zz_665 = _zz_454;
-      end
-      3'b110 : begin
-        _zz_665 = _zz_455;
-      end
-      default : begin
-        _zz_665 = _zz_456;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_966)
-      3'b000 : begin
-        _zz_666 = _zz_449;
-      end
-      3'b001 : begin
-        _zz_666 = _zz_450;
-      end
-      3'b010 : begin
-        _zz_666 = _zz_451;
-      end
-      3'b011 : begin
-        _zz_666 = _zz_452;
-      end
-      3'b100 : begin
-        _zz_666 = _zz_453;
-      end
-      3'b101 : begin
-        _zz_666 = _zz_454;
-      end
-      3'b110 : begin
-        _zz_666 = _zz_455;
-      end
-      default : begin
-        _zz_666 = _zz_456;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_832)
-      3'b000 : begin
-        _zz_667 = _zz_449;
-      end
-      3'b001 : begin
-        _zz_667 = _zz_450;
-      end
-      3'b010 : begin
-        _zz_667 = _zz_451;
-      end
-      3'b011 : begin
-        _zz_667 = _zz_452;
-      end
-      3'b100 : begin
-        _zz_667 = _zz_453;
-      end
-      3'b101 : begin
-        _zz_667 = _zz_454;
-      end
-      3'b110 : begin
-        _zz_667 = _zz_455;
-      end
-      default : begin
-        _zz_667 = _zz_456;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_967)
+    case(_zz_PmpPlugin_dGuard_hits_1_1)
       4'b0000 : begin
-        _zz_668 = _zz_86;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_0;
       end
       4'b0001 : begin
-        _zz_668 = _zz_105;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_1;
       end
       4'b0010 : begin
-        _zz_668 = _zz_124;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_2;
       end
       4'b0011 : begin
-        _zz_668 = _zz_143;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_3;
       end
       4'b0100 : begin
-        _zz_668 = _zz_162;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_4;
       end
       4'b0101 : begin
-        _zz_668 = _zz_181;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_5;
       end
       4'b0110 : begin
-        _zz_668 = _zz_200;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_6;
       end
       4'b0111 : begin
-        _zz_668 = _zz_219;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_7;
       end
       4'b1000 : begin
-        _zz_668 = _zz_238;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_8;
       end
       4'b1001 : begin
-        _zz_668 = _zz_257;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_9;
       end
       4'b1010 : begin
-        _zz_668 = _zz_276;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_10;
       end
       4'b1011 : begin
-        _zz_668 = _zz_295;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_11;
       end
       4'b1100 : begin
-        _zz_668 = _zz_314;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_12;
       end
       4'b1101 : begin
-        _zz_668 = _zz_333;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_13;
       end
       4'b1110 : begin
-        _zz_668 = _zz_352;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_14;
       end
       default : begin
-        _zz_668 = _zz_371;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_968)
+    case(_zz_PmpPlugin_dGuard_hits_1_3)
       4'b0000 : begin
-        _zz_669 = _zz_87;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_0;
       end
       4'b0001 : begin
-        _zz_669 = _zz_106;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_1;
       end
       4'b0010 : begin
-        _zz_669 = _zz_125;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_2;
       end
       4'b0011 : begin
-        _zz_669 = _zz_144;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_3;
       end
       4'b0100 : begin
-        _zz_669 = _zz_163;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_4;
       end
       4'b0101 : begin
-        _zz_669 = _zz_182;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_5;
       end
       4'b0110 : begin
-        _zz_669 = _zz_201;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_6;
       end
       4'b0111 : begin
-        _zz_669 = _zz_220;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_7;
       end
       4'b1000 : begin
-        _zz_669 = _zz_239;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_8;
       end
       4'b1001 : begin
-        _zz_669 = _zz_258;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_9;
       end
       4'b1010 : begin
-        _zz_669 = _zz_277;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_10;
       end
       4'b1011 : begin
-        _zz_669 = _zz_296;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_11;
       end
       4'b1100 : begin
-        _zz_669 = _zz_315;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_12;
       end
       4'b1101 : begin
-        _zz_669 = _zz_334;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_13;
       end
       4'b1110 : begin
-        _zz_669 = _zz_353;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_14;
       end
       default : begin
-        _zz_669 = _zz_372;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_969)
+    case(_zz_PmpPlugin_dGuard_hits_2_1)
       4'b0000 : begin
-        _zz_670 = _zz_88;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_0;
       end
       4'b0001 : begin
-        _zz_670 = _zz_107;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_1;
       end
       4'b0010 : begin
-        _zz_670 = _zz_126;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_2;
       end
       4'b0011 : begin
-        _zz_670 = _zz_145;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_3;
       end
       4'b0100 : begin
-        _zz_670 = _zz_164;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_4;
       end
       4'b0101 : begin
-        _zz_670 = _zz_183;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_5;
       end
       4'b0110 : begin
-        _zz_670 = _zz_202;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_6;
       end
       4'b0111 : begin
-        _zz_670 = _zz_221;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_7;
       end
       4'b1000 : begin
-        _zz_670 = _zz_240;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_8;
       end
       4'b1001 : begin
-        _zz_670 = _zz_259;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_9;
       end
       4'b1010 : begin
-        _zz_670 = _zz_278;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_10;
       end
       4'b1011 : begin
-        _zz_670 = _zz_297;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_11;
       end
       4'b1100 : begin
-        _zz_670 = _zz_316;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_12;
       end
       4'b1101 : begin
-        _zz_670 = _zz_335;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_13;
       end
       4'b1110 : begin
-        _zz_670 = _zz_354;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_14;
       end
       default : begin
-        _zz_670 = _zz_373;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_2_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_3_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_3_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_4_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_4_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_5_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_5_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_6_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_6_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_7_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_7_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_8_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_8_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_9_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_9_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_10_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_10_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_11_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_11_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_12_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_12_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_13_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_13_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_14_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_14_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_15_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_15_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_0_2)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_0_4)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_1_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_1_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_2_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_2_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_3_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_3_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_4_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_4_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_5_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_5_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_6_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_6_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_7_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_7_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_8_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_8_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_9_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_9_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_10_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_10_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_11_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_11_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_12_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_12_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_13_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_13_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_14_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_14_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_15_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_15_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_1)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_1_2)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_2_1)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_3_1)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_PmpPlugin_pmpNcfg_)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_1)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_3)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_5)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_7)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_15;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3344,134 +6236,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -3484,30 +6376,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -3519,27 +6411,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3552,30 +6444,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3588,12 +6480,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3606,12 +6498,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3624,12 +6516,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3642,48 +6534,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -3696,12 +6588,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -3714,12 +6606,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3731,88 +6623,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3825,73 +6717,73 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_513)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_513_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_513_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_513_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_513_string = "URS1        ";
-      default : _zz_513_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_514)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_514_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_514_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_514_string = "BITWISE ";
-      default : _zz_514_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_515)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_515_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_515_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_515_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_515_string = "PC ";
-      default : _zz_515_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_516)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_516_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_516_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_516_string = "AND_1";
-      default : _zz_516_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_517)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_517_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_517_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_517_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_517_string = "SRA_1    ";
-      default : _zz_517_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_518)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_518_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_518_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_518_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_518_string = "JALR";
-      default : _zz_518_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_519)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_519_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_519_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_519_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_519_string = "ECALL";
-      default : _zz_519_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3922,28 +6814,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -3982,9 +6874,50 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
+  always @(*) begin
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_BOOT      ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateIdle ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateWrite";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateCfg  ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateAddr ";
+      default : execute_PmpPlugin_fsm_stateReg_string = "????????????????????????????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_PmpPlugin_fsm_stateNext)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_BOOT      ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateIdle ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateWrite";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateCfg  ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateAddr ";
+      default : execute_PmpPlugin_fsm_stateNext_string = "????????????????????????????????";
+    endcase
+  end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_726) + $signed(_zz_734));
+  always @(*) begin
+    _zz_1 = 1'b0;
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
+        if(execute_PmpPlugin_pmpaddrCsr_) begin
+          if(when_PmpPlugin_l216) begin
+            _zz_1 = 1'b1;
+          end
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -3992,44 +6925,44 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_736;
-  assign execute_REGFILE_WRITE_DATA = _zz_521;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_632[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_738[0];
-  assign decode_IS_RS1_SIGNED = _zz_739[0];
-  assign decode_IS_DIV = _zz_740[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[30];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_741[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_742[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_743[0];
-  assign decode_MEMORY_MANAGMENT = _zz_744[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_745[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_746[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_747[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -4049,22 +6982,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_543;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_748[0];
-  assign decode_RS1_USE = _zz_749[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_671)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -4074,139 +7007,139 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_532)begin
-      if((_zz_533 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_534;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_672)begin
-      if(_zz_673)begin
-        if(_zz_536)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_674)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_538)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_675)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_540)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_532)begin
-      if((_zz_533 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_534;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_672)begin
-      if(_zz_673)begin
-        if(_zz_535)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_674)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_537)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_675)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_539)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_529;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_676)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_750[0];
-  assign decode_SRC_ADD_ZERO = _zz_751[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_527;
-  assign execute_SRC1 = _zz_522;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_2 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_2 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_752[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_970) == 32'h00001073),{(_zz_971 == _zz_972),{_zz_973,{_zz_974,_zz_975}}}}}}} != 21'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_725)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_862;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_863;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -4218,206 +7151,211 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_753[0];
-  assign decode_FLUSH_ALL = _zz_754[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_677)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_678)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_679)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_680)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_530 || _zz_531)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_681)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_681)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_648 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_682)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_671)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_writeInstruction) begin
+      if(when_PmpPlugin_l172) begin
+        execute_arbitration_haltItself = (! execute_PmpPlugin_fsmComplete);
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
   assign execute_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_676)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_683)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_684)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4426,51 +7364,84 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_683)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_684)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(execute_CsrPlugin_readInstruction) begin
+      if(when_PmpPlugin_l155) begin
+        if(execute_PmpPlugin_pmpcfgCsr) begin
+          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+        end
+        if(execute_PmpPlugin_pmpaddrCsr) begin
+          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+        end
+      end
+    end
+    if(execute_CsrPlugin_writeInstruction) begin
+      if(when_PmpPlugin_l172) begin
+        CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+      end
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+    if(execute_CsrPlugin_readInstruction) begin
+      if(when_PmpPlugin_l155) begin
+        if(execute_PmpPlugin_pmpcfgCsr) begin
+          CsrPlugin_csrMapping_readDataSignal = {{{_zz_CsrPlugin_csrMapping_readDataSignal,_zz_CsrPlugin_csrMapping_readDataSignal_2},_zz_CsrPlugin_csrMapping_readDataSignal_4},_zz_CsrPlugin_csrMapping_readDataSignal_6};
+        end
+        if(execute_PmpPlugin_pmpaddrCsr) begin
+          CsrPlugin_csrMapping_readDataSignal = _zz_PmpPlugin_pmpaddr_port2;
+        end
+      end
+    end
+  end
+
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_682)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
   assign CsrPlugin_thirdPartyWake = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_683)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_684)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_683)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_684)begin
-      case(_zz_685)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4483,59 +7454,65 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
+  assign CsrPlugin_allowEbreakException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_54 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_55 = (_zz_54 & (~ _zz_755));
-  assign _zz_56 = _zz_55[3];
-  assign _zz_57 = (_zz_55[1] || _zz_56);
-  assign _zz_58 = (_zz_55[2] || _zz_56);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_652;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_757);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -4543,265 +7520,280 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_59);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_59);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
-  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_63 = _zz_64;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_65 = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_67;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_68 = _zz_758[11];
-  always @ (*) begin
-    _zz_69[18] = _zz_68;
-    _zz_69[17] = _zz_68;
-    _zz_69[16] = _zz_68;
-    _zz_69[15] = _zz_68;
-    _zz_69[14] = _zz_68;
-    _zz_69[13] = _zz_68;
-    _zz_69[12] = _zz_68;
-    _zz_69[11] = _zz_68;
-    _zz_69[10] = _zz_68;
-    _zz_69[9] = _zz_68;
-    _zz_69[8] = _zz_68;
-    _zz_69[7] = _zz_68;
-    _zz_69[6] = _zz_68;
-    _zz_69[5] = _zz_68;
-    _zz_69[4] = _zz_68;
-    _zz_69[3] = _zz_68;
-    _zz_69[2] = _zz_68;
-    _zz_69[1] = _zz_68;
-    _zz_69[0] = _zz_68;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_759[31]));
-    if(_zz_74)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_7) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_70 = _zz_760[19];
-  always @ (*) begin
-    _zz_71[10] = _zz_70;
-    _zz_71[9] = _zz_70;
-    _zz_71[8] = _zz_70;
-    _zz_71[7] = _zz_70;
-    _zz_71[6] = _zz_70;
-    _zz_71[5] = _zz_70;
-    _zz_71[4] = _zz_70;
-    _zz_71[3] = _zz_70;
-    _zz_71[2] = _zz_70;
-    _zz_71[1] = _zz_70;
-    _zz_71[0] = _zz_70;
+  assign _zz_3 = _zz__zz_3[19];
+  always @(*) begin
+    _zz_4[10] = _zz_3;
+    _zz_4[9] = _zz_3;
+    _zz_4[8] = _zz_3;
+    _zz_4[7] = _zz_3;
+    _zz_4[6] = _zz_3;
+    _zz_4[5] = _zz_3;
+    _zz_4[4] = _zz_3;
+    _zz_4[3] = _zz_3;
+    _zz_4[2] = _zz_3;
+    _zz_4[1] = _zz_3;
+    _zz_4[0] = _zz_3;
   end
 
-  assign _zz_72 = _zz_761[11];
-  always @ (*) begin
-    _zz_73[18] = _zz_72;
-    _zz_73[17] = _zz_72;
-    _zz_73[16] = _zz_72;
-    _zz_73[15] = _zz_72;
-    _zz_73[14] = _zz_72;
-    _zz_73[13] = _zz_72;
-    _zz_73[12] = _zz_72;
-    _zz_73[11] = _zz_72;
-    _zz_73[10] = _zz_72;
-    _zz_73[9] = _zz_72;
-    _zz_73[8] = _zz_72;
-    _zz_73[7] = _zz_72;
-    _zz_73[6] = _zz_72;
-    _zz_73[5] = _zz_72;
-    _zz_73[4] = _zz_72;
-    _zz_73[3] = _zz_72;
-    _zz_73[2] = _zz_72;
-    _zz_73[1] = _zz_72;
-    _zz_73[0] = _zz_72;
+  assign _zz_5 = _zz__zz_5[11];
+  always @(*) begin
+    _zz_6[18] = _zz_5;
+    _zz_6[17] = _zz_5;
+    _zz_6[16] = _zz_5;
+    _zz_6[15] = _zz_5;
+    _zz_6[14] = _zz_5;
+    _zz_6[13] = _zz_5;
+    _zz_6[12] = _zz_5;
+    _zz_6[11] = _zz_5;
+    _zz_6[10] = _zz_5;
+    _zz_6[9] = _zz_5;
+    _zz_6[8] = _zz_5;
+    _zz_6[7] = _zz_5;
+    _zz_6[6] = _zz_5;
+    _zz_6[5] = _zz_5;
+    _zz_6[4] = _zz_5;
+    _zz_6[3] = _zz_5;
+    _zz_6[2] = _zz_5;
+    _zz_6[1] = _zz_5;
+    _zz_6[0] = _zz_5;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_74 = _zz_762[1];
+        _zz_7 = _zz__zz_7[1];
       end
       default : begin
-        _zz_74 = _zz_763[1];
+        _zz_7 = _zz__zz_7_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_75 = _zz_764[19];
-  always @ (*) begin
-    _zz_76[10] = _zz_75;
-    _zz_76[9] = _zz_75;
-    _zz_76[8] = _zz_75;
-    _zz_76[7] = _zz_75;
-    _zz_76[6] = _zz_75;
-    _zz_76[5] = _zz_75;
-    _zz_76[4] = _zz_75;
-    _zz_76[3] = _zz_75;
-    _zz_76[2] = _zz_75;
-    _zz_76[1] = _zz_75;
-    _zz_76[0] = _zz_75;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_77 = _zz_765[11];
-  always @ (*) begin
-    _zz_78[18] = _zz_77;
-    _zz_78[17] = _zz_77;
-    _zz_78[16] = _zz_77;
-    _zz_78[15] = _zz_77;
-    _zz_78[14] = _zz_77;
-    _zz_78[13] = _zz_77;
-    _zz_78[12] = _zz_77;
-    _zz_78[11] = _zz_77;
-    _zz_78[10] = _zz_77;
-    _zz_78[9] = _zz_77;
-    _zz_78[8] = _zz_77;
-    _zz_78[7] = _zz_77;
-    _zz_78[6] = _zz_77;
-    _zz_78[5] = _zz_77;
-    _zz_78[4] = _zz_77;
-    _zz_78[3] = _zz_77;
-    _zz_78[2] = _zz_77;
-    _zz_78[1] = _zz_77;
-    _zz_78[0] = _zz_77;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_76,{{{_zz_988,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_78,{{{_zz_989,_zz_990},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_623 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_624 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_625 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_624;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_627 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_628 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_629 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_680)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_678)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_630 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_678)begin
-      _zz_630 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_679)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_677)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_679)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_677)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_622 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_649 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -4809,2143 +7801,350 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_631 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_632 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_81 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_81 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_81 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_648 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_633 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_634 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_633;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_634;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_635 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_635 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_636 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_637 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_638 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_686)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_686)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_686)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_766};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_767};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_82 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_83[31] = _zz_82;
-    _zz_83[30] = _zz_82;
-    _zz_83[29] = _zz_82;
-    _zz_83[28] = _zz_82;
-    _zz_83[27] = _zz_82;
-    _zz_83[26] = _zz_82;
-    _zz_83[25] = _zz_82;
-    _zz_83[24] = _zz_82;
-    _zz_83[23] = _zz_82;
-    _zz_83[22] = _zz_82;
-    _zz_83[21] = _zz_82;
-    _zz_83[20] = _zz_82;
-    _zz_83[19] = _zz_82;
-    _zz_83[18] = _zz_82;
-    _zz_83[17] = _zz_82;
-    _zz_83[16] = _zz_82;
-    _zz_83[15] = _zz_82;
-    _zz_83[14] = _zz_82;
-    _zz_83[13] = _zz_82;
-    _zz_83[12] = _zz_82;
-    _zz_83[11] = _zz_82;
-    _zz_83[10] = _zz_82;
-    _zz_83[9] = _zz_82;
-    _zz_83[8] = _zz_82;
-    _zz_83[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_84 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_85[31] = _zz_84;
-    _zz_85[30] = _zz_84;
-    _zz_85[29] = _zz_84;
-    _zz_85[28] = _zz_84;
-    _zz_85[27] = _zz_84;
-    _zz_85[26] = _zz_84;
-    _zz_85[25] = _zz_84;
-    _zz_85[24] = _zz_84;
-    _zz_85[23] = _zz_84;
-    _zz_85[22] = _zz_84;
-    _zz_85[21] = _zz_84;
-    _zz_85[20] = _zz_84;
-    _zz_85[19] = _zz_84;
-    _zz_85[18] = _zz_84;
-    _zz_85[17] = _zz_84;
-    _zz_85[16] = _zz_84;
-    _zz_85[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_723)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_83;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_85;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_92 = _zz_86;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_92 = _zz_894[0];
-      end
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_PmpPlugin_l138 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    execute_PmpPlugin_fsmComplete = 1'b0;
+    if(when_StateMachine_l230) begin
+      execute_PmpPlugin_fsmComplete = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_93 = _zz_87;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_93 = _zz_893[0];
+  assign execute_PmpPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
+  assign execute_PmpPlugin_pmpNcfg = execute_PmpPlugin_csrAddress[3 : 0];
+  assign execute_PmpPlugin_pmpcfgN = execute_PmpPlugin_pmpNcfg[1 : 0];
+  assign execute_PmpPlugin_pmpcfgCsr = (execute_INSTRUCTION[31 : 24] == 8'h3a);
+  assign execute_PmpPlugin_pmpaddrCsr = (execute_INSTRUCTION[31 : 24] == 8'h3b);
+  assign execute_PmpPlugin_fsm_wantExit = 1'b0;
+  always @(*) begin
+    execute_PmpPlugin_fsm_wantStart = 1'b0;
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
       end
-    end
-  end
-
-  always @ (*) begin
-    _zz_94 = _zz_88;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_94 = _zz_892[0];
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
       end
-    end
-  end
-
-  always @ (*) begin
-    _zz_95 = _zz_89;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_95 = _zz_882[0];
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
       end
-    end
-  end
-
-  always @ (*) begin
-    _zz_96 = _zz_90;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_96 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_97 = _zz_91;
-    if(execute_CsrPlugin_csr_944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_97 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_102 = (_zz_91 <<< 2);
-  assign _zz_103 = (_zz_91 & (~ _zz_768));
-  assign _zz_104 = ((_zz_91 & (~ _zz_103)) <<< 2);
-  assign _zz_99 = _zz_89;
-  always @ (*) begin
-    _zz_98 = 1'b1;
-    case(_zz_96)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
       end
       default : begin
-        _zz_98 = 1'b0;
+        execute_PmpPlugin_fsm_wantStart = 1'b1;
       end
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_96)
-      2'b01 : begin
-        _zz_100 = 32'h0;
-      end
-      2'b10 : begin
-        _zz_100 = _zz_102;
-      end
-      2'b11 : begin
-        _zz_100 = _zz_104;
-      end
-      default : begin
-        _zz_100 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_96)
-      2'b01 : begin
-        _zz_101 = _zz_102;
-      end
-      2'b10 : begin
-        _zz_101 = (_zz_102 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_101 = (_zz_104 + _zz_769);
-      end
-      default : begin
-        _zz_101 = _zz_102;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_111 = _zz_105;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_111 = _zz_891[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_112 = _zz_106;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_112 = _zz_890[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_113 = _zz_107;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_113 = _zz_889[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_114 = _zz_108;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_114 = _zz_881[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_115 = _zz_109;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_115 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_116 = _zz_110;
-    if(execute_CsrPlugin_csr_945)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_116 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_121 = (_zz_110 <<< 2);
-  assign _zz_122 = (_zz_110 & (~ _zz_771));
-  assign _zz_123 = ((_zz_110 & (~ _zz_122)) <<< 2);
-  assign _zz_118 = _zz_108;
-  always @ (*) begin
-    _zz_117 = 1'b1;
-    case(_zz_115)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_117 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_115)
-      2'b01 : begin
-        _zz_119 = _zz_101;
-      end
-      2'b10 : begin
-        _zz_119 = _zz_121;
-      end
-      2'b11 : begin
-        _zz_119 = _zz_123;
-      end
-      default : begin
-        _zz_119 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_115)
-      2'b01 : begin
-        _zz_120 = _zz_121;
-      end
-      2'b10 : begin
-        _zz_120 = (_zz_121 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_120 = (_zz_123 + _zz_772);
-      end
-      default : begin
-        _zz_120 = _zz_121;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_130 = _zz_124;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_130 = _zz_888[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_131 = _zz_125;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_131 = _zz_887[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_132 = _zz_126;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_132 = _zz_886[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_133 = _zz_127;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_133 = _zz_880[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_134 = _zz_128;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_134 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_135 = _zz_129;
-    if(execute_CsrPlugin_csr_946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_135 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_140 = (_zz_129 <<< 2);
-  assign _zz_141 = (_zz_129 & (~ _zz_774));
-  assign _zz_142 = ((_zz_129 & (~ _zz_141)) <<< 2);
-  assign _zz_137 = _zz_127;
-  always @ (*) begin
-    _zz_136 = 1'b1;
-    case(_zz_134)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_136 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_134)
-      2'b01 : begin
-        _zz_138 = _zz_120;
-      end
-      2'b10 : begin
-        _zz_138 = _zz_140;
-      end
-      2'b11 : begin
-        _zz_138 = _zz_142;
-      end
-      default : begin
-        _zz_138 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_134)
-      2'b01 : begin
-        _zz_139 = _zz_140;
-      end
-      2'b10 : begin
-        _zz_139 = (_zz_140 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_139 = (_zz_142 + _zz_775);
-      end
-      default : begin
-        _zz_139 = _zz_140;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_149 = _zz_143;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_149 = _zz_885[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_150 = _zz_144;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_150 = _zz_884[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_151 = _zz_145;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_151 = _zz_883[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_152 = _zz_146;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_152 = _zz_879[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_153 = _zz_147;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_153 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_154 = _zz_148;
-    if(execute_CsrPlugin_csr_947)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_154 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_159 = (_zz_148 <<< 2);
-  assign _zz_160 = (_zz_148 & (~ _zz_777));
-  assign _zz_161 = ((_zz_148 & (~ _zz_160)) <<< 2);
-  assign _zz_156 = _zz_146;
-  always @ (*) begin
-    _zz_155 = 1'b1;
-    case(_zz_153)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_155 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_153)
-      2'b01 : begin
-        _zz_157 = _zz_139;
-      end
-      2'b10 : begin
-        _zz_157 = _zz_159;
-      end
-      2'b11 : begin
-        _zz_157 = _zz_161;
-      end
-      default : begin
-        _zz_157 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_153)
-      2'b01 : begin
-        _zz_158 = _zz_159;
-      end
-      2'b10 : begin
-        _zz_158 = (_zz_159 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_158 = (_zz_161 + _zz_778);
-      end
-      default : begin
-        _zz_158 = _zz_159;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_168 = _zz_162;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_168 = _zz_910[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_169 = _zz_163;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_169 = _zz_909[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_170 = _zz_164;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_170 = _zz_908[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_171 = _zz_165;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_171 = _zz_898[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_172 = _zz_166;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_172 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_173 = _zz_167;
-    if(execute_CsrPlugin_csr_948)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_173 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_178 = (_zz_167 <<< 2);
-  assign _zz_179 = (_zz_167 & (~ _zz_780));
-  assign _zz_180 = ((_zz_167 & (~ _zz_179)) <<< 2);
-  assign _zz_175 = _zz_165;
-  always @ (*) begin
-    _zz_174 = 1'b1;
-    case(_zz_172)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_174 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_172)
-      2'b01 : begin
-        _zz_176 = _zz_158;
-      end
-      2'b10 : begin
-        _zz_176 = _zz_178;
-      end
-      2'b11 : begin
-        _zz_176 = _zz_180;
-      end
-      default : begin
-        _zz_176 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_172)
-      2'b01 : begin
-        _zz_177 = _zz_178;
-      end
-      2'b10 : begin
-        _zz_177 = (_zz_178 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_177 = (_zz_180 + _zz_781);
-      end
-      default : begin
-        _zz_177 = _zz_178;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_187 = _zz_181;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_187 = _zz_907[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_188 = _zz_182;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_188 = _zz_906[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_189 = _zz_183;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_189 = _zz_905[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_190 = _zz_184;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_190 = _zz_897[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_191 = _zz_185;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_191 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_192 = _zz_186;
-    if(execute_CsrPlugin_csr_949)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_192 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_197 = (_zz_186 <<< 2);
-  assign _zz_198 = (_zz_186 & (~ _zz_783));
-  assign _zz_199 = ((_zz_186 & (~ _zz_198)) <<< 2);
-  assign _zz_194 = _zz_184;
-  always @ (*) begin
-    _zz_193 = 1'b1;
-    case(_zz_191)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_193 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_191)
-      2'b01 : begin
-        _zz_195 = _zz_177;
-      end
-      2'b10 : begin
-        _zz_195 = _zz_197;
-      end
-      2'b11 : begin
-        _zz_195 = _zz_199;
-      end
-      default : begin
-        _zz_195 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_191)
-      2'b01 : begin
-        _zz_196 = _zz_197;
-      end
-      2'b10 : begin
-        _zz_196 = (_zz_197 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_196 = (_zz_199 + _zz_784);
-      end
-      default : begin
-        _zz_196 = _zz_197;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_206 = _zz_200;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_206 = _zz_904[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_207 = _zz_201;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_207 = _zz_903[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_208 = _zz_202;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_208 = _zz_902[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_209 = _zz_203;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_209 = _zz_896[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_210 = _zz_204;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_210 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_211 = _zz_205;
-    if(execute_CsrPlugin_csr_950)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_211 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_216 = (_zz_205 <<< 2);
-  assign _zz_217 = (_zz_205 & (~ _zz_786));
-  assign _zz_218 = ((_zz_205 & (~ _zz_217)) <<< 2);
-  assign _zz_213 = _zz_203;
-  always @ (*) begin
-    _zz_212 = 1'b1;
-    case(_zz_210)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_212 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_210)
-      2'b01 : begin
-        _zz_214 = _zz_196;
-      end
-      2'b10 : begin
-        _zz_214 = _zz_216;
-      end
-      2'b11 : begin
-        _zz_214 = _zz_218;
-      end
-      default : begin
-        _zz_214 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_210)
-      2'b01 : begin
-        _zz_215 = _zz_216;
-      end
-      2'b10 : begin
-        _zz_215 = (_zz_216 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_215 = (_zz_218 + _zz_787);
-      end
-      default : begin
-        _zz_215 = _zz_216;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_225 = _zz_219;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_225 = _zz_901[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_226 = _zz_220;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_226 = _zz_900[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_227 = _zz_221;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_227 = _zz_899[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_228 = _zz_222;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_228 = _zz_895[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_229 = _zz_223;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_229 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_230 = _zz_224;
-    if(execute_CsrPlugin_csr_951)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_230 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_235 = (_zz_224 <<< 2);
-  assign _zz_236 = (_zz_224 & (~ _zz_789));
-  assign _zz_237 = ((_zz_224 & (~ _zz_236)) <<< 2);
-  assign _zz_232 = _zz_222;
-  always @ (*) begin
-    _zz_231 = 1'b1;
-    case(_zz_229)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_231 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_229)
-      2'b01 : begin
-        _zz_233 = _zz_215;
-      end
-      2'b10 : begin
-        _zz_233 = _zz_235;
-      end
-      2'b11 : begin
-        _zz_233 = _zz_237;
-      end
-      default : begin
-        _zz_233 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_229)
-      2'b01 : begin
-        _zz_234 = _zz_235;
-      end
-      2'b10 : begin
-        _zz_234 = (_zz_235 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_234 = (_zz_237 + _zz_790);
-      end
-      default : begin
-        _zz_234 = _zz_235;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_244 = _zz_238;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_244 = _zz_926[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_245 = _zz_239;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_245 = _zz_925[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_246 = _zz_240;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_246 = _zz_924[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_247 = _zz_241;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_247 = _zz_914[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_248 = _zz_242;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_248 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_249 = _zz_243;
-    if(execute_CsrPlugin_csr_952)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_249 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_254 = (_zz_243 <<< 2);
-  assign _zz_255 = (_zz_243 & (~ _zz_792));
-  assign _zz_256 = ((_zz_243 & (~ _zz_255)) <<< 2);
-  assign _zz_251 = _zz_241;
-  always @ (*) begin
-    _zz_250 = 1'b1;
-    case(_zz_248)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_250 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_248)
-      2'b01 : begin
-        _zz_252 = _zz_234;
-      end
-      2'b10 : begin
-        _zz_252 = _zz_254;
-      end
-      2'b11 : begin
-        _zz_252 = _zz_256;
-      end
-      default : begin
-        _zz_252 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_248)
-      2'b01 : begin
-        _zz_253 = _zz_254;
-      end
-      2'b10 : begin
-        _zz_253 = (_zz_254 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_253 = (_zz_256 + _zz_793);
-      end
-      default : begin
-        _zz_253 = _zz_254;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_263 = _zz_257;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_263 = _zz_923[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_264 = _zz_258;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_264 = _zz_922[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_265 = _zz_259;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_265 = _zz_921[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_266 = _zz_260;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_266 = _zz_913[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_267 = _zz_261;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_267 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_268 = _zz_262;
-    if(execute_CsrPlugin_csr_953)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_268 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_273 = (_zz_262 <<< 2);
-  assign _zz_274 = (_zz_262 & (~ _zz_795));
-  assign _zz_275 = ((_zz_262 & (~ _zz_274)) <<< 2);
-  assign _zz_270 = _zz_260;
-  always @ (*) begin
-    _zz_269 = 1'b1;
-    case(_zz_267)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_269 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_267)
-      2'b01 : begin
-        _zz_271 = _zz_253;
-      end
-      2'b10 : begin
-        _zz_271 = _zz_273;
-      end
-      2'b11 : begin
-        _zz_271 = _zz_275;
-      end
-      default : begin
-        _zz_271 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_267)
-      2'b01 : begin
-        _zz_272 = _zz_273;
-      end
-      2'b10 : begin
-        _zz_272 = (_zz_273 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_272 = (_zz_275 + _zz_796);
-      end
-      default : begin
-        _zz_272 = _zz_273;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_282 = _zz_276;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_282 = _zz_920[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_283 = _zz_277;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_283 = _zz_919[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_284 = _zz_278;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_284 = _zz_918[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_285 = _zz_279;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_285 = _zz_912[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_286 = _zz_280;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_286 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_287 = _zz_281;
-    if(execute_CsrPlugin_csr_954)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_287 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_292 = (_zz_281 <<< 2);
-  assign _zz_293 = (_zz_281 & (~ _zz_798));
-  assign _zz_294 = ((_zz_281 & (~ _zz_293)) <<< 2);
-  assign _zz_289 = _zz_279;
-  always @ (*) begin
-    _zz_288 = 1'b1;
-    case(_zz_286)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_288 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_286)
-      2'b01 : begin
-        _zz_290 = _zz_272;
-      end
-      2'b10 : begin
-        _zz_290 = _zz_292;
-      end
-      2'b11 : begin
-        _zz_290 = _zz_294;
-      end
-      default : begin
-        _zz_290 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_286)
-      2'b01 : begin
-        _zz_291 = _zz_292;
-      end
-      2'b10 : begin
-        _zz_291 = (_zz_292 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_291 = (_zz_294 + _zz_799);
-      end
-      default : begin
-        _zz_291 = _zz_292;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_301 = _zz_295;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_301 = _zz_917[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_302 = _zz_296;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_302 = _zz_916[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_303 = _zz_297;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_303 = _zz_915[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_304 = _zz_298;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_304 = _zz_911[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_305 = _zz_299;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_305 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_306 = _zz_300;
-    if(execute_CsrPlugin_csr_955)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_306 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_311 = (_zz_300 <<< 2);
-  assign _zz_312 = (_zz_300 & (~ _zz_801));
-  assign _zz_313 = ((_zz_300 & (~ _zz_312)) <<< 2);
-  assign _zz_308 = _zz_298;
-  always @ (*) begin
-    _zz_307 = 1'b1;
-    case(_zz_305)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_307 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_305)
-      2'b01 : begin
-        _zz_309 = _zz_291;
-      end
-      2'b10 : begin
-        _zz_309 = _zz_311;
-      end
-      2'b11 : begin
-        _zz_309 = _zz_313;
-      end
-      default : begin
-        _zz_309 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_305)
-      2'b01 : begin
-        _zz_310 = _zz_311;
-      end
-      2'b10 : begin
-        _zz_310 = (_zz_311 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_310 = (_zz_313 + _zz_802);
-      end
-      default : begin
-        _zz_310 = _zz_311;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_320 = _zz_314;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_320 = _zz_942[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_321 = _zz_315;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_321 = _zz_941[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_322 = _zz_316;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_322 = _zz_940[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_323 = _zz_317;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_323 = _zz_930[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_324 = _zz_318;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_324 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_325 = _zz_319;
-    if(execute_CsrPlugin_csr_956)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_325 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_330 = (_zz_319 <<< 2);
-  assign _zz_331 = (_zz_319 & (~ _zz_804));
-  assign _zz_332 = ((_zz_319 & (~ _zz_331)) <<< 2);
-  assign _zz_327 = _zz_317;
-  always @ (*) begin
-    _zz_326 = 1'b1;
-    case(_zz_324)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_326 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_324)
-      2'b01 : begin
-        _zz_328 = _zz_310;
-      end
-      2'b10 : begin
-        _zz_328 = _zz_330;
-      end
-      2'b11 : begin
-        _zz_328 = _zz_332;
-      end
-      default : begin
-        _zz_328 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_324)
-      2'b01 : begin
-        _zz_329 = _zz_330;
-      end
-      2'b10 : begin
-        _zz_329 = (_zz_330 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_329 = (_zz_332 + _zz_805);
-      end
-      default : begin
-        _zz_329 = _zz_330;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_339 = _zz_333;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_339 = _zz_939[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_340 = _zz_334;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_340 = _zz_938[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_341 = _zz_335;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_341 = _zz_937[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_342 = _zz_336;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_342 = _zz_929[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_343 = _zz_337;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_343 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_344 = _zz_338;
-    if(execute_CsrPlugin_csr_957)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_344 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_349 = (_zz_338 <<< 2);
-  assign _zz_350 = (_zz_338 & (~ _zz_807));
-  assign _zz_351 = ((_zz_338 & (~ _zz_350)) <<< 2);
-  assign _zz_346 = _zz_336;
-  always @ (*) begin
-    _zz_345 = 1'b1;
-    case(_zz_343)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_345 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_343)
-      2'b01 : begin
-        _zz_347 = _zz_329;
-      end
-      2'b10 : begin
-        _zz_347 = _zz_349;
-      end
-      2'b11 : begin
-        _zz_347 = _zz_351;
-      end
-      default : begin
-        _zz_347 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_343)
-      2'b01 : begin
-        _zz_348 = _zz_349;
-      end
-      2'b10 : begin
-        _zz_348 = (_zz_349 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_348 = (_zz_351 + _zz_808);
-      end
-      default : begin
-        _zz_348 = _zz_349;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_358 = _zz_352;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_358 = _zz_936[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_359 = _zz_353;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_359 = _zz_935[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_360 = _zz_354;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_360 = _zz_934[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_361 = _zz_355;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_361 = _zz_928[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_362 = _zz_356;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_362 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_363 = _zz_357;
-    if(execute_CsrPlugin_csr_958)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_363 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_368 = (_zz_357 <<< 2);
-  assign _zz_369 = (_zz_357 & (~ _zz_810));
-  assign _zz_370 = ((_zz_357 & (~ _zz_369)) <<< 2);
-  assign _zz_365 = _zz_355;
-  always @ (*) begin
-    _zz_364 = 1'b1;
-    case(_zz_362)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_364 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_362)
-      2'b01 : begin
-        _zz_366 = _zz_348;
-      end
-      2'b10 : begin
-        _zz_366 = _zz_368;
-      end
-      2'b11 : begin
-        _zz_366 = _zz_370;
-      end
-      default : begin
-        _zz_366 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_362)
-      2'b01 : begin
-        _zz_367 = _zz_368;
-      end
-      2'b10 : begin
-        _zz_367 = (_zz_368 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_367 = (_zz_370 + _zz_811);
-      end
-      default : begin
-        _zz_367 = _zz_368;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_377 = _zz_371;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_377 = _zz_933[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_378 = _zz_372;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_378 = _zz_932[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_379 = _zz_373;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_379 = _zz_931[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_380 = _zz_374;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_380 = _zz_927[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_381 = _zz_375;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_381 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_382 = _zz_376;
-    if(execute_CsrPlugin_csr_959)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_382 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_387 = (_zz_376 <<< 2);
-  assign _zz_388 = (_zz_376 & (~ _zz_813));
-  assign _zz_389 = ((_zz_376 & (~ _zz_388)) <<< 2);
-  assign _zz_384 = _zz_374;
-  always @ (*) begin
-    _zz_383 = 1'b1;
-    case(_zz_381)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_383 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_381)
-      2'b01 : begin
-        _zz_385 = _zz_367;
-      end
-      2'b10 : begin
-        _zz_385 = _zz_387;
-      end
-      2'b11 : begin
-        _zz_385 = _zz_389;
-      end
-      default : begin
-        _zz_385 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_381)
-      2'b01 : begin
-        _zz_386 = _zz_387;
-      end
-      2'b10 : begin
-        _zz_386 = (_zz_387 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_386 = (_zz_389 + _zz_814);
-      end
-      default : begin
-        _zz_386 = _zz_387;
-      end
-    endcase
-  end
-
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign PmpPlugin_ports_0_hits_0 = (((_zz_98 && (_zz_100 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_101)) && (_zz_99 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_1 = (((_zz_117 && (_zz_119 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_120)) && (_zz_118 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_2 = (((_zz_136 && (_zz_138 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_139)) && (_zz_137 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_3 = (((_zz_155 && (_zz_157 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_158)) && (_zz_156 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_4 = (((_zz_174 && (_zz_176 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_177)) && (_zz_175 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_5 = (((_zz_193 && (_zz_195 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_196)) && (_zz_194 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_6 = (((_zz_212 && (_zz_214 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_215)) && (_zz_213 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_7 = (((_zz_231 && (_zz_233 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_234)) && (_zz_232 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_8 = (((_zz_250 && (_zz_252 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_253)) && (_zz_251 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_9 = (((_zz_269 && (_zz_271 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_272)) && (_zz_270 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_10 = (((_zz_288 && (_zz_290 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_291)) && (_zz_289 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_11 = (((_zz_307 && (_zz_309 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_310)) && (_zz_308 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_12 = (((_zz_326 && (_zz_328 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_329)) && (_zz_327 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_13 = (((_zz_345 && (_zz_347 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_348)) && (_zz_346 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_14 = (((_zz_364 && (_zz_366 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_367)) && (_zz_365 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_15 = (((_zz_383 && (_zz_385 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_386)) && (_zz_384 || (! (CsrPlugin_privilege == 2'b11))));
-  assign _zz_390 = 5'h0;
-  assign _zz_391 = 5'h01;
-  assign _zz_392 = 5'h01;
-  assign _zz_393 = 5'h02;
-  assign _zz_394 = 5'h01;
-  assign _zz_395 = 5'h02;
-  assign _zz_396 = 5'h02;
-  assign _zz_397 = 5'h03;
-  always @ (*) begin
-    if(_zz_687)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+  assign execute_PmpPlugin_fsm_wantKill = 1'b0;
+  always @(*) begin
+    if(execute_PmpPlugin_pmpaddrCsr_) begin
+      PmpPlugin_setter_io_addr = execute_PmpPlugin_writeData_;
     end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_659;
+      PmpPlugin_setter_io_addr = _zz_PmpPlugin_pmpaddr_port0;
     end
   end
 
-  always @ (*) begin
-    if(_zz_687)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_660;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_687)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_661;
-    end
-  end
-
-  assign _zz_398 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_991,_zz_992}}}}}}}}}}};
-  assign _zz_399 = (_zz_398 & (~ _zz_823));
-  assign _zz_400 = _zz_399[3];
-  assign _zz_401 = _zz_399[5];
-  assign _zz_402 = _zz_399[6];
-  assign _zz_403 = _zz_399[7];
-  assign _zz_404 = _zz_399[9];
-  assign _zz_405 = _zz_399[10];
-  assign _zz_406 = _zz_399[11];
-  assign _zz_407 = _zz_399[12];
-  assign _zz_408 = _zz_399[13];
-  assign _zz_409 = _zz_399[14];
-  assign _zz_410 = _zz_399[15];
-  assign _zz_411 = (((((((_zz_399[1] || _zz_400) || _zz_401) || _zz_403) || _zz_404) || _zz_406) || _zz_408) || _zz_410);
-  assign _zz_412 = (((((((_zz_399[2] || _zz_400) || _zz_402) || _zz_403) || _zz_405) || _zz_406) || _zz_409) || _zz_410);
-  assign _zz_413 = (((((((_zz_399[4] || _zz_401) || _zz_402) || _zz_403) || _zz_407) || _zz_408) || _zz_409) || _zz_410);
-  assign _zz_414 = (((((((_zz_399[8] || _zz_404) || _zz_405) || _zz_406) || _zz_407) || _zz_408) || _zz_409) || _zz_410);
-  assign _zz_415 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_993,_zz_994}}}}}}}}}}};
-  assign _zz_416 = (_zz_415 & (~ _zz_824));
-  assign _zz_417 = _zz_416[3];
-  assign _zz_418 = _zz_416[5];
-  assign _zz_419 = _zz_416[6];
-  assign _zz_420 = _zz_416[7];
-  assign _zz_421 = _zz_416[9];
-  assign _zz_422 = _zz_416[10];
-  assign _zz_423 = _zz_416[11];
-  assign _zz_424 = _zz_416[12];
-  assign _zz_425 = _zz_416[13];
-  assign _zz_426 = _zz_416[14];
-  assign _zz_427 = _zz_416[15];
-  assign _zz_428 = (((((((_zz_416[1] || _zz_417) || _zz_418) || _zz_420) || _zz_421) || _zz_423) || _zz_425) || _zz_427);
-  assign _zz_429 = (((((((_zz_416[2] || _zz_417) || _zz_419) || _zz_420) || _zz_422) || _zz_423) || _zz_426) || _zz_427);
-  assign _zz_430 = (((((((_zz_416[4] || _zz_418) || _zz_419) || _zz_420) || _zz_424) || _zz_425) || _zz_426) || _zz_427);
-  assign _zz_431 = (((((((_zz_416[8] || _zz_421) || _zz_422) || _zz_423) || _zz_424) || _zz_425) || _zz_426) || _zz_427);
-  assign _zz_432 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_995,_zz_996}}}}}}}}}}};
-  assign _zz_433 = (_zz_432 & (~ _zz_825));
-  assign _zz_434 = _zz_433[3];
-  assign _zz_435 = _zz_433[5];
-  assign _zz_436 = _zz_433[6];
-  assign _zz_437 = _zz_433[7];
-  assign _zz_438 = _zz_433[9];
-  assign _zz_439 = _zz_433[10];
-  assign _zz_440 = _zz_433[11];
-  assign _zz_441 = _zz_433[12];
-  assign _zz_442 = _zz_433[13];
-  assign _zz_443 = _zz_433[14];
-  assign _zz_444 = _zz_433[15];
-  assign _zz_445 = (((((((_zz_433[1] || _zz_434) || _zz_435) || _zz_437) || _zz_438) || _zz_440) || _zz_442) || _zz_444);
-  assign _zz_446 = (((((((_zz_433[2] || _zz_434) || _zz_436) || _zz_437) || _zz_439) || _zz_440) || _zz_443) || _zz_444);
-  assign _zz_447 = (((((((_zz_433[4] || _zz_435) || _zz_436) || _zz_437) || _zz_441) || _zz_442) || _zz_443) || _zz_444);
-  assign _zz_448 = (((((((_zz_433[8] || _zz_438) || _zz_439) || _zz_440) || _zz_441) || _zz_442) || _zz_443) || _zz_444);
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
-  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
+  assign when_PmpPlugin_l246 = (execute_PmpPlugin_fsm_fsmEnable && (! _zz_when_PmpPlugin_l246[7]));
+  assign _zz_8 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
+  assign _zz_9 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
   assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign PmpPlugin_ports_1_hits_0 = (((_zz_98 && (_zz_100 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_101)) && (_zz_99 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_1 = (((_zz_117 && (_zz_119 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_120)) && (_zz_118 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_2 = (((_zz_136 && (_zz_138 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_139)) && (_zz_137 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_3 = (((_zz_155 && (_zz_157 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_158)) && (_zz_156 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_4 = (((_zz_174 && (_zz_176 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_177)) && (_zz_175 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_5 = (((_zz_193 && (_zz_195 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_196)) && (_zz_194 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_6 = (((_zz_212 && (_zz_214 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_215)) && (_zz_213 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_7 = (((_zz_231 && (_zz_233 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_234)) && (_zz_232 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_8 = (((_zz_250 && (_zz_252 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_253)) && (_zz_251 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_9 = (((_zz_269 && (_zz_271 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_272)) && (_zz_270 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_10 = (((_zz_288 && (_zz_290 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_291)) && (_zz_289 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_11 = (((_zz_307 && (_zz_309 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_310)) && (_zz_308 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_12 = (((_zz_326 && (_zz_328 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_329)) && (_zz_327 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_13 = (((_zz_345 && (_zz_347 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_348)) && (_zz_346 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_14 = (((_zz_364 && (_zz_366 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_367)) && (_zz_365 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_15 = (((_zz_383 && (_zz_385 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_386)) && (_zz_384 || (! (CsrPlugin_privilege == 2'b11))));
-  assign _zz_449 = 5'h0;
-  assign _zz_450 = 5'h01;
-  assign _zz_451 = 5'h01;
-  assign _zz_452 = 5'h02;
-  assign _zz_453 = 5'h01;
-  assign _zz_454 = 5'h02;
-  assign _zz_455 = 5'h02;
-  assign _zz_456 = 5'h03;
-  always @ (*) begin
-    if(_zz_688)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_668;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_688)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_669;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_688)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_670;
-    end
-  end
-
-  assign _zz_457 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_997,_zz_998}}}}}}}}}}};
-  assign _zz_458 = (_zz_457 & (~ _zz_833));
-  assign _zz_459 = _zz_458[3];
-  assign _zz_460 = _zz_458[5];
-  assign _zz_461 = _zz_458[6];
-  assign _zz_462 = _zz_458[7];
-  assign _zz_463 = _zz_458[9];
-  assign _zz_464 = _zz_458[10];
-  assign _zz_465 = _zz_458[11];
-  assign _zz_466 = _zz_458[12];
-  assign _zz_467 = _zz_458[13];
-  assign _zz_468 = _zz_458[14];
-  assign _zz_469 = _zz_458[15];
-  assign _zz_470 = (((((((_zz_458[1] || _zz_459) || _zz_460) || _zz_462) || _zz_463) || _zz_465) || _zz_467) || _zz_469);
-  assign _zz_471 = (((((((_zz_458[2] || _zz_459) || _zz_461) || _zz_462) || _zz_464) || _zz_465) || _zz_468) || _zz_469);
-  assign _zz_472 = (((((((_zz_458[4] || _zz_460) || _zz_461) || _zz_462) || _zz_466) || _zz_467) || _zz_468) || _zz_469);
-  assign _zz_473 = (((((((_zz_458[8] || _zz_463) || _zz_464) || _zz_465) || _zz_466) || _zz_467) || _zz_468) || _zz_469);
-  assign _zz_474 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_999,_zz_1000}}}}}}}}}}};
-  assign _zz_475 = (_zz_474 & (~ _zz_834));
-  assign _zz_476 = _zz_475[3];
-  assign _zz_477 = _zz_475[5];
-  assign _zz_478 = _zz_475[6];
-  assign _zz_479 = _zz_475[7];
-  assign _zz_480 = _zz_475[9];
-  assign _zz_481 = _zz_475[10];
-  assign _zz_482 = _zz_475[11];
-  assign _zz_483 = _zz_475[12];
-  assign _zz_484 = _zz_475[13];
-  assign _zz_485 = _zz_475[14];
-  assign _zz_486 = _zz_475[15];
-  assign _zz_487 = (((((((_zz_475[1] || _zz_476) || _zz_477) || _zz_479) || _zz_480) || _zz_482) || _zz_484) || _zz_486);
-  assign _zz_488 = (((((((_zz_475[2] || _zz_476) || _zz_478) || _zz_479) || _zz_481) || _zz_482) || _zz_485) || _zz_486);
-  assign _zz_489 = (((((((_zz_475[4] || _zz_477) || _zz_478) || _zz_479) || _zz_483) || _zz_484) || _zz_485) || _zz_486);
-  assign _zz_490 = (((((((_zz_475[8] || _zz_480) || _zz_481) || _zz_482) || _zz_483) || _zz_484) || _zz_485) || _zz_486);
-  assign _zz_491 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1001,_zz_1002}}}}}}}}}}};
-  assign _zz_492 = (_zz_491 & (~ _zz_835));
-  assign _zz_493 = _zz_492[3];
-  assign _zz_494 = _zz_492[5];
-  assign _zz_495 = _zz_492[6];
-  assign _zz_496 = _zz_492[7];
-  assign _zz_497 = _zz_492[9];
-  assign _zz_498 = _zz_492[10];
-  assign _zz_499 = _zz_492[11];
-  assign _zz_500 = _zz_492[12];
-  assign _zz_501 = _zz_492[13];
-  assign _zz_502 = _zz_492[14];
-  assign _zz_503 = _zz_492[15];
-  assign _zz_504 = (((((((_zz_492[1] || _zz_493) || _zz_494) || _zz_496) || _zz_497) || _zz_499) || _zz_501) || _zz_503);
-  assign _zz_505 = (((((((_zz_492[2] || _zz_493) || _zz_495) || _zz_496) || _zz_498) || _zz_499) || _zz_502) || _zz_503);
-  assign _zz_506 = (((((((_zz_492[4] || _zz_494) || _zz_495) || _zz_496) || _zz_500) || _zz_501) || _zz_502) || _zz_503);
-  assign _zz_507 = (((((((_zz_492[8] || _zz_497) || _zz_498) || _zz_499) || _zz_500) || _zz_501) || _zz_502) || _zz_503);
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
   assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_509 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_510 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_511 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_512 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_508 = {(_zz_512 != 1'b0),{(_zz_512 != 1'b0),{((_zz_1003 == _zz_1004) != 1'b0),{(_zz_1005 != 1'b0),{(_zz_1006 != _zz_1007),{_zz_1008,{_zz_1009,_zz_1010}}}}}}};
-  assign _zz_513 = _zz_508[2 : 1];
-  assign _zz_49 = _zz_513;
-  assign _zz_514 = _zz_508[7 : 6];
-  assign _zz_48 = _zz_514;
-  assign _zz_515 = _zz_508[9 : 8];
-  assign _zz_47 = _zz_515;
-  assign _zz_516 = _zz_508[19 : 18];
-  assign _zz_46 = _zz_516;
-  assign _zz_517 = _zz_508[22 : 21];
-  assign _zz_45 = _zz_517;
-  assign _zz_518 = _zz_508[24 : 23];
-  assign _zz_44 = _zz_518;
-  assign _zz_519 = _zz_508[27 : 26];
-  assign _zz_43 = _zz_519;
+  assign _zz_PmpPlugin_dGuard_hits_0 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
+  assign PmpPlugin_dGuard_hits_0 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_0_1) == _zz_PmpPlugin_dGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_1 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_1) == _zz_PmpPlugin_dGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_2 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_2) == _zz_PmpPlugin_dGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_3 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_3) == _zz_PmpPlugin_dGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_4 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_4) == _zz_PmpPlugin_dGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_5 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_5) == _zz_PmpPlugin_dGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_6 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_6) == _zz_PmpPlugin_dGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_7 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_7) == _zz_PmpPlugin_dGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_8 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_8) == _zz_PmpPlugin_dGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_9 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_9) == _zz_PmpPlugin_dGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_10 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_10) == _zz_PmpPlugin_dGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_11 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_11) == _zz_PmpPlugin_dGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_12 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_12) == _zz_PmpPlugin_dGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_13 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_13) == _zz_PmpPlugin_dGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_14 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_14) == _zz_PmpPlugin_dGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_15 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_15) == _zz_PmpPlugin_dGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
+  assign when_PmpPlugin_l277 = (! ({PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{_zz_when_PmpPlugin_l277,_zz_when_PmpPlugin_l277_1}}}}}}}}}} != 16'h0));
+  always @(*) begin
+    if(when_PmpPlugin_l277) begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = ({(PmpPlugin_dGuard_hits_15 && PmpPlugin_pmpcfg_15[0]),{(PmpPlugin_dGuard_hits_14 && PmpPlugin_pmpcfg_14[0]),{(PmpPlugin_dGuard_hits_13 && PmpPlugin_pmpcfg_13[0]),{(PmpPlugin_dGuard_hits_12 && PmpPlugin_pmpcfg_12[0]),{(PmpPlugin_dGuard_hits_11 && _zz_DBusCachedPlugin_mmuBus_rsp_allowRead),{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2,_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3}}}}}}} != 16'h0);
+    end
+  end
+
+  always @(*) begin
+    if(when_PmpPlugin_l277) begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = ({(PmpPlugin_dGuard_hits_15 && PmpPlugin_pmpcfg_15[1]),{(PmpPlugin_dGuard_hits_14 && PmpPlugin_pmpcfg_14[1]),{(PmpPlugin_dGuard_hits_13 && PmpPlugin_pmpcfg_13[1]),{(PmpPlugin_dGuard_hits_12 && PmpPlugin_pmpcfg_12[1]),{(PmpPlugin_dGuard_hits_11 && _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite),{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2,_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3}}}}}}} != 16'h0);
+    end
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b0;
+  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
+  assign _zz_PmpPlugin_iGuard_hits_0 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
+  assign PmpPlugin_iGuard_hits_0 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_0_1) == _zz_PmpPlugin_iGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_1 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_1) == _zz_PmpPlugin_iGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_2 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_2) == _zz_PmpPlugin_iGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_3 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_3) == _zz_PmpPlugin_iGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_4 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_4) == _zz_PmpPlugin_iGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_5 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_5) == _zz_PmpPlugin_iGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_6 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_6) == _zz_PmpPlugin_iGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_7 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_7) == _zz_PmpPlugin_iGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_8 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_8) == _zz_PmpPlugin_iGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_9 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_9) == _zz_PmpPlugin_iGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_10 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_10) == _zz_PmpPlugin_iGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_11 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_11) == _zz_PmpPlugin_iGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_12 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_12) == _zz_PmpPlugin_iGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_13 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_13) == _zz_PmpPlugin_iGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_14 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_14) == _zz_PmpPlugin_iGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_15 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_15) == _zz_PmpPlugin_iGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
+  assign when_PmpPlugin_l299 = (! ({PmpPlugin_iGuard_hits_15,{PmpPlugin_iGuard_hits_14,{PmpPlugin_iGuard_hits_13,{PmpPlugin_iGuard_hits_12,{PmpPlugin_iGuard_hits_11,{PmpPlugin_iGuard_hits_10,{PmpPlugin_iGuard_hits_9,{PmpPlugin_iGuard_hits_8,{PmpPlugin_iGuard_hits_7,{_zz_when_PmpPlugin_l299,_zz_when_PmpPlugin_l299_1}}}}}}}}}} != 16'h0));
+  always @(*) begin
+    if(when_PmpPlugin_l299) begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = ({(PmpPlugin_iGuard_hits_15 && PmpPlugin_pmpcfg_15[2]),{(PmpPlugin_iGuard_hits_14 && PmpPlugin_pmpcfg_14[2]),{(PmpPlugin_iGuard_hits_13 && PmpPlugin_pmpcfg_13[2]),{(PmpPlugin_iGuard_hits_12 && PmpPlugin_pmpcfg_12[2]),{(PmpPlugin_iGuard_hits_11 && _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute),{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3}}}}}}} != 16'h0);
+    end
+  end
+
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_650;
-  assign decode_RegFilePlugin_rs2Data = _zz_651;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_520)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_520)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_10) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_520)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_10) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -6954,353 +8153,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_521 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_521 = {31'd0, _zz_836};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_521 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_522 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_522 = {29'd0, _zz_837};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_522 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_522 = {27'd0, _zz_838};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_523 = _zz_839[11];
-  always @ (*) begin
-    _zz_524[19] = _zz_523;
-    _zz_524[18] = _zz_523;
-    _zz_524[17] = _zz_523;
-    _zz_524[16] = _zz_523;
-    _zz_524[15] = _zz_523;
-    _zz_524[14] = _zz_523;
-    _zz_524[13] = _zz_523;
-    _zz_524[12] = _zz_523;
-    _zz_524[11] = _zz_523;
-    _zz_524[10] = _zz_523;
-    _zz_524[9] = _zz_523;
-    _zz_524[8] = _zz_523;
-    _zz_524[7] = _zz_523;
-    _zz_524[6] = _zz_523;
-    _zz_524[5] = _zz_523;
-    _zz_524[4] = _zz_523;
-    _zz_524[3] = _zz_523;
-    _zz_524[2] = _zz_523;
-    _zz_524[1] = _zz_523;
-    _zz_524[0] = _zz_523;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_525 = _zz_840[11];
-  always @ (*) begin
-    _zz_526[19] = _zz_525;
-    _zz_526[18] = _zz_525;
-    _zz_526[17] = _zz_525;
-    _zz_526[16] = _zz_525;
-    _zz_526[15] = _zz_525;
-    _zz_526[14] = _zz_525;
-    _zz_526[13] = _zz_525;
-    _zz_526[12] = _zz_525;
-    _zz_526[11] = _zz_525;
-    _zz_526[10] = _zz_525;
-    _zz_526[9] = _zz_525;
-    _zz_526[8] = _zz_525;
-    _zz_526[7] = _zz_525;
-    _zz_526[6] = _zz_525;
-    _zz_526[5] = _zz_525;
-    _zz_526[4] = _zz_525;
-    _zz_526[3] = _zz_525;
-    _zz_526[2] = _zz_525;
-    _zz_526[1] = _zz_525;
-    _zz_526[0] = _zz_525;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_527 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_527 = {_zz_524,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_527 = {_zz_526,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_527 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_841;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_528[0] = execute_SRC1[31];
-    _zz_528[1] = execute_SRC1[30];
-    _zz_528[2] = execute_SRC1[29];
-    _zz_528[3] = execute_SRC1[28];
-    _zz_528[4] = execute_SRC1[27];
-    _zz_528[5] = execute_SRC1[26];
-    _zz_528[6] = execute_SRC1[25];
-    _zz_528[7] = execute_SRC1[24];
-    _zz_528[8] = execute_SRC1[23];
-    _zz_528[9] = execute_SRC1[22];
-    _zz_528[10] = execute_SRC1[21];
-    _zz_528[11] = execute_SRC1[20];
-    _zz_528[12] = execute_SRC1[19];
-    _zz_528[13] = execute_SRC1[18];
-    _zz_528[14] = execute_SRC1[17];
-    _zz_528[15] = execute_SRC1[16];
-    _zz_528[16] = execute_SRC1[15];
-    _zz_528[17] = execute_SRC1[14];
-    _zz_528[18] = execute_SRC1[13];
-    _zz_528[19] = execute_SRC1[12];
-    _zz_528[20] = execute_SRC1[11];
-    _zz_528[21] = execute_SRC1[10];
-    _zz_528[22] = execute_SRC1[9];
-    _zz_528[23] = execute_SRC1[8];
-    _zz_528[24] = execute_SRC1[7];
-    _zz_528[25] = execute_SRC1[6];
-    _zz_528[26] = execute_SRC1[5];
-    _zz_528[27] = execute_SRC1[4];
-    _zz_528[28] = execute_SRC1[3];
-    _zz_528[29] = execute_SRC1[2];
-    _zz_528[30] = execute_SRC1[1];
-    _zz_528[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_528 : execute_SRC1);
-  always @ (*) begin
-    _zz_529[0] = memory_SHIFT_RIGHT[31];
-    _zz_529[1] = memory_SHIFT_RIGHT[30];
-    _zz_529[2] = memory_SHIFT_RIGHT[29];
-    _zz_529[3] = memory_SHIFT_RIGHT[28];
-    _zz_529[4] = memory_SHIFT_RIGHT[27];
-    _zz_529[5] = memory_SHIFT_RIGHT[26];
-    _zz_529[6] = memory_SHIFT_RIGHT[25];
-    _zz_529[7] = memory_SHIFT_RIGHT[24];
-    _zz_529[8] = memory_SHIFT_RIGHT[23];
-    _zz_529[9] = memory_SHIFT_RIGHT[22];
-    _zz_529[10] = memory_SHIFT_RIGHT[21];
-    _zz_529[11] = memory_SHIFT_RIGHT[20];
-    _zz_529[12] = memory_SHIFT_RIGHT[19];
-    _zz_529[13] = memory_SHIFT_RIGHT[18];
-    _zz_529[14] = memory_SHIFT_RIGHT[17];
-    _zz_529[15] = memory_SHIFT_RIGHT[16];
-    _zz_529[16] = memory_SHIFT_RIGHT[15];
-    _zz_529[17] = memory_SHIFT_RIGHT[14];
-    _zz_529[18] = memory_SHIFT_RIGHT[13];
-    _zz_529[19] = memory_SHIFT_RIGHT[12];
-    _zz_529[20] = memory_SHIFT_RIGHT[11];
-    _zz_529[21] = memory_SHIFT_RIGHT[10];
-    _zz_529[22] = memory_SHIFT_RIGHT[9];
-    _zz_529[23] = memory_SHIFT_RIGHT[8];
-    _zz_529[24] = memory_SHIFT_RIGHT[7];
-    _zz_529[25] = memory_SHIFT_RIGHT[6];
-    _zz_529[26] = memory_SHIFT_RIGHT[5];
-    _zz_529[27] = memory_SHIFT_RIGHT[4];
-    _zz_529[28] = memory_SHIFT_RIGHT[3];
-    _zz_529[29] = memory_SHIFT_RIGHT[2];
-    _zz_529[30] = memory_SHIFT_RIGHT[1];
-    _zz_529[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_530 = 1'b0;
-    if(_zz_689)begin
-      if(_zz_690)begin
-        if(_zz_535)begin
-          _zz_530 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_691)begin
-      if(_zz_692)begin
-        if(_zz_537)begin
-          _zz_530 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_693)begin
-      if(_zz_694)begin
-        if(_zz_539)begin
-          _zz_530 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_530 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_531 = 1'b0;
-    if(_zz_689)begin
-      if(_zz_690)begin
-        if(_zz_536)begin
-          _zz_531 = 1'b1;
-        end
-      end
-    end
-    if(_zz_691)begin
-      if(_zz_692)begin
-        if(_zz_538)begin
-          _zz_531 = 1'b1;
-        end
-      end
-    end
-    if(_zz_693)begin
-      if(_zz_694)begin
-        if(_zz_540)begin
-          _zz_531 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_531 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_535 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_536 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_537 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_538 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_539 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_540 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_541 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_541 == 3'b000)) begin
-        _zz_542 = execute_BranchPlugin_eq;
-    end else if((_zz_541 == 3'b001)) begin
-        _zz_542 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_541 & 3'b101) == 3'b101))) begin
-        _zz_542 = (! execute_SRC_LESS);
-    end else begin
-        _zz_542 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_543 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_543 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_543 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_543 = _zz_542;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_544 = _zz_848[11];
-  always @ (*) begin
-    _zz_545[19] = _zz_544;
-    _zz_545[18] = _zz_544;
-    _zz_545[17] = _zz_544;
-    _zz_545[16] = _zz_544;
-    _zz_545[15] = _zz_544;
-    _zz_545[14] = _zz_544;
-    _zz_545[13] = _zz_544;
-    _zz_545[12] = _zz_544;
-    _zz_545[11] = _zz_544;
-    _zz_545[10] = _zz_544;
-    _zz_545[9] = _zz_544;
-    _zz_545[8] = _zz_544;
-    _zz_545[7] = _zz_544;
-    _zz_545[6] = _zz_544;
-    _zz_545[5] = _zz_544;
-    _zz_545[4] = _zz_544;
-    _zz_545[3] = _zz_544;
-    _zz_545[2] = _zz_544;
-    _zz_545[1] = _zz_544;
-    _zz_545[0] = _zz_544;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_546 = _zz_849[19];
-  always @ (*) begin
-    _zz_547[10] = _zz_546;
-    _zz_547[9] = _zz_546;
-    _zz_547[8] = _zz_546;
-    _zz_547[7] = _zz_546;
-    _zz_547[6] = _zz_546;
-    _zz_547[5] = _zz_546;
-    _zz_547[4] = _zz_546;
-    _zz_547[3] = _zz_546;
-    _zz_547[2] = _zz_546;
-    _zz_547[1] = _zz_546;
-    _zz_547[0] = _zz_546;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_548 = _zz_850[11];
-  always @ (*) begin
-    _zz_549[18] = _zz_548;
-    _zz_549[17] = _zz_548;
-    _zz_549[16] = _zz_548;
-    _zz_549[15] = _zz_548;
-    _zz_549[14] = _zz_548;
-    _zz_549[13] = _zz_548;
-    _zz_549[12] = _zz_548;
-    _zz_549[11] = _zz_548;
-    _zz_549[10] = _zz_548;
-    _zz_549[9] = _zz_548;
-    _zz_549[8] = _zz_548;
-    _zz_549[7] = _zz_548;
-    _zz_549[6] = _zz_548;
-    _zz_549[5] = _zz_548;
-    _zz_549[4] = _zz_548;
-    _zz_549[3] = _zz_548;
-    _zz_549[2] = _zz_548;
-    _zz_549[1] = _zz_548;
-    _zz_549[0] = _zz_548;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_550 = (_zz_851[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_550 = _zz_852[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_550 = _zz_853[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_550);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -7311,80 +8533,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_551 = _zz_854[11];
-  always @ (*) begin
-    _zz_552[19] = _zz_551;
-    _zz_552[18] = _zz_551;
-    _zz_552[17] = _zz_551;
-    _zz_552[16] = _zz_551;
-    _zz_552[15] = _zz_551;
-    _zz_552[14] = _zz_551;
-    _zz_552[13] = _zz_551;
-    _zz_552[12] = _zz_551;
-    _zz_552[11] = _zz_551;
-    _zz_552[10] = _zz_551;
-    _zz_552[9] = _zz_551;
-    _zz_552[8] = _zz_551;
-    _zz_552[7] = _zz_551;
-    _zz_552[6] = _zz_551;
-    _zz_552[5] = _zz_551;
-    _zz_552[4] = _zz_551;
-    _zz_552[3] = _zz_551;
-    _zz_552[2] = _zz_551;
-    _zz_552[1] = _zz_551;
-    _zz_552[0] = _zz_551;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_552,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_554,{{{_zz_1167,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_556,{{{_zz_1168,_zz_1169},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_857};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_553 = _zz_855[19];
-  always @ (*) begin
-    _zz_554[10] = _zz_553;
-    _zz_554[9] = _zz_553;
-    _zz_554[8] = _zz_553;
-    _zz_554[7] = _zz_553;
-    _zz_554[6] = _zz_553;
-    _zz_554[5] = _zz_553;
-    _zz_554[4] = _zz_553;
-    _zz_554[3] = _zz_553;
-    _zz_554[2] = _zz_553;
-    _zz_554[1] = _zz_553;
-    _zz_554[0] = _zz_553;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_555 = _zz_856[11];
-  always @ (*) begin
-    _zz_556[18] = _zz_555;
-    _zz_556[17] = _zz_555;
-    _zz_556[16] = _zz_555;
-    _zz_556[15] = _zz_555;
-    _zz_556[14] = _zz_555;
-    _zz_556[13] = _zz_555;
-    _zz_556[12] = _zz_555;
-    _zz_556[11] = _zz_555;
-    _zz_556[10] = _zz_555;
-    _zz_556[9] = _zz_555;
-    _zz_556[8] = _zz_555;
-    _zz_556[7] = _zz_555;
-    _zz_556[6] = _zz_555;
-    _zz_556[5] = _zz_555;
-    _zz_556[4] = _zz_555;
-    _zz_556[3] = _zz_555;
-    _zz_556[2] = _zz_555;
-    _zz_556[1] = _zz_555;
-    _zz_556[0] = _zz_555;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -7394,92 +8616,106 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
-    CsrPlugin_privilege = _zz_557;
-    if(CsrPlugin_forceMachineWire)begin
+  always @(*) begin
+    CsrPlugin_privilege = _zz_CsrPlugin_privilege;
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_558 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_559 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_560 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_561 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_562 = _zz_858[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_681)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -7490,8 +8726,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -7501,195 +8737,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_944)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_945)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_946)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_947)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_948)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_949)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_950)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_951)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_952)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_953)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_954)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_955)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_956)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_957)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_958)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_959)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_928)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_929)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_930)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_931)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_695)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_696)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_697)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_696)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_697)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -7702,39 +8887,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_695)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_695)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_724)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_698)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -7747,8 +8942,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_698)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -7767,79 +8962,150 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_860) + $signed(_zz_861));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_676)begin
-      if(_zz_699)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_700)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_865);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_563 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_563[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_866);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_867 : _zz_868);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_869[31:0];
-  assign _zz_564 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_565 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_566 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_567[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_567[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_569 = (_zz_568 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_569 != 32'h0);
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -7860,489 +9126,352 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
-    _zz_570 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_570[12 : 0] = 13'h1000;
-      _zz_570[25 : 20] = 6'h20;
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
+    execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_stateReg;
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
+        if(execute_PmpPlugin_fsmPending) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite;
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
+        if(execute_PmpPlugin_pmpcfgCsr_) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg;
+        end
+        if(execute_PmpPlugin_pmpaddrCsr_) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr;
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
+        if(when_PmpPlugin_l229) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle;
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
+        execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle;
+      end
+      default : begin
+      end
+    endcase
+    if(execute_PmpPlugin_fsm_wantStart) begin
+      execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle;
+    end
+    if(execute_PmpPlugin_fsm_wantKill) begin
+      execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT;
     end
   end
 
-  always @ (*) begin
-    _zz_571 = 32'h0;
-    if(execute_CsrPlugin_csr_944)begin
-      _zz_571[31 : 0] = _zz_91;
+  assign _zz_PmpPlugin_pmpcfg_0 = execute_PmpPlugin_writeData_[7 : 0];
+  assign _zz_PmpPlugin_pmpcfg_0_1 = execute_PmpPlugin_writeData_[15 : 8];
+  assign _zz_PmpPlugin_pmpcfg_0_2 = execute_PmpPlugin_writeData_[23 : 16];
+  assign _zz_PmpPlugin_pmpcfg_0_3 = execute_PmpPlugin_writeData_[31 : 24];
+  assign when_PmpPlugin_l209 = (! _zz_when_PmpPlugin_l209[7]);
+  assign _zz_11 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b00});
+  assign when_PmpPlugin_l209_1 = (! _zz_when_PmpPlugin_l209_1_1[7]);
+  assign _zz_12 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b01});
+  assign when_PmpPlugin_l209_2 = (! _zz_when_PmpPlugin_l209_2[7]);
+  assign _zz_13 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b10});
+  assign when_PmpPlugin_l209_3 = (! _zz_when_PmpPlugin_l209_3[7]);
+  assign _zz_14 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b11});
+  assign when_PmpPlugin_l216 = (! _zz_when_PmpPlugin_l216[7]);
+  assign when_PmpPlugin_l229 = (execute_PmpPlugin_fsm_fsmCounter[1 : 0] == 2'b11);
+  assign when_StateMachine_l214 = ((execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite) && (! (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite)));
+  assign when_StateMachine_l230 = ((! (execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle)) && (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle));
+  assign when_StateMachine_l230_1 = ((! (execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg)) && (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg));
+  assign when_StateMachine_l230_2 = ((! (execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr)) && (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_572 = 32'h0;
-    if(execute_CsrPlugin_csr_945)begin
-      _zz_572[31 : 0] = _zz_110;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[0 : 0] = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_573 = 32'h0;
-    if(execute_CsrPlugin_csr_946)begin
-      _zz_573[31 : 0] = _zz_129;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 0] = 2'b10;
     end
   end
 
-  always @ (*) begin
-    _zz_574 = 32'h0;
-    if(execute_CsrPlugin_csr_947)begin
-      _zz_574[31 : 0] = _zz_148;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 0] = 2'b11;
     end
   end
 
-  always @ (*) begin
-    _zz_575 = 32'h0;
-    if(execute_CsrPlugin_csr_948)begin
-      _zz_575[31 : 0] = _zz_167;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_576 = 32'h0;
-    if(execute_CsrPlugin_csr_949)begin
-      _zz_576[31 : 0] = _zz_186;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_577 = 32'h0;
-    if(execute_CsrPlugin_csr_950)begin
-      _zz_577[31 : 0] = _zz_205;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_578 = 32'h0;
-    if(execute_CsrPlugin_csr_951)begin
-      _zz_578[31 : 0] = _zz_224;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_579 = 32'h0;
-    if(execute_CsrPlugin_csr_952)begin
-      _zz_579[31 : 0] = _zz_243;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_580 = 32'h0;
-    if(execute_CsrPlugin_csr_953)begin
-      _zz_580[31 : 0] = _zz_262;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_581 = 32'h0;
-    if(execute_CsrPlugin_csr_954)begin
-      _zz_581[31 : 0] = _zz_281;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_582 = 32'h0;
-    if(execute_CsrPlugin_csr_955)begin
-      _zz_582[31 : 0] = _zz_300;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_583 = 32'h0;
-    if(execute_CsrPlugin_csr_956)begin
-      _zz_583[31 : 0] = _zz_319;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_584 = 32'h0;
-    if(execute_CsrPlugin_csr_957)begin
-      _zz_584[31 : 0] = _zz_338;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_585 = 32'h0;
-    if(execute_CsrPlugin_csr_958)begin
-      _zz_585[31 : 0] = _zz_357;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_586 = 32'h0;
-    if(execute_CsrPlugin_csr_959)begin
-      _zz_586[31 : 0] = _zz_376;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_587 = 32'h0;
-    if(execute_CsrPlugin_csr_928)begin
-      _zz_587[31 : 31] = _zz_146;
-      _zz_587[23 : 23] = _zz_127;
-      _zz_587[15 : 15] = _zz_108;
-      _zz_587[7 : 7] = _zz_89;
-      _zz_587[28 : 27] = _zz_147;
-      _zz_587[26 : 26] = _zz_145;
-      _zz_587[25 : 25] = _zz_144;
-      _zz_587[24 : 24] = _zz_143;
-      _zz_587[20 : 19] = _zz_128;
-      _zz_587[18 : 18] = _zz_126;
-      _zz_587[17 : 17] = _zz_125;
-      _zz_587[16 : 16] = _zz_124;
-      _zz_587[12 : 11] = _zz_109;
-      _zz_587[10 : 10] = _zz_107;
-      _zz_587[9 : 9] = _zz_106;
-      _zz_587[8 : 8] = _zz_105;
-      _zz_587[4 : 3] = _zz_90;
-      _zz_587[2 : 2] = _zz_88;
-      _zz_587[1 : 1] = _zz_87;
-      _zz_587[0 : 0] = _zz_86;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_588 = 32'h0;
-    if(execute_CsrPlugin_csr_929)begin
-      _zz_588[31 : 31] = _zz_222;
-      _zz_588[23 : 23] = _zz_203;
-      _zz_588[15 : 15] = _zz_184;
-      _zz_588[7 : 7] = _zz_165;
-      _zz_588[28 : 27] = _zz_223;
-      _zz_588[26 : 26] = _zz_221;
-      _zz_588[25 : 25] = _zz_220;
-      _zz_588[24 : 24] = _zz_219;
-      _zz_588[20 : 19] = _zz_204;
-      _zz_588[18 : 18] = _zz_202;
-      _zz_588[17 : 17] = _zz_201;
-      _zz_588[16 : 16] = _zz_200;
-      _zz_588[12 : 11] = _zz_185;
-      _zz_588[10 : 10] = _zz_183;
-      _zz_588[9 : 9] = _zz_182;
-      _zz_588[8 : 8] = _zz_181;
-      _zz_588[4 : 3] = _zz_166;
-      _zz_588[2 : 2] = _zz_164;
-      _zz_588[1 : 1] = _zz_163;
-      _zz_588[0 : 0] = _zz_162;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_589 = 32'h0;
-    if(execute_CsrPlugin_csr_930)begin
-      _zz_589[31 : 31] = _zz_298;
-      _zz_589[23 : 23] = _zz_279;
-      _zz_589[15 : 15] = _zz_260;
-      _zz_589[7 : 7] = _zz_241;
-      _zz_589[28 : 27] = _zz_299;
-      _zz_589[26 : 26] = _zz_297;
-      _zz_589[25 : 25] = _zz_296;
-      _zz_589[24 : 24] = _zz_295;
-      _zz_589[20 : 19] = _zz_280;
-      _zz_589[18 : 18] = _zz_278;
-      _zz_589[17 : 17] = _zz_277;
-      _zz_589[16 : 16] = _zz_276;
-      _zz_589[12 : 11] = _zz_261;
-      _zz_589[10 : 10] = _zz_259;
-      _zz_589[9 : 9] = _zz_258;
-      _zz_589[8 : 8] = _zz_257;
-      _zz_589[4 : 3] = _zz_242;
-      _zz_589[2 : 2] = _zz_240;
-      _zz_589[1 : 1] = _zz_239;
-      _zz_589[0 : 0] = _zz_238;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_590 = 32'h0;
-    if(execute_CsrPlugin_csr_931)begin
-      _zz_590[31 : 31] = _zz_374;
-      _zz_590[23 : 23] = _zz_355;
-      _zz_590[15 : 15] = _zz_336;
-      _zz_590[7 : 7] = _zz_317;
-      _zz_590[28 : 27] = _zz_375;
-      _zz_590[26 : 26] = _zz_373;
-      _zz_590[25 : 25] = _zz_372;
-      _zz_590[24 : 24] = _zz_371;
-      _zz_590[20 : 19] = _zz_356;
-      _zz_590[18 : 18] = _zz_354;
-      _zz_590[17 : 17] = _zz_353;
-      _zz_590[16 : 16] = _zz_352;
-      _zz_590[12 : 11] = _zz_337;
-      _zz_590[10 : 10] = _zz_335;
-      _zz_590[9 : 9] = _zz_334;
-      _zz_590[8 : 8] = _zz_333;
-      _zz_590[4 : 3] = _zz_318;
-      _zz_590[2 : 2] = _zz_316;
-      _zz_590[1 : 1] = _zz_315;
-      _zz_590[0 : 0] = _zz_314;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_591 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_591[0 : 0] = 1'b1;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_592 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_592[1 : 0] = 2'b10;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_593 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_593[1 : 0] = 2'b11;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  always @ (*) begin
-    _zz_594 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_594[31 : 30] = CsrPlugin_misa_base;
-      _zz_594[25 : 0] = CsrPlugin_misa_extensions;
-    end
-  end
-
-  always @ (*) begin
-    _zz_595 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_595[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_595[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_595[3 : 3] = CsrPlugin_mstatus_MIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_596 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_596[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_596[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_596[3 : 3] = CsrPlugin_mip_MSIP;
-    end
-  end
-
-  always @ (*) begin
-    _zz_597 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_597[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_597[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_597[3 : 3] = CsrPlugin_mie_MSIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_598 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_598[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_598[1 : 0] = CsrPlugin_mtvec_mode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_599 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_599[31 : 0] = CsrPlugin_mepc;
-    end
-  end
-
-  always @ (*) begin
-    _zz_600 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_600[31 : 0] = CsrPlugin_mscratch;
-    end
-  end
-
-  always @ (*) begin
-    _zz_601 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_601[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_601[3 : 0] = CsrPlugin_mcause_exceptionCode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_602 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_602[31 : 0] = CsrPlugin_mtval;
-    end
-  end
-
-  always @ (*) begin
-    _zz_603 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_603[31 : 0] = CsrPlugin_mcycle[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_604 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_604[31 : 0] = CsrPlugin_mcycle[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_605 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_605[31 : 0] = CsrPlugin_minstret[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_606 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_606[31 : 0] = CsrPlugin_minstret[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_607 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_607[31 : 0] = CsrPlugin_mcycle[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_608 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_608[31 : 0] = CsrPlugin_mcycle[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_609 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_609[31 : 0] = CsrPlugin_minstret[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_610 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_610[31 : 0] = CsrPlugin_minstret[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_611 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_611[31 : 0] = _zz_568;
-    end
-  end
-
-  always @ (*) begin
-    _zz_612 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_612[31 : 0] = _zz_569;
-    end
-  end
-
-  assign execute_CsrPlugin_readData = (((((_zz_1170 | _zz_1171) | (_zz_1172 | _zz_1173)) | ((_zz_1174 | _zz_1175) | (_zz_1176 | _zz_1177))) | (((_zz_1178 | _zz_1179) | (_zz_1180 | _zz_1181)) | ((_zz_1182 | _zz_1183) | (_zz_1184 | _zz_1185)))) | ((((_zz_601 | _zz_602) | (_zz_603 | _zz_604)) | ((_zz_605 | _zz_606) | (_zz_607 | _zz_608))) | ((_zz_609 | _zz_610) | (_zz_611 | _zz_612))));
-  assign iBusWishbone_ADR = {_zz_950,_zz_613};
-  assign iBusWishbone_CTI = ((_zz_613 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_PmpPlugin_l155 = (CsrPlugin_privilege == 2'b11);
+  assign when_PmpPlugin_l172 = ((execute_PmpPlugin_pmpcfgCsr || execute_PmpPlugin_pmpaddrCsr) && (CsrPlugin_privilege == 2'b11));
+  assign when_PmpPlugin_l175 = ((! execute_PmpPlugin_fsmPending) && CsrPlugin_csrMapping_hazardFree);
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_701)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_701)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_614;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_620 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_616 = dBus_cmd_valid;
-  assign _zz_618 = dBus_cmd_payload_wr;
-  assign _zz_619 = (_zz_615 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_617 && (_zz_618 || _zz_619));
-  assign dBusWishbone_ADR = ((_zz_620 ? {{dBus_cmd_payload_address[31 : 5],_zz_615},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_620 ? (_zz_619 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_618 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_618;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_617 = (_zz_616 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_616;
-  assign dBusWishbone_STB = _zz_616;
-  assign dBus_rsp_valid = _zz_621;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_64 <= 1'b0;
-      _zz_66 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_79;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_80;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_89 <= 1'b0;
-      _zz_90 <= 2'b00;
-      _zz_108 <= 1'b0;
-      _zz_109 <= 2'b00;
-      _zz_127 <= 1'b0;
-      _zz_128 <= 2'b00;
-      _zz_146 <= 1'b0;
-      _zz_147 <= 2'b00;
-      _zz_165 <= 1'b0;
-      _zz_166 <= 2'b00;
-      _zz_184 <= 1'b0;
-      _zz_185 <= 2'b00;
-      _zz_203 <= 1'b0;
-      _zz_204 <= 2'b00;
-      _zz_222 <= 1'b0;
-      _zz_223 <= 2'b00;
-      _zz_241 <= 1'b0;
-      _zz_242 <= 2'b00;
-      _zz_260 <= 1'b0;
-      _zz_261 <= 2'b00;
-      _zz_279 <= 1'b0;
-      _zz_280 <= 2'b00;
-      _zz_298 <= 1'b0;
-      _zz_299 <= 2'b00;
-      _zz_317 <= 1'b0;
-      _zz_318 <= 2'b00;
-      _zz_336 <= 1'b0;
-      _zz_337 <= 2'b00;
-      _zz_355 <= 1'b0;
-      _zz_356 <= 2'b00;
-      _zz_374 <= 1'b0;
-      _zz_375 <= 2'b00;
-      _zz_520 <= 1'b1;
-      _zz_532 <= 1'b0;
-      _zz_557 <= 2'b11;
+      PmpPlugin_pmpcfg_0 <= 8'h0;
+      PmpPlugin_pmpcfg_1 <= 8'h0;
+      PmpPlugin_pmpcfg_2 <= 8'h0;
+      PmpPlugin_pmpcfg_3 <= 8'h0;
+      PmpPlugin_pmpcfg_4 <= 8'h0;
+      PmpPlugin_pmpcfg_5 <= 8'h0;
+      PmpPlugin_pmpcfg_6 <= 8'h0;
+      PmpPlugin_pmpcfg_7 <= 8'h0;
+      PmpPlugin_pmpcfg_8 <= 8'h0;
+      PmpPlugin_pmpcfg_9 <= 8'h0;
+      PmpPlugin_pmpcfg_10 <= 8'h0;
+      PmpPlugin_pmpcfg_11 <= 8'h0;
+      PmpPlugin_pmpcfg_12 <= 8'h0;
+      PmpPlugin_pmpcfg_13 <= 8'h0;
+      PmpPlugin_pmpcfg_14 <= 8'h0;
+      PmpPlugin_pmpcfg_15 <= 8'h0;
+      execute_PmpPlugin_fsmPending <= 1'b0;
+      execute_PmpPlugin_pmpcfgCsr_ <= 1'b0;
+      execute_PmpPlugin_pmpaddrCsr_ <= 1'b0;
+      execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
+      execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
+      _zz_10 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
+      _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0101064;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -8363,224 +9492,164 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_568 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_613 <= 3'b000;
-      _zz_614 <= 1'b0;
-      _zz_615 <= 3'b000;
-      _zz_621 <= 1'b0;
+      execute_PmpPlugin_fsm_stateReg <= `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_62)begin
-        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_66 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_702)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(_zz_703)begin
-        _zz_89 <= _zz_95;
-        _zz_90 <= _zz_96;
+      if(when_PmpPlugin_l138) begin
+        execute_PmpPlugin_fsmPending <= 1'b0;
       end
-      if(_zz_704)begin
-        _zz_108 <= _zz_114;
-        _zz_109 <= _zz_115;
-      end
-      if(_zz_705)begin
-        _zz_127 <= _zz_133;
-        _zz_128 <= _zz_134;
-      end
-      if(_zz_706)begin
-        _zz_146 <= _zz_152;
-        _zz_147 <= _zz_153;
-      end
-      if(_zz_707)begin
-        _zz_165 <= _zz_171;
-        _zz_166 <= _zz_172;
-      end
-      if(_zz_708)begin
-        _zz_184 <= _zz_190;
-        _zz_185 <= _zz_191;
-      end
-      if(_zz_709)begin
-        _zz_203 <= _zz_209;
-        _zz_204 <= _zz_210;
-      end
-      if(_zz_710)begin
-        _zz_222 <= _zz_228;
-        _zz_223 <= _zz_229;
-      end
-      if(_zz_711)begin
-        _zz_241 <= _zz_247;
-        _zz_242 <= _zz_248;
-      end
-      if(_zz_712)begin
-        _zz_260 <= _zz_266;
-        _zz_261 <= _zz_267;
-      end
-      if(_zz_713)begin
-        _zz_279 <= _zz_285;
-        _zz_280 <= _zz_286;
-      end
-      if(_zz_714)begin
-        _zz_298 <= _zz_304;
-        _zz_299 <= _zz_305;
-      end
-      if(_zz_715)begin
-        _zz_317 <= _zz_323;
-        _zz_318 <= _zz_324;
-      end
-      if(_zz_716)begin
-        _zz_336 <= _zz_342;
-        _zz_337 <= _zz_343;
-      end
-      if(_zz_717)begin
-        _zz_355 <= _zz_361;
-        _zz_356 <= _zz_362;
-      end
-      if(_zz_718)begin
-        _zz_374 <= _zz_380;
-        _zz_375 <= _zz_381;
-      end
-      _zz_520 <= 1'b0;
-      _zz_532 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_10 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_719)begin
-        if(_zz_720)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_721)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_722)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_683)begin
-        _zz_557 <= CsrPlugin_targetPrivilege;
+      if(when_CsrPlugin_l1019) begin
+        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -8591,249 +9660,490 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_684)begin
-        case(_zz_685)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_557 <= CsrPlugin_mstatus_MPP;
+            _zz_CsrPlugin_privilege <= CsrPlugin_mstatus_MPP;
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_560,{_zz_559,_zz_558}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      execute_PmpPlugin_fsm_stateReg <= execute_PmpPlugin_fsm_stateNext;
+      case(execute_PmpPlugin_fsm_stateReg)
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
+        end
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
+          if(execute_PmpPlugin_pmpcfgCsr_) begin
+            if(when_PmpPlugin_l209) begin
+              if(_zz_11[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+            end
+            if(when_PmpPlugin_l209_1) begin
+              if(_zz_12[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+            end
+            if(when_PmpPlugin_l209_2) begin
+              if(_zz_13[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+            end
+            if(when_PmpPlugin_l209_3) begin
+              if(_zz_14[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+            end
+          end
+        end
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
+          execute_PmpPlugin_fsm_fsmCounter <= (execute_PmpPlugin_fsm_fsmCounter + 4'b0001);
+        end
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
+        end
+        default : begin
+        end
+      endcase
+      if(when_StateMachine_l214) begin
+        execute_PmpPlugin_fsm_fsmEnable <= 1'b1;
+      end
+      if(when_StateMachine_l230) begin
+        execute_PmpPlugin_fsmPending <= 1'b0;
+        execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
+        execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
+      end
+      if(when_StateMachine_l230_1) begin
+        execute_PmpPlugin_fsm_fsmCounter <= {execute_PmpPlugin_pmpcfgN_,2'b00};
+      end
+      if(when_StateMachine_l230_2) begin
+        execute_PmpPlugin_fsm_fsmCounter <= execute_PmpPlugin_pmpNcfg_;
+      end
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_943[0];
-          CsrPlugin_mstatus_MIE <= _zz_944[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_946[0];
-          CsrPlugin_mie_MTIE <= _zz_947[0];
-          CsrPlugin_mie_MSIE <= _zz_948[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_568 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_701)begin
-        if(iBusWishbone_ACK)begin
-          _zz_613 <= (_zz_613 + 3'b001);
+      if(execute_CsrPlugin_writeInstruction) begin
+        if(when_PmpPlugin_l172) begin
+          if(when_PmpPlugin_l175) begin
+            execute_PmpPlugin_fsmPending <= 1'b1;
+            execute_PmpPlugin_pmpcfgCsr_ <= execute_PmpPlugin_pmpcfgCsr;
+            execute_PmpPlugin_pmpaddrCsr_ <= execute_PmpPlugin_pmpaddrCsr;
+          end
         end
       end
-      _zz_614 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_616 && _zz_617))begin
-        _zz_615 <= (_zz_615 + 3'b001);
-        if(_zz_619)begin
-          _zz_615 <= 3'b000;
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_621 <= ((_zz_616 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
+        end
+      end
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_67 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_702)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(_zz_703)begin
-      _zz_86 <= _zz_92;
-      _zz_87 <= _zz_93;
-      _zz_88 <= _zz_94;
-      _zz_91 <= _zz_97;
+    if(when_PmpPlugin_l246) begin
+      if(_zz_8[0]) begin
+        PmpPlugin_base_0 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[1]) begin
+        PmpPlugin_base_1 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[2]) begin
+        PmpPlugin_base_2 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[3]) begin
+        PmpPlugin_base_3 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[4]) begin
+        PmpPlugin_base_4 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[5]) begin
+        PmpPlugin_base_5 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[6]) begin
+        PmpPlugin_base_6 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[7]) begin
+        PmpPlugin_base_7 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[8]) begin
+        PmpPlugin_base_8 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[9]) begin
+        PmpPlugin_base_9 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[10]) begin
+        PmpPlugin_base_10 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[11]) begin
+        PmpPlugin_base_11 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[12]) begin
+        PmpPlugin_base_12 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[13]) begin
+        PmpPlugin_base_13 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[14]) begin
+        PmpPlugin_base_14 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[15]) begin
+        PmpPlugin_base_15 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_9[0]) begin
+        PmpPlugin_mask_0 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[1]) begin
+        PmpPlugin_mask_1 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[2]) begin
+        PmpPlugin_mask_2 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[3]) begin
+        PmpPlugin_mask_3 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[4]) begin
+        PmpPlugin_mask_4 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[5]) begin
+        PmpPlugin_mask_5 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[6]) begin
+        PmpPlugin_mask_6 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[7]) begin
+        PmpPlugin_mask_7 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[8]) begin
+        PmpPlugin_mask_8 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[9]) begin
+        PmpPlugin_mask_9 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[10]) begin
+        PmpPlugin_mask_10 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[11]) begin
+        PmpPlugin_mask_11 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[12]) begin
+        PmpPlugin_mask_12 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[13]) begin
+        PmpPlugin_mask_13 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[14]) begin
+        PmpPlugin_mask_14 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[15]) begin
+        PmpPlugin_mask_15 <= PmpPlugin_setter_io_mask;
+      end
     end
-    if(_zz_704)begin
-      _zz_105 <= _zz_111;
-      _zz_106 <= _zz_112;
-      _zz_107 <= _zz_113;
-      _zz_110 <= _zz_116;
-    end
-    if(_zz_705)begin
-      _zz_124 <= _zz_130;
-      _zz_125 <= _zz_131;
-      _zz_126 <= _zz_132;
-      _zz_129 <= _zz_135;
-    end
-    if(_zz_706)begin
-      _zz_143 <= _zz_149;
-      _zz_144 <= _zz_150;
-      _zz_145 <= _zz_151;
-      _zz_148 <= _zz_154;
-    end
-    if(_zz_707)begin
-      _zz_162 <= _zz_168;
-      _zz_163 <= _zz_169;
-      _zz_164 <= _zz_170;
-      _zz_167 <= _zz_173;
-    end
-    if(_zz_708)begin
-      _zz_181 <= _zz_187;
-      _zz_182 <= _zz_188;
-      _zz_183 <= _zz_189;
-      _zz_186 <= _zz_192;
-    end
-    if(_zz_709)begin
-      _zz_200 <= _zz_206;
-      _zz_201 <= _zz_207;
-      _zz_202 <= _zz_208;
-      _zz_205 <= _zz_211;
-    end
-    if(_zz_710)begin
-      _zz_219 <= _zz_225;
-      _zz_220 <= _zz_226;
-      _zz_221 <= _zz_227;
-      _zz_224 <= _zz_230;
-    end
-    if(_zz_711)begin
-      _zz_238 <= _zz_244;
-      _zz_239 <= _zz_245;
-      _zz_240 <= _zz_246;
-      _zz_243 <= _zz_249;
-    end
-    if(_zz_712)begin
-      _zz_257 <= _zz_263;
-      _zz_258 <= _zz_264;
-      _zz_259 <= _zz_265;
-      _zz_262 <= _zz_268;
-    end
-    if(_zz_713)begin
-      _zz_276 <= _zz_282;
-      _zz_277 <= _zz_283;
-      _zz_278 <= _zz_284;
-      _zz_281 <= _zz_287;
-    end
-    if(_zz_714)begin
-      _zz_295 <= _zz_301;
-      _zz_296 <= _zz_302;
-      _zz_297 <= _zz_303;
-      _zz_300 <= _zz_306;
-    end
-    if(_zz_715)begin
-      _zz_314 <= _zz_320;
-      _zz_315 <= _zz_321;
-      _zz_316 <= _zz_322;
-      _zz_319 <= _zz_325;
-    end
-    if(_zz_716)begin
-      _zz_333 <= _zz_339;
-      _zz_334 <= _zz_340;
-      _zz_335 <= _zz_341;
-      _zz_338 <= _zz_344;
-    end
-    if(_zz_717)begin
-      _zz_352 <= _zz_358;
-      _zz_353 <= _zz_359;
-      _zz_354 <= _zz_360;
-      _zz_357 <= _zz_363;
-    end
-    if(_zz_718)begin
-      _zz_371 <= _zz_377;
-      _zz_372 <= _zz_378;
-      _zz_373 <= _zz_379;
-      _zz_376 <= _zz_382;
-    end
-    _zz_533 <= _zz_40[11 : 7];
-    _zz_534 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_681)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_562 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_562 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_719)begin
-      if(_zz_720)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_721)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_722)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_683)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -8841,396 +10151,345 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_676)begin
-      if(_zz_699)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_870[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_700)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_566 ? (~ _zz_567) : _zz_567) + _zz_876);
-      memory_DivPlugin_rs2 <= ((_zz_565 ? (~ execute_RS2) : execute_RS2) + _zz_878);
-      memory_DivPlugin_div_needRevert <= ((_zz_566 ^ (_zz_565 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_49) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_50) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_51) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_52) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_53) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_944 <= (decode_INSTRUCTION[31 : 20] == 12'h3b0);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_945 <= (decode_INSTRUCTION[31 : 20] == 12'h3b1);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_946 <= (decode_INSTRUCTION[31 : 20] == 12'h3b2);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_947 <= (decode_INSTRUCTION[31 : 20] == 12'h3b3);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_948 <= (decode_INSTRUCTION[31 : 20] == 12'h3b4);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_949 <= (decode_INSTRUCTION[31 : 20] == 12'h3b5);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_950 <= (decode_INSTRUCTION[31 : 20] == 12'h3b6);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_951 <= (decode_INSTRUCTION[31 : 20] == 12'h3b7);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_952 <= (decode_INSTRUCTION[31 : 20] == 12'h3b8);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_953 <= (decode_INSTRUCTION[31 : 20] == 12'h3b9);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_954 <= (decode_INSTRUCTION[31 : 20] == 12'h3ba);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_955 <= (decode_INSTRUCTION[31 : 20] == 12'h3bb);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_956 <= (decode_INSTRUCTION[31 : 20] == 12'h3bc);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_957 <= (decode_INSTRUCTION[31 : 20] == 12'h3bd);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_958 <= (decode_INSTRUCTION[31 : 20] == 12'h3be);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_959 <= (decode_INSTRUCTION[31 : 20] == 12'h3bf);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_928 <= (decode_INSTRUCTION[31 : 20] == 12'h3a0);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_929 <= (decode_INSTRUCTION[31 : 20] == 12'h3a1);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_930 <= (decode_INSTRUCTION[31 : 20] == 12'h3a2);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_931 <= (decode_INSTRUCTION[31 : 20] == 12'h3a3);
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_945[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_949[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+    if(execute_CsrPlugin_writeInstruction) begin
+      if(when_PmpPlugin_l172) begin
+        if(when_PmpPlugin_l175) begin
+          execute_PmpPlugin_writeData_ <= CsrPlugin_csrMapping_writeDataSignal;
+          execute_PmpPlugin_pmpNcfg_ <= execute_PmpPlugin_pmpNcfg;
+          execute_PmpPlugin_pmpcfgN_ <= execute_PmpPlugin_pmpcfgN;
+        end
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -9243,9 +10502,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -9267,6 +10525,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -9282,9 +10541,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -9292,7 +10552,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -9301,24 +10561,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -9343,40 +10594,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -9386,23 +10645,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -9410,10 +10679,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -9425,59 +10702,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -9492,274 +10764,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -9767,89 +11058,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -9857,12 +11132,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -9873,20 +11148,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -9894,45 +11189,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -9943,46 +11240,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -9990,50 +11278,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -10083,13 +11372,9 @@ module InstructionCache (
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_9;
-  reg        [21:0]   _zz_10;
-  wire                _zz_11;
-  wire                _zz_12;
-  wire       [0:0]    _zz_13;
-  wire       [0:0]    _zz_14;
-  wire       [21:0]   _zz_15;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -10098,8 +11383,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -10113,22 +11403,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -10138,82 +11431,85 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_11 = (! lineLoader_flushCounter[7]);
-  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_13 = _zz_8[0 : 0];
-  assign _zz_14 = _zz_8[1 : 1];
-  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_9 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_10 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -10229,30 +11525,35 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_10;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -10260,51 +11561,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_12)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_11)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_12)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -10315,13 +11616,28 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
   end
 
+
+endmodule
+
+module PmpSetter (
+  input      [31:0]   io_addr,
+  output     [24:0]   io_base,
+  output     [24:0]   io_mask
+);
+  wire       [31:0]   _zz_ones;
+  wire       [31:0]   ones;
+
+  assign _zz_ones = (io_addr + 32'h00000001);
+  assign ones = (io_addr & (~ _zz_ones));
+  assign io_base = (io_addr[29 : 5] ^ ones[29 : 5]);
+  assign io_mask = (~ ones[30 : 6]);
 
 endmodule

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_SecureDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_SecureDebug.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
+// Generator : SpinalHDL v1.5.0    git head : 83a031922866b078c411ec5529e00f1b6e79f8e7
 // Component : VexRiscv
-// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
+// Git hash  : 6bce178f5927e8960c36a559e33b1ba090ce88d4
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -16,15 +16,15 @@
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define ShiftCtrlEnum_defaultEncoding_DISABLE 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -42,6 +42,13 @@
 `define Src1CtrlEnum_defaultEncoding_IMU 2'b01
 `define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
 `define Src1CtrlEnum_defaultEncoding_URS1 2'b11
+
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_type [2:0]
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT 3'b000
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle 3'b001
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite 3'b010
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg 3'b011
+`define execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr 3'b100
 
 
 module VexRiscv (
@@ -82,55 +89,42 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_625;
-  wire                _zz_626;
-  wire                _zz_627;
-  wire                _zz_628;
-  wire                _zz_629;
-  wire                _zz_630;
-  wire                _zz_631;
-  wire                _zz_632;
-  reg                 _zz_633;
-  wire                _zz_634;
-  wire       [31:0]   _zz_635;
-  wire                _zz_636;
-  wire       [31:0]   _zz_637;
-  reg                 _zz_638;
-  wire                _zz_639;
-  wire                _zz_640;
-  wire       [31:0]   _zz_641;
-  wire                _zz_642;
-  wire                _zz_643;
-  wire                _zz_644;
-  wire                _zz_645;
-  wire                _zz_646;
-  wire                _zz_647;
-  wire                _zz_648;
-  wire                _zz_649;
-  wire       [3:0]    _zz_650;
-  wire                _zz_651;
-  wire                _zz_652;
-  reg        [31:0]   _zz_653;
-  reg        [31:0]   _zz_654;
-  reg        [31:0]   _zz_655;
-  reg        [4:0]    _zz_656;
-  reg        [4:0]    _zz_657;
-  reg        [4:0]    _zz_658;
-  reg        [4:0]    _zz_659;
-  reg        [4:0]    _zz_660;
-  reg        [4:0]    _zz_661;
-  reg                 _zz_662;
-  reg                 _zz_663;
-  reg                 _zz_664;
-  reg        [4:0]    _zz_665;
-  reg        [4:0]    _zz_666;
-  reg        [4:0]    _zz_667;
-  reg        [4:0]    _zz_668;
-  reg        [4:0]    _zz_669;
-  reg        [4:0]    _zz_670;
-  reg                 _zz_671;
-  reg                 _zz_672;
-  reg                 _zz_673;
+  reg        [31:0]   PmpPlugin_setter_io_addr;
+  wire                IBusCachedPlugin_cache_io_flush;
+  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
+  wire                IBusCachedPlugin_cache_io_cpu_decode_isUser;
+  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                dataCache_1_io_cpu_execute_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_execute_address;
+  wire                dataCache_1_io_cpu_memory_isValid;
+  wire       [31:0]   dataCache_1_io_cpu_memory_address;
+  reg                 dataCache_1_io_cpu_memory_mmuRsp_isIoAccess;
+  reg                 dataCache_1_io_cpu_writeBack_isValid;
+  wire                dataCache_1_io_cpu_writeBack_isUser;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_storeData;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_address;
+  wire                dataCache_1_io_cpu_writeBack_fence_SW;
+  wire                dataCache_1_io_cpu_writeBack_fence_SR;
+  wire                dataCache_1_io_cpu_writeBack_fence_SO;
+  wire                dataCache_1_io_cpu_writeBack_fence_SI;
+  wire                dataCache_1_io_cpu_writeBack_fence_PW;
+  wire                dataCache_1_io_cpu_writeBack_fence_PR;
+  wire                dataCache_1_io_cpu_writeBack_fence_PO;
+  wire                dataCache_1_io_cpu_writeBack_fence_PI;
+  wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
+  wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_mem_cmd_ready;
+  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port0;
+  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port2;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
+  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
+  wire       [24:0]   PmpPlugin_setter_io_base;
+  wire       [24:0]   PmpPlugin_setter_io_mask;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -153,6 +147,7 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_accessError;
   wire                dataCache_1_io_cpu_writeBack_isWrite;
   wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_writeBack_exclusiveOk;
   wire                dataCache_1_io_cpu_flush_ready;
   wire                dataCache_1_io_cpu_redo;
   wire                dataCache_1_io_mem_cmd_valid;
@@ -161,529 +156,450 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_size;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_674;
-  wire                _zz_675;
-  wire                _zz_676;
-  wire                _zz_677;
-  wire                _zz_678;
-  wire                _zz_679;
-  wire                _zz_680;
-  wire                _zz_681;
-  wire                _zz_682;
-  wire                _zz_683;
-  wire                _zz_684;
-  wire                _zz_685;
-  wire                _zz_686;
-  wire                _zz_687;
-  wire                _zz_688;
-  wire                _zz_689;
-  wire                _zz_690;
-  wire       [1:0]    _zz_691;
-  wire                _zz_692;
-  wire                _zz_693;
-  wire                _zz_694;
-  wire                _zz_695;
-  wire                _zz_696;
-  wire                _zz_697;
-  wire                _zz_698;
-  wire                _zz_699;
-  wire                _zz_700;
-  wire                _zz_701;
-  wire                _zz_702;
-  wire                _zz_703;
-  wire       [1:0]    _zz_704;
-  wire                _zz_705;
-  wire                _zz_706;
-  wire       [5:0]    _zz_707;
-  wire                _zz_708;
-  wire                _zz_709;
-  wire                _zz_710;
-  wire                _zz_711;
-  wire                _zz_712;
-  wire                _zz_713;
-  wire                _zz_714;
-  wire                _zz_715;
-  wire                _zz_716;
-  wire                _zz_717;
-  wire                _zz_718;
-  wire                _zz_719;
-  wire                _zz_720;
-  wire                _zz_721;
-  wire                _zz_722;
-  wire                _zz_723;
-  wire                _zz_724;
-  wire                _zz_725;
-  wire                _zz_726;
-  wire                _zz_727;
-  wire                _zz_728;
-  wire                _zz_729;
-  wire       [1:0]    _zz_730;
-  wire                _zz_731;
-  wire       [1:0]    _zz_732;
-  wire       [51:0]   _zz_733;
-  wire       [51:0]   _zz_734;
-  wire       [51:0]   _zz_735;
-  wire       [32:0]   _zz_736;
-  wire       [51:0]   _zz_737;
-  wire       [49:0]   _zz_738;
-  wire       [51:0]   _zz_739;
-  wire       [49:0]   _zz_740;
-  wire       [51:0]   _zz_741;
-  wire       [32:0]   _zz_742;
-  wire       [31:0]   _zz_743;
-  wire       [32:0]   _zz_744;
-  wire       [0:0]    _zz_745;
-  wire       [0:0]    _zz_746;
-  wire       [0:0]    _zz_747;
-  wire       [0:0]    _zz_748;
-  wire       [0:0]    _zz_749;
-  wire       [0:0]    _zz_750;
-  wire       [0:0]    _zz_751;
-  wire       [0:0]    _zz_752;
-  wire       [0:0]    _zz_753;
-  wire       [0:0]    _zz_754;
-  wire       [0:0]    _zz_755;
-  wire       [0:0]    _zz_756;
-  wire       [0:0]    _zz_757;
-  wire       [0:0]    _zz_758;
-  wire       [0:0]    _zz_759;
-  wire       [0:0]    _zz_760;
-  wire       [0:0]    _zz_761;
-  wire       [0:0]    _zz_762;
-  wire       [3:0]    _zz_763;
-  wire       [2:0]    _zz_764;
-  wire       [31:0]   _zz_765;
-  wire       [11:0]   _zz_766;
-  wire       [31:0]   _zz_767;
-  wire       [19:0]   _zz_768;
-  wire       [11:0]   _zz_769;
-  wire       [31:0]   _zz_770;
-  wire       [31:0]   _zz_771;
-  wire       [19:0]   _zz_772;
-  wire       [11:0]   _zz_773;
-  wire       [2:0]    _zz_774;
-  wire       [2:0]    _zz_775;
-  wire       [31:0]   _zz_776;
-  wire       [31:0]   _zz_777;
-  wire       [31:0]   _zz_778;
-  wire       [31:0]   _zz_779;
-  wire       [31:0]   _zz_780;
-  wire       [31:0]   _zz_781;
-  wire       [31:0]   _zz_782;
-  wire       [31:0]   _zz_783;
-  wire       [31:0]   _zz_784;
-  wire       [31:0]   _zz_785;
-  wire       [31:0]   _zz_786;
-  wire       [31:0]   _zz_787;
-  wire       [31:0]   _zz_788;
-  wire       [31:0]   _zz_789;
-  wire       [31:0]   _zz_790;
-  wire       [31:0]   _zz_791;
-  wire       [31:0]   _zz_792;
-  wire       [31:0]   _zz_793;
-  wire       [31:0]   _zz_794;
-  wire       [31:0]   _zz_795;
-  wire       [31:0]   _zz_796;
-  wire       [31:0]   _zz_797;
-  wire       [31:0]   _zz_798;
-  wire       [31:0]   _zz_799;
-  wire       [31:0]   _zz_800;
-  wire       [31:0]   _zz_801;
-  wire       [31:0]   _zz_802;
-  wire       [31:0]   _zz_803;
-  wire       [31:0]   _zz_804;
-  wire       [31:0]   _zz_805;
-  wire       [31:0]   _zz_806;
-  wire       [31:0]   _zz_807;
-  wire       [31:0]   _zz_808;
-  wire       [31:0]   _zz_809;
-  wire       [31:0]   _zz_810;
-  wire       [31:0]   _zz_811;
-  wire       [31:0]   _zz_812;
-  wire       [31:0]   _zz_813;
-  wire       [31:0]   _zz_814;
-  wire       [31:0]   _zz_815;
-  wire       [31:0]   _zz_816;
-  wire       [31:0]   _zz_817;
-  wire       [31:0]   _zz_818;
-  wire       [31:0]   _zz_819;
-  wire       [31:0]   _zz_820;
-  wire       [31:0]   _zz_821;
-  wire       [31:0]   _zz_822;
-  wire       [31:0]   _zz_823;
-  wire       [4:0]    _zz_824;
-  wire       [4:0]    _zz_825;
-  wire       [4:0]    _zz_826;
-  wire       [4:0]    _zz_827;
-  wire       [4:0]    _zz_828;
-  wire       [0:0]    _zz_829;
-  wire       [2:0]    _zz_830;
-  wire       [15:0]   _zz_831;
-  wire       [15:0]   _zz_832;
-  wire       [15:0]   _zz_833;
-  wire       [4:0]    _zz_834;
-  wire       [4:0]    _zz_835;
-  wire       [4:0]    _zz_836;
-  wire       [4:0]    _zz_837;
-  wire       [4:0]    _zz_838;
-  wire       [0:0]    _zz_839;
-  wire       [2:0]    _zz_840;
-  wire       [15:0]   _zz_841;
-  wire       [15:0]   _zz_842;
-  wire       [15:0]   _zz_843;
-  wire       [0:0]    _zz_844;
-  wire       [2:0]    _zz_845;
-  wire       [4:0]    _zz_846;
-  wire       [11:0]   _zz_847;
-  wire       [11:0]   _zz_848;
-  wire       [31:0]   _zz_849;
-  wire       [31:0]   _zz_850;
-  wire       [31:0]   _zz_851;
-  wire       [31:0]   _zz_852;
-  wire       [31:0]   _zz_853;
-  wire       [31:0]   _zz_854;
-  wire       [31:0]   _zz_855;
-  wire       [11:0]   _zz_856;
-  wire       [19:0]   _zz_857;
-  wire       [11:0]   _zz_858;
-  wire       [31:0]   _zz_859;
-  wire       [31:0]   _zz_860;
-  wire       [31:0]   _zz_861;
-  wire       [11:0]   _zz_862;
-  wire       [19:0]   _zz_863;
-  wire       [11:0]   _zz_864;
-  wire       [2:0]    _zz_865;
-  wire       [1:0]    _zz_866;
-  wire       [1:0]    _zz_867;
-  wire       [65:0]   _zz_868;
-  wire       [65:0]   _zz_869;
-  wire       [31:0]   _zz_870;
-  wire       [31:0]   _zz_871;
-  wire       [0:0]    _zz_872;
-  wire       [5:0]    _zz_873;
-  wire       [32:0]   _zz_874;
-  wire       [31:0]   _zz_875;
-  wire       [31:0]   _zz_876;
-  wire       [32:0]   _zz_877;
-  wire       [32:0]   _zz_878;
-  wire       [32:0]   _zz_879;
-  wire       [32:0]   _zz_880;
-  wire       [0:0]    _zz_881;
-  wire       [32:0]   _zz_882;
-  wire       [0:0]    _zz_883;
-  wire       [32:0]   _zz_884;
-  wire       [0:0]    _zz_885;
-  wire       [31:0]   _zz_886;
-  wire       [0:0]    _zz_887;
-  wire       [0:0]    _zz_888;
-  wire       [0:0]    _zz_889;
-  wire       [0:0]    _zz_890;
-  wire       [0:0]    _zz_891;
-  wire       [0:0]    _zz_892;
-  wire       [0:0]    _zz_893;
-  wire       [0:0]    _zz_894;
-  wire       [0:0]    _zz_895;
-  wire       [0:0]    _zz_896;
-  wire       [0:0]    _zz_897;
-  wire       [0:0]    _zz_898;
-  wire       [0:0]    _zz_899;
-  wire       [0:0]    _zz_900;
-  wire       [0:0]    _zz_901;
-  wire       [0:0]    _zz_902;
-  wire       [0:0]    _zz_903;
-  wire       [0:0]    _zz_904;
-  wire       [0:0]    _zz_905;
-  wire       [0:0]    _zz_906;
-  wire       [0:0]    _zz_907;
-  wire       [0:0]    _zz_908;
-  wire       [0:0]    _zz_909;
-  wire       [0:0]    _zz_910;
-  wire       [0:0]    _zz_911;
-  wire       [0:0]    _zz_912;
-  wire       [0:0]    _zz_913;
-  wire       [0:0]    _zz_914;
-  wire       [0:0]    _zz_915;
-  wire       [0:0]    _zz_916;
-  wire       [0:0]    _zz_917;
-  wire       [0:0]    _zz_918;
-  wire       [0:0]    _zz_919;
-  wire       [0:0]    _zz_920;
-  wire       [0:0]    _zz_921;
-  wire       [0:0]    _zz_922;
-  wire       [0:0]    _zz_923;
-  wire       [0:0]    _zz_924;
-  wire       [0:0]    _zz_925;
-  wire       [0:0]    _zz_926;
-  wire       [0:0]    _zz_927;
-  wire       [0:0]    _zz_928;
-  wire       [0:0]    _zz_929;
-  wire       [0:0]    _zz_930;
-  wire       [0:0]    _zz_931;
-  wire       [0:0]    _zz_932;
-  wire       [0:0]    _zz_933;
-  wire       [0:0]    _zz_934;
-  wire       [0:0]    _zz_935;
-  wire       [0:0]    _zz_936;
-  wire       [0:0]    _zz_937;
-  wire       [0:0]    _zz_938;
-  wire       [0:0]    _zz_939;
-  wire       [0:0]    _zz_940;
-  wire       [0:0]    _zz_941;
-  wire       [0:0]    _zz_942;
-  wire       [0:0]    _zz_943;
-  wire       [0:0]    _zz_944;
-  wire       [0:0]    _zz_945;
-  wire       [0:0]    _zz_946;
-  wire       [0:0]    _zz_947;
-  wire       [0:0]    _zz_948;
-  wire       [0:0]    _zz_949;
-  wire       [0:0]    _zz_950;
-  wire       [0:0]    _zz_951;
-  wire       [0:0]    _zz_952;
-  wire       [0:0]    _zz_953;
-  wire       [0:0]    _zz_954;
-  wire       [0:0]    _zz_955;
-  wire       [0:0]    _zz_956;
-  wire       [0:0]    _zz_957;
-  wire       [26:0]   _zz_958;
-  wire                _zz_959;
-  wire                _zz_960;
-  wire       [1:0]    _zz_961;
-  wire       [2:0]    _zz_962;
-  wire       [2:0]    _zz_963;
-  wire       [2:0]    _zz_964;
-  wire       [2:0]    _zz_965;
-  wire       [2:0]    _zz_966;
-  wire       [3:0]    _zz_967;
-  wire       [3:0]    _zz_968;
-  wire       [3:0]    _zz_969;
-  wire       [2:0]    _zz_970;
-  wire       [2:0]    _zz_971;
-  wire       [2:0]    _zz_972;
-  wire       [2:0]    _zz_973;
-  wire       [2:0]    _zz_974;
-  wire       [3:0]    _zz_975;
-  wire       [3:0]    _zz_976;
-  wire       [3:0]    _zz_977;
-  wire       [31:0]   _zz_978;
-  wire       [31:0]   _zz_979;
-  wire       [31:0]   _zz_980;
-  wire                _zz_981;
-  wire       [0:0]    _zz_982;
-  wire       [13:0]   _zz_983;
-  wire       [31:0]   _zz_984;
-  wire       [31:0]   _zz_985;
-  wire       [31:0]   _zz_986;
-  wire                _zz_987;
-  wire       [0:0]    _zz_988;
-  wire       [7:0]    _zz_989;
-  wire       [31:0]   _zz_990;
-  wire       [31:0]   _zz_991;
-  wire       [31:0]   _zz_992;
-  wire                _zz_993;
-  wire       [0:0]    _zz_994;
-  wire       [1:0]    _zz_995;
-  wire                _zz_996;
-  wire                _zz_997;
-  wire                _zz_998;
-  wire       [0:0]    _zz_999;
-  wire       [4:0]    _zz_1000;
-  wire       [0:0]    _zz_1001;
-  wire       [4:0]    _zz_1002;
-  wire       [0:0]    _zz_1003;
-  wire       [4:0]    _zz_1004;
-  wire       [0:0]    _zz_1005;
-  wire       [4:0]    _zz_1006;
-  wire       [0:0]    _zz_1007;
-  wire       [4:0]    _zz_1008;
-  wire       [0:0]    _zz_1009;
-  wire       [4:0]    _zz_1010;
-  wire       [31:0]   _zz_1011;
-  wire       [0:0]    _zz_1012;
-  wire       [0:0]    _zz_1013;
-  wire                _zz_1014;
-  wire       [0:0]    _zz_1015;
-  wire       [26:0]   _zz_1016;
-  wire       [31:0]   _zz_1017;
-  wire                _zz_1018;
-  wire                _zz_1019;
-  wire                _zz_1020;
-  wire       [1:0]    _zz_1021;
-  wire       [1:0]    _zz_1022;
-  wire                _zz_1023;
-  wire       [0:0]    _zz_1024;
-  wire       [22:0]   _zz_1025;
-  wire       [31:0]   _zz_1026;
-  wire       [31:0]   _zz_1027;
-  wire       [31:0]   _zz_1028;
-  wire       [31:0]   _zz_1029;
-  wire                _zz_1030;
-  wire                _zz_1031;
-  wire       [1:0]    _zz_1032;
-  wire       [1:0]    _zz_1033;
-  wire                _zz_1034;
-  wire       [0:0]    _zz_1035;
-  wire       [19:0]   _zz_1036;
-  wire       [31:0]   _zz_1037;
-  wire       [31:0]   _zz_1038;
-  wire       [31:0]   _zz_1039;
-  wire       [31:0]   _zz_1040;
-  wire                _zz_1041;
-  wire       [0:0]    _zz_1042;
-  wire       [0:0]    _zz_1043;
-  wire                _zz_1044;
-  wire       [0:0]    _zz_1045;
-  wire       [0:0]    _zz_1046;
-  wire                _zz_1047;
-  wire       [0:0]    _zz_1048;
-  wire       [16:0]   _zz_1049;
-  wire       [31:0]   _zz_1050;
-  wire       [31:0]   _zz_1051;
-  wire       [31:0]   _zz_1052;
-  wire       [31:0]   _zz_1053;
-  wire       [31:0]   _zz_1054;
-  wire       [0:0]    _zz_1055;
-  wire       [0:0]    _zz_1056;
-  wire       [0:0]    _zz_1057;
-  wire       [0:0]    _zz_1058;
-  wire                _zz_1059;
-  wire       [0:0]    _zz_1060;
-  wire       [13:0]   _zz_1061;
-  wire       [31:0]   _zz_1062;
-  wire       [31:0]   _zz_1063;
-  wire       [31:0]   _zz_1064;
-  wire                _zz_1065;
-  wire                _zz_1066;
-  wire       [0:0]    _zz_1067;
-  wire       [3:0]    _zz_1068;
-  wire       [0:0]    _zz_1069;
-  wire       [0:0]    _zz_1070;
-  wire                _zz_1071;
-  wire       [0:0]    _zz_1072;
-  wire       [10:0]   _zz_1073;
-  wire       [31:0]   _zz_1074;
-  wire       [31:0]   _zz_1075;
-  wire       [31:0]   _zz_1076;
-  wire                _zz_1077;
-  wire       [0:0]    _zz_1078;
-  wire       [0:0]    _zz_1079;
-  wire       [31:0]   _zz_1080;
-  wire                _zz_1081;
-  wire       [0:0]    _zz_1082;
-  wire       [2:0]    _zz_1083;
-  wire       [0:0]    _zz_1084;
-  wire       [3:0]    _zz_1085;
-  wire       [5:0]    _zz_1086;
-  wire       [5:0]    _zz_1087;
-  wire                _zz_1088;
-  wire       [0:0]    _zz_1089;
-  wire       [7:0]    _zz_1090;
-  wire       [31:0]   _zz_1091;
-  wire       [31:0]   _zz_1092;
-  wire       [31:0]   _zz_1093;
-  wire       [31:0]   _zz_1094;
-  wire       [31:0]   _zz_1095;
-  wire       [31:0]   _zz_1096;
-  wire                _zz_1097;
-  wire       [0:0]    _zz_1098;
-  wire       [0:0]    _zz_1099;
-  wire                _zz_1100;
-  wire       [0:0]    _zz_1101;
-  wire       [1:0]    _zz_1102;
-  wire       [0:0]    _zz_1103;
-  wire       [3:0]    _zz_1104;
-  wire       [0:0]    _zz_1105;
-  wire       [0:0]    _zz_1106;
-  wire       [1:0]    _zz_1107;
-  wire       [1:0]    _zz_1108;
-  wire                _zz_1109;
-  wire       [0:0]    _zz_1110;
-  wire       [5:0]    _zz_1111;
-  wire       [31:0]   _zz_1112;
-  wire       [31:0]   _zz_1113;
-  wire       [31:0]   _zz_1114;
-  wire       [31:0]   _zz_1115;
-  wire       [31:0]   _zz_1116;
-  wire       [31:0]   _zz_1117;
-  wire       [31:0]   _zz_1118;
-  wire       [31:0]   _zz_1119;
-  wire                _zz_1120;
-  wire                _zz_1121;
-  wire       [31:0]   _zz_1122;
-  wire       [31:0]   _zz_1123;
-  wire                _zz_1124;
-  wire       [0:0]    _zz_1125;
-  wire       [1:0]    _zz_1126;
-  wire       [31:0]   _zz_1127;
-  wire       [31:0]   _zz_1128;
-  wire                _zz_1129;
-  wire                _zz_1130;
-  wire       [0:0]    _zz_1131;
-  wire       [0:0]    _zz_1132;
-  wire                _zz_1133;
-  wire       [0:0]    _zz_1134;
-  wire       [3:0]    _zz_1135;
-  wire       [31:0]   _zz_1136;
-  wire       [31:0]   _zz_1137;
-  wire       [31:0]   _zz_1138;
-  wire       [31:0]   _zz_1139;
-  wire       [31:0]   _zz_1140;
-  wire                _zz_1141;
-  wire                _zz_1142;
-  wire       [31:0]   _zz_1143;
-  wire       [31:0]   _zz_1144;
-  wire       [31:0]   _zz_1145;
-  wire       [31:0]   _zz_1146;
-  wire       [0:0]    _zz_1147;
-  wire       [2:0]    _zz_1148;
-  wire       [0:0]    _zz_1149;
-  wire       [0:0]    _zz_1150;
-  wire                _zz_1151;
-  wire       [0:0]    _zz_1152;
-  wire       [1:0]    _zz_1153;
-  wire       [31:0]   _zz_1154;
-  wire       [31:0]   _zz_1155;
-  wire       [31:0]   _zz_1156;
-  wire                _zz_1157;
-  wire                _zz_1158;
-  wire       [31:0]   _zz_1159;
-  wire                _zz_1160;
-  wire       [0:0]    _zz_1161;
-  wire       [0:0]    _zz_1162;
-  wire       [0:0]    _zz_1163;
-  wire       [0:0]    _zz_1164;
-  wire       [1:0]    _zz_1165;
-  wire       [1:0]    _zz_1166;
-  wire       [0:0]    _zz_1167;
-  wire       [0:0]    _zz_1168;
-  wire       [31:0]   _zz_1169;
-  wire       [31:0]   _zz_1170;
-  wire       [31:0]   _zz_1171;
-  wire       [31:0]   _zz_1172;
-  wire       [31:0]   _zz_1173;
-  wire       [31:0]   _zz_1174;
-  wire                _zz_1175;
-  wire                _zz_1176;
-  wire                _zz_1177;
-  wire       [31:0]   _zz_1178;
-  wire       [31:0]   _zz_1179;
-  wire       [31:0]   _zz_1180;
-  wire       [31:0]   _zz_1181;
-  wire       [31:0]   _zz_1182;
-  wire       [31:0]   _zz_1183;
-  wire       [31:0]   _zz_1184;
-  wire       [31:0]   _zz_1185;
-  wire       [31:0]   _zz_1186;
-  wire       [31:0]   _zz_1187;
-  wire       [31:0]   _zz_1188;
-  wire       [31:0]   _zz_1189;
-  wire       [31:0]   _zz_1190;
-  wire       [31:0]   _zz_1191;
-  wire       [31:0]   _zz_1192;
-  wire       [31:0]   _zz_1193;
-  wire       [31:0]   _zz_1194;
+  wire       [51:0]   _zz_memory_MUL_LOW;
+  wire       [51:0]   _zz_memory_MUL_LOW_1;
+  wire       [51:0]   _zz_memory_MUL_LOW_2;
+  wire       [51:0]   _zz_memory_MUL_LOW_3;
+  wire       [32:0]   _zz_memory_MUL_LOW_4;
+  wire       [51:0]   _zz_memory_MUL_LOW_5;
+  wire       [49:0]   _zz_memory_MUL_LOW_6;
+  wire       [51:0]   _zz_memory_MUL_LOW_7;
+  wire       [49:0]   _zz_memory_MUL_LOW_8;
+  wire       [31:0]   _zz_execute_SHIFT_RIGHT;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_1;
+  wire       [32:0]   _zz_execute_SHIFT_RIGHT_2;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_1;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_2;
+  wire                _zz_decode_LEGAL_INSTRUCTION_3;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_4;
+  wire       [13:0]   _zz_decode_LEGAL_INSTRUCTION_5;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_6;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_7;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_8;
+  wire                _zz_decode_LEGAL_INSTRUCTION_9;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_10;
+  wire       [7:0]    _zz_decode_LEGAL_INSTRUCTION_11;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_12;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_13;
+  wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_14;
+  wire                _zz_decode_LEGAL_INSTRUCTION_15;
+  wire       [0:0]    _zz_decode_LEGAL_INSTRUCTION_16;
+  wire       [1:0]    _zz_decode_LEGAL_INSTRUCTION_17;
+  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_3;
+  wire       [11:0]   _zz__zz_5;
+  wire       [31:0]   _zz__zz_7;
+  wire       [31:0]   _zz__zz_7_1;
+  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
+  wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
+  wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
+  reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+  wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
+  reg        [7:0]    _zz_when_PmpPlugin_l246;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_1;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_2;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_0_3;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_0_4;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_1_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_1_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_2_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_2_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_3_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_3_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_4_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_4_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_5_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_5_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_6_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_6_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_7_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_7_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_8_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_8_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_9_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_9_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_10_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_10_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_11_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_11_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_12_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_12_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_13_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_13_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_14_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_14_3;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_1;
+  reg        [24:0]   _zz_PmpPlugin_dGuard_hits_15_2;
+  wire       [3:0]    _zz_PmpPlugin_dGuard_hits_15_3;
+  wire       [0:0]    _zz_when_PmpPlugin_l277;
+  wire       [5:0]    _zz_when_PmpPlugin_l277_1;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2;
+  wire       [8:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6;
+  wire       [1:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2;
+  wire       [8:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4;
+  wire                _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5;
+  wire       [0:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6;
+  wire       [1:0]    _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_1;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_2;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_0_3;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_0_4;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_1_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_1_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_2_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_2_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_3_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_3_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_4_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_4_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_5_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_5_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_6_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_6_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_7_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_7_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_8_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_8_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_9_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_9_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_10_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_10_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_11_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_11_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_12_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_12_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_13_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_13_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_14_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_14_3;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_1;
+  reg        [24:0]   _zz_PmpPlugin_iGuard_hits_15_2;
+  wire       [3:0]    _zz_PmpPlugin_iGuard_hits_15_3;
+  wire       [0:0]    _zz_when_PmpPlugin_l299;
+  wire       [5:0]    _zz_when_PmpPlugin_l299_1;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1;
+  wire       [0:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2;
+  wire       [8:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4;
+  wire                _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5;
+  wire       [0:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6;
+  wire       [1:0]    _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_1;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_3;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire       [26:0]   _zz__zz_decode_IS_RS2_SIGNED_8;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_17;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_39;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_45;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [16:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_62;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_65;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [13:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_69;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_70;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_77;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_79;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_81;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_82;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_86;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_87;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_89;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_90;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_91;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_93;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_107;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_113;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_130;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_141;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_144;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_146;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_148;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_149;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_152;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_153;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_154;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_157;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_158;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_159;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_162;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire                _zz_RegFilePlugin_regFile_port;
+  wire                _zz_decode_RegFilePlugin_rs1Data;
+  wire                _zz_RegFilePlugin_regFile_port_1;
+  wire                _zz_decode_RegFilePlugin_rs2Data;
+  wire       [0:0]    _zz__zz_execute_REGFILE_WRITE_DATA;
+  wire       [2:0]    _zz__zz_execute_SRC1;
+  wire       [4:0]    _zz__zz_execute_SRC1_1;
+  wire       [11:0]   _zz__zz_execute_SRC2_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_1;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_2;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_3;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_4;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_5;
+  wire       [31:0]   _zz_execute_SrcPlugin_addSub_6;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_4;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1;
+  wire       [31:0]   _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2;
+  wire       [19:0]   _zz__zz_execute_BranchPlugin_branch_src2_2;
+  wire       [11:0]   _zz__zz_execute_BranchPlugin_branch_src2_4;
+  wire                _zz_execute_BranchPlugin_branch_src2_6;
+  wire                _zz_execute_BranchPlugin_branch_src2_7;
+  wire                _zz_execute_BranchPlugin_branch_src2_8;
+  wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_9;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
+  wire                _zz_when;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result;
+  wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
+  wire       [31:0]   _zz__zz_decode_RS2_2;
+  wire       [31:0]   _zz__zz_decode_RS2_2_1;
+  wire       [5:0]    _zz_memory_DivPlugin_div_counter_valueNext;
+  wire       [0:0]    _zz_memory_DivPlugin_div_counter_valueNext_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_outRemainder_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_stage_0_outNumerator;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_1;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_2;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_3;
+  wire       [32:0]   _zz_memory_DivPlugin_div_result_4;
+  wire       [0:0]    _zz_memory_DivPlugin_div_result_5;
+  wire       [32:0]   _zz_memory_DivPlugin_rs1_2;
+  wire       [0:0]    _zz_memory_DivPlugin_rs1_3;
+  wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
+  wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
+  wire       [31:0]   _zz_PmpPlugin_pmpaddr_port;
+  reg        [7:0]    _zz_when_PmpPlugin_l209;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_1;
+  reg        [7:0]    _zz_when_PmpPlugin_l209_1_1;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_1_2;
+  reg        [7:0]    _zz_when_PmpPlugin_l209_2;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_2_1;
+  reg        [7:0]    _zz_when_PmpPlugin_l209_3;
+  wire       [3:0]    _zz_when_PmpPlugin_l209_3_1;
+  reg        [7:0]    _zz_when_PmpPlugin_l216;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_25;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_1;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_2;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_3;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_4;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_5;
+  reg        [7:0]    _zz_CsrPlugin_csrMapping_readDataSignal_6;
+  wire       [3:0]    _zz_CsrPlugin_csrMapping_readDataSignal_7;
+  wire       [26:0]   _zz_iBusWishbone_ADR_1;
+  reg                 _zz_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -694,8 +610,8 @@ module VexRiscv (
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_MEMORY_STORE_DATA_RF;
+  wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
@@ -707,27 +623,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_to_memory_ENV_CTRL_1;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_to_memory_SHIFT_CTRL_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_to_execute_SHIFT_CTRL_1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -736,17 +652,17 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC2_CTRL_1;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_to_execute_ALU_CTRL_1;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -769,11 +685,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_memory_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_execute_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -781,10 +697,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_decode_RS2;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -794,45 +710,45 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_decode_RS2_1;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_memory_SHIFT_CTRL;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_execute_SRC2;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_execute_SRC2_CTRL;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
+  wire                _zz_lastStageRegFileWrite_valid;
+  reg                 _zz_2;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
-  wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_1;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_1;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_1;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_1;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_1;
+  reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
+  wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
@@ -851,10 +767,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -926,8 +842,8 @@ module VexRiscv (
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
   wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
-  reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
-  reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
+  wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
@@ -941,7 +857,7 @@ module VexRiscv (
   wire       [31:0]   dBus_cmd_payload_address;
   wire       [31:0]   dBus_cmd_payload_data;
   wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
+  wire       [2:0]    dBus_cmd_payload_size;
   wire                dBus_cmd_payload_last;
   wire                dBus_rsp_valid;
   wire                dBus_rsp_payload_last;
@@ -956,7 +872,7 @@ module VexRiscv (
   wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
-  reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
+  wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
   wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
@@ -967,7 +883,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_54;
+  reg                 _zz_when_DBusCachedPlugin_l386;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -976,6 +892,11 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  reg        [31:0]   CsrPlugin_csrMapping_readDataSignal;
+  wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
+  reg                 CsrPlugin_csrMapping_allowCsrSignal;
+  wire                CsrPlugin_csrMapping_hazardFree;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
   reg                 CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
@@ -993,31 +914,37 @@ module VexRiscv (
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
   reg                 CsrPlugin_allowInterrupts;
   reg                 CsrPlugin_allowException;
+  reg                 CsrPlugin_allowEbreakException;
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
   reg                 IBusCachedPlugin_fetchPc_correction;
   reg                 IBusCachedPlugin_fetchPc_correctionReg;
+  wire                when_Fetcher_l127;
   wire                IBusCachedPlugin_fetchPc_corrected;
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l131_2;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
+  wire                when_Fetcher_l158;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -1040,16 +967,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63;
-  wire                _zz_64;
-  reg                 _zz_65;
-  wire                _zz_66;
-  reg                 _zz_67;
-  reg        [31:0]   _zz_68;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  wire                IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready;
+  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  reg        [31:0]   _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1057,22 +986,29 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
+  wire                when_Fetcher_l240;
+  wire                when_Fetcher_l320;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                when_Fetcher_l329;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  wire                when_Fetcher_l329_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  wire                when_Fetcher_l329_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  wire                when_Fetcher_l329_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69;
-  reg        [18:0]   _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
-  reg                 _zz_75;
-  wire                _zz_76;
-  reg        [10:0]   _zz_77;
-  wire                _zz_78;
-  reg        [18:0]   _zz_79;
+  wire                when_Fetcher_l329_4;
+  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_3;
+  reg        [10:0]   _zz_4;
+  wire                _zz_5;
+  reg        [18:0]   _zz_6;
+  reg                 _zz_7;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1080,7 +1016,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80;
+  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1088,6 +1024,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
+  wire                when_IBusCachedPlugin_l239;
+  wire                when_IBusCachedPlugin_l244;
+  wire                when_IBusCachedPlugin_l250;
+  wire                when_IBusCachedPlugin_l256;
+  wire                when_IBusCachedPlugin_l267;
   wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -1095,7 +1036,7 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
@@ -1103,8 +1044,9 @@ module VexRiscv (
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
   reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                when_Stream_l365;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -1112,492 +1054,157 @@ module VexRiscv (
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
+  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
+  wire                when_DBusCachedPlugin_l303;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82;
+  reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
+  wire                when_DBusCachedPlugin_l343;
+  wire                when_DBusCachedPlugin_l359;
+  wire                when_DBusCachedPlugin_l386;
+  wire                when_DBusCachedPlugin_l438;
+  wire                when_DBusCachedPlugin_l458;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
+  wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83;
-  reg        [31:0]   _zz_84;
-  wire                _zz_85;
-  reg        [31:0]   _zz_86;
+  wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
+  wire       [1:0]    switch_Misc_l199;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
+  wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+  reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  reg                 _zz_87;
-  reg                 _zz_88;
-  reg                 _zz_89;
-  reg                 _zz_90;
-  reg        [1:0]    _zz_91;
-  reg        [31:0]   _zz_92;
-  reg                 _zz_93;
-  reg                 _zz_94;
-  reg                 _zz_95;
-  reg                 _zz_96;
-  reg        [1:0]    _zz_97;
-  reg        [31:0]   _zz_98;
-  reg                 _zz_99;
-  wire                _zz_100;
-  reg        [31:0]   _zz_101;
-  reg        [31:0]   _zz_102;
-  wire       [31:0]   _zz_103;
-  wire       [31:0]   _zz_104;
-  wire       [31:0]   _zz_105;
-  reg                 _zz_106;
-  reg                 _zz_107;
-  reg                 _zz_108;
-  reg                 _zz_109;
-  reg        [1:0]    _zz_110;
-  reg        [31:0]   _zz_111;
-  reg                 _zz_112;
-  reg                 _zz_113;
-  reg                 _zz_114;
-  reg                 _zz_115;
-  reg        [1:0]    _zz_116;
-  reg        [31:0]   _zz_117;
-  reg                 _zz_118;
-  wire                _zz_119;
-  reg        [31:0]   _zz_120;
-  reg        [31:0]   _zz_121;
-  wire       [31:0]   _zz_122;
-  wire       [31:0]   _zz_123;
-  wire       [31:0]   _zz_124;
-  reg                 _zz_125;
-  reg                 _zz_126;
-  reg                 _zz_127;
-  reg                 _zz_128;
-  reg        [1:0]    _zz_129;
-  reg        [31:0]   _zz_130;
-  reg                 _zz_131;
-  reg                 _zz_132;
-  reg                 _zz_133;
-  reg                 _zz_134;
-  reg        [1:0]    _zz_135;
-  reg        [31:0]   _zz_136;
-  reg                 _zz_137;
-  wire                _zz_138;
-  reg        [31:0]   _zz_139;
-  reg        [31:0]   _zz_140;
-  wire       [31:0]   _zz_141;
-  wire       [31:0]   _zz_142;
-  wire       [31:0]   _zz_143;
-  reg                 _zz_144;
-  reg                 _zz_145;
-  reg                 _zz_146;
-  reg                 _zz_147;
-  reg        [1:0]    _zz_148;
-  reg        [31:0]   _zz_149;
-  reg                 _zz_150;
-  reg                 _zz_151;
-  reg                 _zz_152;
-  reg                 _zz_153;
-  reg        [1:0]    _zz_154;
-  reg        [31:0]   _zz_155;
-  reg                 _zz_156;
-  wire                _zz_157;
-  reg        [31:0]   _zz_158;
-  reg        [31:0]   _zz_159;
-  wire       [31:0]   _zz_160;
-  wire       [31:0]   _zz_161;
-  wire       [31:0]   _zz_162;
-  reg                 _zz_163;
-  reg                 _zz_164;
-  reg                 _zz_165;
-  reg                 _zz_166;
-  reg        [1:0]    _zz_167;
-  reg        [31:0]   _zz_168;
-  reg                 _zz_169;
-  reg                 _zz_170;
-  reg                 _zz_171;
-  reg                 _zz_172;
-  reg        [1:0]    _zz_173;
-  reg        [31:0]   _zz_174;
-  reg                 _zz_175;
-  wire                _zz_176;
-  reg        [31:0]   _zz_177;
-  reg        [31:0]   _zz_178;
-  wire       [31:0]   _zz_179;
-  wire       [31:0]   _zz_180;
-  wire       [31:0]   _zz_181;
-  reg                 _zz_182;
-  reg                 _zz_183;
-  reg                 _zz_184;
-  reg                 _zz_185;
-  reg        [1:0]    _zz_186;
-  reg        [31:0]   _zz_187;
-  reg                 _zz_188;
-  reg                 _zz_189;
-  reg                 _zz_190;
-  reg                 _zz_191;
-  reg        [1:0]    _zz_192;
-  reg        [31:0]   _zz_193;
-  reg                 _zz_194;
-  wire                _zz_195;
-  reg        [31:0]   _zz_196;
-  reg        [31:0]   _zz_197;
-  wire       [31:0]   _zz_198;
-  wire       [31:0]   _zz_199;
-  wire       [31:0]   _zz_200;
-  reg                 _zz_201;
-  reg                 _zz_202;
-  reg                 _zz_203;
-  reg                 _zz_204;
-  reg        [1:0]    _zz_205;
-  reg        [31:0]   _zz_206;
-  reg                 _zz_207;
-  reg                 _zz_208;
-  reg                 _zz_209;
-  reg                 _zz_210;
-  reg        [1:0]    _zz_211;
-  reg        [31:0]   _zz_212;
-  reg                 _zz_213;
-  wire                _zz_214;
-  reg        [31:0]   _zz_215;
-  reg        [31:0]   _zz_216;
-  wire       [31:0]   _zz_217;
-  wire       [31:0]   _zz_218;
-  wire       [31:0]   _zz_219;
-  reg                 _zz_220;
-  reg                 _zz_221;
-  reg                 _zz_222;
-  reg                 _zz_223;
-  reg        [1:0]    _zz_224;
-  reg        [31:0]   _zz_225;
-  reg                 _zz_226;
-  reg                 _zz_227;
-  reg                 _zz_228;
-  reg                 _zz_229;
-  reg        [1:0]    _zz_230;
-  reg        [31:0]   _zz_231;
-  reg                 _zz_232;
-  wire                _zz_233;
-  reg        [31:0]   _zz_234;
-  reg        [31:0]   _zz_235;
-  wire       [31:0]   _zz_236;
-  wire       [31:0]   _zz_237;
-  wire       [31:0]   _zz_238;
-  reg                 _zz_239;
-  reg                 _zz_240;
-  reg                 _zz_241;
-  reg                 _zz_242;
-  reg        [1:0]    _zz_243;
-  reg        [31:0]   _zz_244;
-  reg                 _zz_245;
-  reg                 _zz_246;
-  reg                 _zz_247;
-  reg                 _zz_248;
-  reg        [1:0]    _zz_249;
-  reg        [31:0]   _zz_250;
-  reg                 _zz_251;
-  wire                _zz_252;
-  reg        [31:0]   _zz_253;
-  reg        [31:0]   _zz_254;
-  wire       [31:0]   _zz_255;
-  wire       [31:0]   _zz_256;
-  wire       [31:0]   _zz_257;
-  reg                 _zz_258;
-  reg                 _zz_259;
-  reg                 _zz_260;
-  reg                 _zz_261;
-  reg        [1:0]    _zz_262;
-  reg        [31:0]   _zz_263;
-  reg                 _zz_264;
-  reg                 _zz_265;
-  reg                 _zz_266;
-  reg                 _zz_267;
-  reg        [1:0]    _zz_268;
-  reg        [31:0]   _zz_269;
-  reg                 _zz_270;
-  wire                _zz_271;
-  reg        [31:0]   _zz_272;
-  reg        [31:0]   _zz_273;
-  wire       [31:0]   _zz_274;
-  wire       [31:0]   _zz_275;
-  wire       [31:0]   _zz_276;
-  reg                 _zz_277;
-  reg                 _zz_278;
-  reg                 _zz_279;
-  reg                 _zz_280;
-  reg        [1:0]    _zz_281;
-  reg        [31:0]   _zz_282;
-  reg                 _zz_283;
-  reg                 _zz_284;
-  reg                 _zz_285;
-  reg                 _zz_286;
-  reg        [1:0]    _zz_287;
-  reg        [31:0]   _zz_288;
-  reg                 _zz_289;
-  wire                _zz_290;
-  reg        [31:0]   _zz_291;
-  reg        [31:0]   _zz_292;
-  wire       [31:0]   _zz_293;
-  wire       [31:0]   _zz_294;
-  wire       [31:0]   _zz_295;
-  reg                 _zz_296;
-  reg                 _zz_297;
-  reg                 _zz_298;
-  reg                 _zz_299;
-  reg        [1:0]    _zz_300;
-  reg        [31:0]   _zz_301;
-  reg                 _zz_302;
-  reg                 _zz_303;
-  reg                 _zz_304;
-  reg                 _zz_305;
-  reg        [1:0]    _zz_306;
-  reg        [31:0]   _zz_307;
-  reg                 _zz_308;
-  wire                _zz_309;
-  reg        [31:0]   _zz_310;
-  reg        [31:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  wire       [31:0]   _zz_314;
-  reg                 _zz_315;
-  reg                 _zz_316;
-  reg                 _zz_317;
-  reg                 _zz_318;
-  reg        [1:0]    _zz_319;
-  reg        [31:0]   _zz_320;
-  reg                 _zz_321;
-  reg                 _zz_322;
-  reg                 _zz_323;
-  reg                 _zz_324;
-  reg        [1:0]    _zz_325;
-  reg        [31:0]   _zz_326;
-  reg                 _zz_327;
-  wire                _zz_328;
-  reg        [31:0]   _zz_329;
-  reg        [31:0]   _zz_330;
-  wire       [31:0]   _zz_331;
-  wire       [31:0]   _zz_332;
-  wire       [31:0]   _zz_333;
-  reg                 _zz_334;
-  reg                 _zz_335;
-  reg                 _zz_336;
-  reg                 _zz_337;
-  reg        [1:0]    _zz_338;
-  reg        [31:0]   _zz_339;
-  reg                 _zz_340;
-  reg                 _zz_341;
-  reg                 _zz_342;
-  reg                 _zz_343;
-  reg        [1:0]    _zz_344;
-  reg        [31:0]   _zz_345;
-  reg                 _zz_346;
-  wire                _zz_347;
-  reg        [31:0]   _zz_348;
-  reg        [31:0]   _zz_349;
-  wire       [31:0]   _zz_350;
-  wire       [31:0]   _zz_351;
-  wire       [31:0]   _zz_352;
-  reg                 _zz_353;
-  reg                 _zz_354;
-  reg                 _zz_355;
-  reg                 _zz_356;
-  reg        [1:0]    _zz_357;
-  reg        [31:0]   _zz_358;
-  reg                 _zz_359;
-  reg                 _zz_360;
-  reg                 _zz_361;
-  reg                 _zz_362;
-  reg        [1:0]    _zz_363;
-  reg        [31:0]   _zz_364;
-  reg                 _zz_365;
-  wire                _zz_366;
-  reg        [31:0]   _zz_367;
-  reg        [31:0]   _zz_368;
-  wire       [31:0]   _zz_369;
-  wire       [31:0]   _zz_370;
-  wire       [31:0]   _zz_371;
-  reg                 _zz_372;
-  reg                 _zz_373;
-  reg                 _zz_374;
-  reg                 _zz_375;
-  reg        [1:0]    _zz_376;
-  reg        [31:0]   _zz_377;
-  reg                 _zz_378;
-  reg                 _zz_379;
-  reg                 _zz_380;
-  reg                 _zz_381;
-  reg        [1:0]    _zz_382;
-  reg        [31:0]   _zz_383;
-  reg                 _zz_384;
-  wire                _zz_385;
-  reg        [31:0]   _zz_386;
-  reg        [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
-  wire       [31:0]   _zz_390;
-  wire                PmpPlugin_ports_0_hits_0;
-  wire                PmpPlugin_ports_0_hits_1;
-  wire                PmpPlugin_ports_0_hits_2;
-  wire                PmpPlugin_ports_0_hits_3;
-  wire                PmpPlugin_ports_0_hits_4;
-  wire                PmpPlugin_ports_0_hits_5;
-  wire                PmpPlugin_ports_0_hits_6;
-  wire                PmpPlugin_ports_0_hits_7;
-  wire                PmpPlugin_ports_0_hits_8;
-  wire                PmpPlugin_ports_0_hits_9;
-  wire                PmpPlugin_ports_0_hits_10;
-  wire                PmpPlugin_ports_0_hits_11;
-  wire                PmpPlugin_ports_0_hits_12;
-  wire                PmpPlugin_ports_0_hits_13;
-  wire                PmpPlugin_ports_0_hits_14;
-  wire                PmpPlugin_ports_0_hits_15;
-  wire       [4:0]    _zz_391;
-  wire       [4:0]    _zz_392;
-  wire       [4:0]    _zz_393;
-  wire       [4:0]    _zz_394;
-  wire       [4:0]    _zz_395;
-  wire       [4:0]    _zz_396;
-  wire       [4:0]    _zz_397;
-  wire       [4:0]    _zz_398;
-  wire       [15:0]   _zz_399;
-  wire       [15:0]   _zz_400;
-  wire                _zz_401;
-  wire                _zz_402;
-  wire                _zz_403;
-  wire                _zz_404;
-  wire                _zz_405;
-  wire                _zz_406;
-  wire                _zz_407;
-  wire                _zz_408;
-  wire                _zz_409;
-  wire                _zz_410;
-  wire                _zz_411;
-  wire                _zz_412;
-  wire                _zz_413;
-  wire                _zz_414;
-  wire                _zz_415;
-  wire       [15:0]   _zz_416;
-  wire       [15:0]   _zz_417;
-  wire                _zz_418;
-  wire                _zz_419;
-  wire                _zz_420;
-  wire                _zz_421;
-  wire                _zz_422;
-  wire                _zz_423;
-  wire                _zz_424;
-  wire                _zz_425;
-  wire                _zz_426;
-  wire                _zz_427;
-  wire                _zz_428;
-  wire                _zz_429;
-  wire                _zz_430;
-  wire                _zz_431;
-  wire                _zz_432;
-  wire       [15:0]   _zz_433;
-  wire       [15:0]   _zz_434;
-  wire                _zz_435;
-  wire                _zz_436;
-  wire                _zz_437;
-  wire                _zz_438;
-  wire                _zz_439;
-  wire                _zz_440;
-  wire                _zz_441;
-  wire                _zz_442;
-  wire                _zz_443;
-  wire                _zz_444;
-  wire                _zz_445;
-  wire                _zz_446;
-  wire                _zz_447;
-  wire                _zz_448;
-  wire                _zz_449;
-  wire                PmpPlugin_ports_1_hits_0;
-  wire                PmpPlugin_ports_1_hits_1;
-  wire                PmpPlugin_ports_1_hits_2;
-  wire                PmpPlugin_ports_1_hits_3;
-  wire                PmpPlugin_ports_1_hits_4;
-  wire                PmpPlugin_ports_1_hits_5;
-  wire                PmpPlugin_ports_1_hits_6;
-  wire                PmpPlugin_ports_1_hits_7;
-  wire                PmpPlugin_ports_1_hits_8;
-  wire                PmpPlugin_ports_1_hits_9;
-  wire                PmpPlugin_ports_1_hits_10;
-  wire                PmpPlugin_ports_1_hits_11;
-  wire                PmpPlugin_ports_1_hits_12;
-  wire                PmpPlugin_ports_1_hits_13;
-  wire                PmpPlugin_ports_1_hits_14;
-  wire                PmpPlugin_ports_1_hits_15;
-  wire       [4:0]    _zz_450;
-  wire       [4:0]    _zz_451;
-  wire       [4:0]    _zz_452;
-  wire       [4:0]    _zz_453;
-  wire       [4:0]    _zz_454;
-  wire       [4:0]    _zz_455;
-  wire       [4:0]    _zz_456;
-  wire       [4:0]    _zz_457;
-  wire       [15:0]   _zz_458;
-  wire       [15:0]   _zz_459;
-  wire                _zz_460;
-  wire                _zz_461;
-  wire                _zz_462;
-  wire                _zz_463;
-  wire                _zz_464;
-  wire                _zz_465;
-  wire                _zz_466;
-  wire                _zz_467;
-  wire                _zz_468;
-  wire                _zz_469;
-  wire                _zz_470;
-  wire                _zz_471;
-  wire                _zz_472;
-  wire                _zz_473;
-  wire                _zz_474;
-  wire       [15:0]   _zz_475;
-  wire       [15:0]   _zz_476;
-  wire                _zz_477;
-  wire                _zz_478;
-  wire                _zz_479;
-  wire                _zz_480;
-  wire                _zz_481;
-  wire                _zz_482;
-  wire                _zz_483;
-  wire                _zz_484;
-  wire                _zz_485;
-  wire                _zz_486;
-  wire                _zz_487;
-  wire                _zz_488;
-  wire                _zz_489;
-  wire                _zz_490;
-  wire                _zz_491;
-  wire       [15:0]   _zz_492;
-  wire       [15:0]   _zz_493;
-  wire                _zz_494;
-  wire                _zz_495;
-  wire                _zz_496;
-  wire                _zz_497;
-  wire                _zz_498;
-  wire                _zz_499;
-  wire                _zz_500;
-  wire                _zz_501;
-  wire                _zz_502;
-  wire                _zz_503;
-  wire                _zz_504;
-  wire                _zz_505;
-  wire                _zz_506;
-  wire                _zz_507;
-  wire                _zz_508;
-  wire       [32:0]   _zz_509;
-  wire                _zz_510;
-  wire                _zz_511;
-  wire                _zz_512;
-  wire                _zz_513;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_514;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_515;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_516;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_517;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_518;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_519;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_520;
+  wire                when_DBusCachedPlugin_l484;
+  reg        [7:0]    PmpPlugin_pmpcfg_0;
+  reg        [7:0]    PmpPlugin_pmpcfg_1;
+  reg        [7:0]    PmpPlugin_pmpcfg_2;
+  reg        [7:0]    PmpPlugin_pmpcfg_3;
+  reg        [7:0]    PmpPlugin_pmpcfg_4;
+  reg        [7:0]    PmpPlugin_pmpcfg_5;
+  reg        [7:0]    PmpPlugin_pmpcfg_6;
+  reg        [7:0]    PmpPlugin_pmpcfg_7;
+  reg        [7:0]    PmpPlugin_pmpcfg_8;
+  reg        [7:0]    PmpPlugin_pmpcfg_9;
+  reg        [7:0]    PmpPlugin_pmpcfg_10;
+  reg        [7:0]    PmpPlugin_pmpcfg_11;
+  reg        [7:0]    PmpPlugin_pmpcfg_12;
+  reg        [7:0]    PmpPlugin_pmpcfg_13;
+  reg        [7:0]    PmpPlugin_pmpcfg_14;
+  reg        [7:0]    PmpPlugin_pmpcfg_15;
+  reg        [24:0]   PmpPlugin_base_0;
+  reg        [24:0]   PmpPlugin_base_1;
+  reg        [24:0]   PmpPlugin_base_2;
+  reg        [24:0]   PmpPlugin_base_3;
+  reg        [24:0]   PmpPlugin_base_4;
+  reg        [24:0]   PmpPlugin_base_5;
+  reg        [24:0]   PmpPlugin_base_6;
+  reg        [24:0]   PmpPlugin_base_7;
+  reg        [24:0]   PmpPlugin_base_8;
+  reg        [24:0]   PmpPlugin_base_9;
+  reg        [24:0]   PmpPlugin_base_10;
+  reg        [24:0]   PmpPlugin_base_11;
+  reg        [24:0]   PmpPlugin_base_12;
+  reg        [24:0]   PmpPlugin_base_13;
+  reg        [24:0]   PmpPlugin_base_14;
+  reg        [24:0]   PmpPlugin_base_15;
+  reg        [24:0]   PmpPlugin_mask_0;
+  reg        [24:0]   PmpPlugin_mask_1;
+  reg        [24:0]   PmpPlugin_mask_2;
+  reg        [24:0]   PmpPlugin_mask_3;
+  reg        [24:0]   PmpPlugin_mask_4;
+  reg        [24:0]   PmpPlugin_mask_5;
+  reg        [24:0]   PmpPlugin_mask_6;
+  reg        [24:0]   PmpPlugin_mask_7;
+  reg        [24:0]   PmpPlugin_mask_8;
+  reg        [24:0]   PmpPlugin_mask_9;
+  reg        [24:0]   PmpPlugin_mask_10;
+  reg        [24:0]   PmpPlugin_mask_11;
+  reg        [24:0]   PmpPlugin_mask_12;
+  reg        [24:0]   PmpPlugin_mask_13;
+  reg        [24:0]   PmpPlugin_mask_14;
+  reg        [24:0]   PmpPlugin_mask_15;
+  reg                 execute_PmpPlugin_fsmPending;
+  wire                when_PmpPlugin_l138;
+  reg                 execute_PmpPlugin_fsmComplete;
+  wire       [11:0]   execute_PmpPlugin_csrAddress;
+  wire       [3:0]    execute_PmpPlugin_pmpNcfg;
+  wire       [1:0]    execute_PmpPlugin_pmpcfgN;
+  wire                execute_PmpPlugin_pmpcfgCsr;
+  wire                execute_PmpPlugin_pmpaddrCsr;
+  reg        [3:0]    execute_PmpPlugin_pmpNcfg_;
+  reg        [1:0]    execute_PmpPlugin_pmpcfgN_;
+  reg                 execute_PmpPlugin_pmpcfgCsr_;
+  reg                 execute_PmpPlugin_pmpaddrCsr_;
+  reg        [31:0]   execute_PmpPlugin_writeData_;
+  wire                execute_PmpPlugin_fsm_wantExit;
+  reg                 execute_PmpPlugin_fsm_wantStart;
+  wire                execute_PmpPlugin_fsm_wantKill;
+  reg                 execute_PmpPlugin_fsm_fsmEnable;
+  reg        [3:0]    execute_PmpPlugin_fsm_fsmCounter;
+  wire                when_PmpPlugin_l246;
+  wire       [15:0]   _zz_8;
+  wire       [15:0]   _zz_9;
+  wire       [24:0]   _zz_PmpPlugin_dGuard_hits_0;
+  wire                PmpPlugin_dGuard_hits_0;
+  wire                PmpPlugin_dGuard_hits_1;
+  wire                PmpPlugin_dGuard_hits_2;
+  wire                PmpPlugin_dGuard_hits_3;
+  wire                PmpPlugin_dGuard_hits_4;
+  wire                PmpPlugin_dGuard_hits_5;
+  wire                PmpPlugin_dGuard_hits_6;
+  wire                PmpPlugin_dGuard_hits_7;
+  wire                PmpPlugin_dGuard_hits_8;
+  wire                PmpPlugin_dGuard_hits_9;
+  wire                PmpPlugin_dGuard_hits_10;
+  wire                PmpPlugin_dGuard_hits_11;
+  wire                PmpPlugin_dGuard_hits_12;
+  wire                PmpPlugin_dGuard_hits_13;
+  wire                PmpPlugin_dGuard_hits_14;
+  wire                PmpPlugin_dGuard_hits_15;
+  wire                when_PmpPlugin_l277;
+  wire       [24:0]   _zz_PmpPlugin_iGuard_hits_0;
+  wire                PmpPlugin_iGuard_hits_0;
+  wire                PmpPlugin_iGuard_hits_1;
+  wire                PmpPlugin_iGuard_hits_2;
+  wire                PmpPlugin_iGuard_hits_3;
+  wire                PmpPlugin_iGuard_hits_4;
+  wire                PmpPlugin_iGuard_hits_5;
+  wire                PmpPlugin_iGuard_hits_6;
+  wire                PmpPlugin_iGuard_hits_7;
+  wire                PmpPlugin_iGuard_hits_8;
+  wire                PmpPlugin_iGuard_hits_9;
+  wire                PmpPlugin_iGuard_hits_10;
+  wire                PmpPlugin_iGuard_hits_11;
+  wire                PmpPlugin_iGuard_hits_12;
+  wire                PmpPlugin_iGuard_hits_13;
+  wire                PmpPlugin_iGuard_hits_14;
+  wire                PmpPlugin_iGuard_hits_15;
+  wire                when_PmpPlugin_l299;
+  wire       [32:0]   _zz_decode_IS_RS2_SIGNED;
+  wire                _zz_decode_IS_RS2_SIGNED_1;
+  wire                _zz_decode_IS_RS2_SIGNED_2;
+  wire                _zz_decode_IS_RS2_SIGNED_3;
+  wire                _zz_decode_IS_RS2_SIGNED_4;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_decode_SRC1_CTRL_2;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_decode_ALU_CTRL_2;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_decode_SRC2_CTRL_2;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_decode_SHIFT_CTRL_2;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_decode_BRANCH_CTRL_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_decode_ENV_CTRL_2;
+  wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -1605,54 +1212,72 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_521;
+  reg                 _zz_10;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_522;
-  reg        [31:0]   _zz_523;
-  wire                _zz_524;
-  reg        [19:0]   _zz_525;
-  wire                _zz_526;
-  reg        [19:0]   _zz_527;
-  reg        [31:0]   _zz_528;
+  reg        [31:0]   _zz_execute_REGFILE_WRITE_DATA;
+  reg        [31:0]   _zz_execute_SRC1;
+  wire                _zz_execute_SRC2_1;
+  reg        [19:0]   _zz_execute_SRC2_2;
+  wire                _zz_execute_SRC2_3;
+  reg        [19:0]   _zz_execute_SRC2_4;
+  reg        [31:0]   _zz_execute_SRC2_5;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_529;
+  reg        [31:0]   _zz_execute_FullBarrelShifterPlugin_reversed;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_530;
-  reg                 _zz_531;
-  reg                 _zz_532;
-  reg                 _zz_533;
-  reg        [4:0]    _zz_534;
-  reg        [31:0]   _zz_535;
-  wire                _zz_536;
-  wire                _zz_537;
-  wire                _zz_538;
-  wire                _zz_539;
-  wire                _zz_540;
-  wire                _zz_541;
+  reg        [31:0]   _zz_decode_RS2_3;
+  reg                 HazardSimplePlugin_src0Hazard;
+  reg                 HazardSimplePlugin_src1Hazard;
+  wire                HazardSimplePlugin_writeBackWrites_valid;
+  wire       [4:0]    HazardSimplePlugin_writeBackWrites_payload_address;
+  wire       [31:0]   HazardSimplePlugin_writeBackWrites_payload_data;
+  reg                 HazardSimplePlugin_writeBackBuffer_valid;
+  reg        [4:0]    HazardSimplePlugin_writeBackBuffer_payload_address;
+  reg        [31:0]   HazardSimplePlugin_writeBackBuffer_payload_data;
+  wire                HazardSimplePlugin_addr0Match;
+  wire                HazardSimplePlugin_addr1Match;
+  wire                when_HazardSimplePlugin_l47;
+  wire                when_HazardSimplePlugin_l48;
+  wire                when_HazardSimplePlugin_l51;
+  wire                when_HazardSimplePlugin_l45;
+  wire                when_HazardSimplePlugin_l57;
+  wire                when_HazardSimplePlugin_l58;
+  wire                when_HazardSimplePlugin_l48_1;
+  wire                when_HazardSimplePlugin_l51_1;
+  wire                when_HazardSimplePlugin_l45_1;
+  wire                when_HazardSimplePlugin_l57_1;
+  wire                when_HazardSimplePlugin_l58_1;
+  wire                when_HazardSimplePlugin_l48_2;
+  wire                when_HazardSimplePlugin_l51_2;
+  wire                when_HazardSimplePlugin_l45_2;
+  wire                when_HazardSimplePlugin_l57_2;
+  wire                when_HazardSimplePlugin_l58_2;
+  wire                when_HazardSimplePlugin_l105;
+  wire                when_HazardSimplePlugin_l108;
+  wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_542;
-  reg                 _zz_543;
-  reg                 _zz_544;
-  wire                _zz_545;
-  reg        [19:0]   _zz_546;
-  wire                _zz_547;
-  reg        [10:0]   _zz_548;
-  wire                _zz_549;
-  reg        [18:0]   _zz_550;
-  reg                 _zz_551;
+  wire       [2:0]    switch_Misc_l199_1;
+  reg                 _zz_execute_BRANCH_COND_RESULT;
+  reg                 _zz_execute_BRANCH_COND_RESULT_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget;
+  reg        [19:0]   _zz_execute_BranchPlugin_missAlignedTarget_1;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_missAlignedTarget_3;
+  wire                _zz_execute_BranchPlugin_missAlignedTarget_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_missAlignedTarget_5;
+  reg                 _zz_execute_BranchPlugin_missAlignedTarget_6;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_552;
-  reg        [19:0]   _zz_553;
-  wire                _zz_554;
-  reg        [10:0]   _zz_555;
-  wire                _zz_556;
-  reg        [18:0]   _zz_557;
+  wire                _zz_execute_BranchPlugin_branch_src2;
+  reg        [19:0]   _zz_execute_BranchPlugin_branch_src2_1;
+  wire                _zz_execute_BranchPlugin_branch_src2_2;
+  reg        [10:0]   _zz_execute_BranchPlugin_branch_src2_3;
+  wire                _zz_execute_BranchPlugin_branch_src2_4;
+  reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_558;
+  reg        [1:0]    _zz_CsrPlugin_privilege;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1673,9 +1298,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_559;
-  wire                _zz_560;
-  wire                _zz_561;
+  wire                _zz_when_CsrPlugin_l952;
+  wire                _zz_when_CsrPlugin_l952_1;
+  wire                _zz_when_CsrPlugin_l952_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1688,40 +1313,67 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_562;
-  wire                _zz_563;
+  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
+  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
+  wire                when_CsrPlugin_l909;
+  wire                when_CsrPlugin_l909_1;
+  wire                when_CsrPlugin_l909_2;
+  wire                when_CsrPlugin_l909_3;
+  wire                when_CsrPlugin_l922;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
+  wire                when_CsrPlugin_l946;
+  wire                when_CsrPlugin_l952;
+  wire                when_CsrPlugin_l952_1;
+  wire                when_CsrPlugin_l952_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
+  wire                when_CsrPlugin_l980;
+  wire                when_CsrPlugin_l980_1;
+  wire                when_CsrPlugin_l980_2;
+  wire                when_CsrPlugin_l985;
   reg                 CsrPlugin_pipelineLiberator_done;
+  wire                when_CsrPlugin_l991;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
+  wire                when_CsrPlugin_l1019;
+  wire                when_CsrPlugin_l1064;
+  wire       [1:0]    switch_CsrPlugin_l1068;
   reg                 execute_CsrPlugin_wfiWake;
+  wire                when_CsrPlugin_l1108;
+  wire                when_CsrPlugin_l1110;
+  wire                when_CsrPlugin_l1116;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire       [31:0]   execute_CsrPlugin_readData;
+  wire                when_CsrPlugin_l1129;
+  wire                when_CsrPlugin_l1136;
+  wire                when_CsrPlugin_l1137;
+  wire                when_CsrPlugin_l1144;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  reg        [31:0]   execute_CsrPlugin_writeData;
+  wire                switch_Misc_l199_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
+  wire                when_CsrPlugin_l1176;
+  wire                when_CsrPlugin_l1180;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
   wire       [31:0]   execute_MulPlugin_a;
   wire       [31:0]   execute_MulPlugin_b;
+  wire       [1:0]    switch_MulPlugin_l87;
   wire       [15:0]   execute_MulPlugin_aULow;
   wire       [15:0]   execute_MulPlugin_bULow;
   wire       [16:0]   execute_MulPlugin_aSLow;
@@ -1729,6 +1381,8 @@ module VexRiscv (
   wire       [16:0]   execute_MulPlugin_aHigh;
   wire       [16:0]   execute_MulPlugin_bHigh;
   wire       [65:0]   writeBack_MulPlugin_result;
+  wire                when_MulPlugin_l147;
+  wire       [1:0]    switch_MulPlugin_l148;
   reg        [32:0]   memory_DivPlugin_rs1;
   reg        [31:0]   memory_DivPlugin_rs2;
   reg        [64:0]   memory_DivPlugin_accumulator;
@@ -1741,19 +1395,26 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflowIfInc;
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
+  wire                when_MulDivIterativePlugin_l126;
+  wire                when_MulDivIterativePlugin_l126_1;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_564;
+  wire                when_MulDivIterativePlugin_l128;
+  wire                when_MulDivIterativePlugin_l129;
+  wire                when_MulDivIterativePlugin_l132;
+  wire       [31:0]   _zz_memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_565;
-  wire                _zz_566;
-  wire                _zz_567;
-  reg        [32:0]   _zz_568;
+  wire                when_MulDivIterativePlugin_l151;
+  wire       [31:0]   _zz_memory_DivPlugin_div_result;
+  wire                when_MulDivIterativePlugin_l162;
+  wire                _zz_memory_DivPlugin_rs2;
+  wire                _zz_memory_DivPlugin_rs1;
+  reg        [32:0]   _zz_memory_DivPlugin_rs1_1;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_569;
-  wire       [31:0]   _zz_570;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
+  wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1761,1618 +1422,4858 @@ module VexRiscv (
   reg                 DebugPlugin_stepIt;
   reg                 DebugPlugin_isPipBusy;
   reg                 DebugPlugin_godmode;
+  wire                when_DebugPlugin_l225;
   reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_571;
+  reg                 DebugPlugin_debugUsed /* verilator public */ ;
+  reg                 DebugPlugin_disableEbreak;
   wire                DebugPlugin_allowEBreak;
+  reg        [31:0]   DebugPlugin_busReadDataReg;
+  reg                 _zz_when_DebugPlugin_l244;
+  wire                when_DebugPlugin_l244;
+  wire       [5:0]    switch_DebugPlugin_l256;
+  wire                when_DebugPlugin_l260;
+  wire                when_DebugPlugin_l260_1;
+  wire                when_DebugPlugin_l261;
+  wire                when_DebugPlugin_l261_1;
+  wire                when_DebugPlugin_l262;
+  wire                when_DebugPlugin_l263;
+  wire                when_DebugPlugin_l264;
+  wire                when_DebugPlugin_l264_1;
+  wire                when_DebugPlugin_l284;
+  wire                when_DebugPlugin_l287;
+  wire                when_DebugPlugin_l300;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                when_DebugPlugin_l316;
+  wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
+  wire                when_Pipeline_l124_1;
   reg        [31:0]   execute_to_memory_PC;
+  wire                when_Pipeline_l124_2;
   reg        [31:0]   memory_to_writeBack_PC;
+  wire                when_Pipeline_l124_3;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
+  wire                when_Pipeline_l124_4;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
+  wire                when_Pipeline_l124_5;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  wire                when_Pipeline_l124_6;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_7;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  wire                when_Pipeline_l124_10;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  wire                when_Pipeline_l124_12;
   reg                 decode_to_execute_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_13;
   reg                 execute_to_memory_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
+  wire                when_Pipeline_l124_15;
   reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  wire                when_Pipeline_l124_16;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_18;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_19;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  wire                when_Pipeline_l124_20;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  wire                when_Pipeline_l124_21;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  wire                when_Pipeline_l124_23;
   reg                 decode_to_execute_MEMORY_WR;
+  wire                when_Pipeline_l124_24;
   reg                 execute_to_memory_MEMORY_WR;
+  wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
+  wire                when_Pipeline_l124_26;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
+  wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_28;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  wire                when_Pipeline_l124_29;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  wire                when_Pipeline_l124_30;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  wire                when_Pipeline_l124_31;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_33;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  wire                when_Pipeline_l124_34;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  wire                when_Pipeline_l124_35;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
+  wire                when_Pipeline_l124_37;
   reg                 execute_to_memory_IS_MUL;
+  wire                when_Pipeline_l124_38;
   reg                 memory_to_writeBack_IS_MUL;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_IS_DIV;
+  wire                when_Pipeline_l124_40;
   reg                 execute_to_memory_IS_DIV;
+  wire                when_Pipeline_l124_41;
   reg                 decode_to_execute_IS_RS1_SIGNED;
+  wire                when_Pipeline_l124_42;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   decode_to_execute_RS1;
+  wire                when_Pipeline_l124_44;
   reg        [31:0]   decode_to_execute_RS2;
+  wire                when_Pipeline_l124_45;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  wire                when_Pipeline_l124_46;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  wire                when_Pipeline_l124_47;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  wire                when_Pipeline_l124_48;
   reg                 decode_to_execute_CSR_READ_OPCODE;
+  wire                when_Pipeline_l124_49;
   reg                 decode_to_execute_DO_EBREAK;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  wire                when_Pipeline_l124_50;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_51;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  wire                when_Pipeline_l124_52;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_53;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  wire                when_Pipeline_l124_54;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  wire                when_Pipeline_l124_55;
   reg                 execute_to_memory_BRANCH_DO;
+  wire                when_Pipeline_l124_56;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  wire                when_Pipeline_l124_57;
   reg        [31:0]   execute_to_memory_MUL_LL;
+  wire                when_Pipeline_l124_58;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  wire                when_Pipeline_l124_59;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  wire                when_Pipeline_l124_60;
   reg        [33:0]   execute_to_memory_MUL_HH;
+  wire                when_Pipeline_l124_61;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_62;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_572;
+  wire                when_Pipeline_l151;
+  wire                when_Pipeline_l154;
+  wire                when_Pipeline_l151_1;
+  wire                when_Pipeline_l154_1;
+  wire                when_Pipeline_l151_2;
+  wire                when_Pipeline_l154_2;
+  reg        [2:0]    switch_Fetcher_l362;
+  wire                when_Fetcher_l378;
+  reg        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_type execute_PmpPlugin_fsm_stateReg;
+  reg        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_type execute_PmpPlugin_fsm_stateNext;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_1;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_2;
+  wire       [7:0]    _zz_PmpPlugin_pmpcfg_0_3;
+  wire                when_PmpPlugin_l209;
+  wire       [15:0]   _zz_11;
+  wire                when_PmpPlugin_l209_1;
+  wire       [15:0]   _zz_12;
+  wire                when_PmpPlugin_l209_2;
+  wire       [15:0]   _zz_13;
+  wire                when_PmpPlugin_l209_3;
+  wire       [15:0]   _zz_14;
+  wire                when_PmpPlugin_l216;
+  wire                when_PmpPlugin_l229;
+  wire                when_StateMachine_l214;
+  wire                when_StateMachine_l230;
+  wire                when_StateMachine_l230_1;
+  wire                when_StateMachine_l230_2;
+  wire                when_CsrPlugin_l1264;
   reg                 execute_CsrPlugin_csr_3264;
-  reg                 execute_CsrPlugin_csr_944;
-  reg                 execute_CsrPlugin_csr_945;
-  reg                 execute_CsrPlugin_csr_946;
-  reg                 execute_CsrPlugin_csr_947;
-  reg                 execute_CsrPlugin_csr_948;
-  reg                 execute_CsrPlugin_csr_949;
-  reg                 execute_CsrPlugin_csr_950;
-  reg                 execute_CsrPlugin_csr_951;
-  reg                 execute_CsrPlugin_csr_952;
-  reg                 execute_CsrPlugin_csr_953;
-  reg                 execute_CsrPlugin_csr_954;
-  reg                 execute_CsrPlugin_csr_955;
-  reg                 execute_CsrPlugin_csr_956;
-  reg                 execute_CsrPlugin_csr_957;
-  reg                 execute_CsrPlugin_csr_958;
-  reg                 execute_CsrPlugin_csr_959;
-  reg                 execute_CsrPlugin_csr_928;
-  reg                 execute_CsrPlugin_csr_929;
-  reg                 execute_CsrPlugin_csr_930;
-  reg                 execute_CsrPlugin_csr_931;
+  wire                when_CsrPlugin_l1264_1;
   reg                 execute_CsrPlugin_csr_3857;
+  wire                when_CsrPlugin_l1264_2;
   reg                 execute_CsrPlugin_csr_3858;
+  wire                when_CsrPlugin_l1264_3;
   reg                 execute_CsrPlugin_csr_3859;
+  wire                when_CsrPlugin_l1264_4;
   reg                 execute_CsrPlugin_csr_3860;
+  wire                when_CsrPlugin_l1264_5;
   reg                 execute_CsrPlugin_csr_769;
+  wire                when_CsrPlugin_l1264_6;
   reg                 execute_CsrPlugin_csr_768;
+  wire                when_CsrPlugin_l1264_7;
   reg                 execute_CsrPlugin_csr_836;
+  wire                when_CsrPlugin_l1264_8;
   reg                 execute_CsrPlugin_csr_772;
+  wire                when_CsrPlugin_l1264_9;
   reg                 execute_CsrPlugin_csr_773;
+  wire                when_CsrPlugin_l1264_10;
   reg                 execute_CsrPlugin_csr_833;
+  wire                when_CsrPlugin_l1264_11;
   reg                 execute_CsrPlugin_csr_832;
+  wire                when_CsrPlugin_l1264_12;
   reg                 execute_CsrPlugin_csr_834;
+  wire                when_CsrPlugin_l1264_13;
   reg                 execute_CsrPlugin_csr_835;
+  wire                when_CsrPlugin_l1264_14;
   reg                 execute_CsrPlugin_csr_2816;
+  wire                when_CsrPlugin_l1264_15;
   reg                 execute_CsrPlugin_csr_2944;
+  wire                when_CsrPlugin_l1264_16;
   reg                 execute_CsrPlugin_csr_2818;
+  wire                when_CsrPlugin_l1264_17;
   reg                 execute_CsrPlugin_csr_2946;
+  wire                when_CsrPlugin_l1264_18;
   reg                 execute_CsrPlugin_csr_3072;
+  wire                when_CsrPlugin_l1264_19;
   reg                 execute_CsrPlugin_csr_3200;
+  wire                when_CsrPlugin_l1264_20;
   reg                 execute_CsrPlugin_csr_3074;
+  wire                when_CsrPlugin_l1264_21;
   reg                 execute_CsrPlugin_csr_3202;
+  wire                when_CsrPlugin_l1264_22;
   reg                 execute_CsrPlugin_csr_3008;
+  wire                when_CsrPlugin_l1264_23;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_573;
-  reg        [31:0]   _zz_574;
-  reg        [31:0]   _zz_575;
-  reg        [31:0]   _zz_576;
-  reg        [31:0]   _zz_577;
-  reg        [31:0]   _zz_578;
-  reg        [31:0]   _zz_579;
-  reg        [31:0]   _zz_580;
-  reg        [31:0]   _zz_581;
-  reg        [31:0]   _zz_582;
-  reg        [31:0]   _zz_583;
-  reg        [31:0]   _zz_584;
-  reg        [31:0]   _zz_585;
-  reg        [31:0]   _zz_586;
-  reg        [31:0]   _zz_587;
-  reg        [31:0]   _zz_588;
-  reg        [31:0]   _zz_589;
-  reg        [31:0]   _zz_590;
-  reg        [31:0]   _zz_591;
-  reg        [31:0]   _zz_592;
-  reg        [31:0]   _zz_593;
-  reg        [31:0]   _zz_594;
-  reg        [31:0]   _zz_595;
-  reg        [31:0]   _zz_596;
-  reg        [31:0]   _zz_597;
-  reg        [31:0]   _zz_598;
-  reg        [31:0]   _zz_599;
-  reg        [31:0]   _zz_600;
-  reg        [31:0]   _zz_601;
-  reg        [31:0]   _zz_602;
-  reg        [31:0]   _zz_603;
-  reg        [31:0]   _zz_604;
-  reg        [31:0]   _zz_605;
-  reg        [31:0]   _zz_606;
-  reg        [31:0]   _zz_607;
-  reg        [31:0]   _zz_608;
-  reg        [31:0]   _zz_609;
-  reg        [31:0]   _zz_610;
-  reg        [31:0]   _zz_611;
-  reg        [31:0]   _zz_612;
-  reg        [31:0]   _zz_613;
-  reg        [31:0]   _zz_614;
-  reg        [31:0]   _zz_615;
-  reg        [2:0]    _zz_616;
-  reg                 _zz_617;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_18;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_19;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_20;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_21;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
+  reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
+  wire                when_PmpPlugin_l155;
+  wire                when_PmpPlugin_l172;
+  wire                when_PmpPlugin_l175;
+  wire                when_CsrPlugin_l1297;
+  wire                when_CsrPlugin_l1302;
+  reg        [2:0]    _zz_iBusWishbone_ADR;
+  wire                when_InstructionCache_l239;
+  reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_618;
-  wire                _zz_619;
-  wire                _zz_620;
-  wire                _zz_621;
-  wire                _zz_622;
-  wire                _zz_623;
-  reg                 _zz_624;
+  reg        [2:0]    _zz_dBus_cmd_ready;
+  wire                _zz_dBus_cmd_ready_1;
+  wire                _zz_dBus_cmd_ready_2;
+  wire                _zz_dBus_cmd_ready_3;
+  wire                _zz_dBus_cmd_ready_4;
+  wire                _zz_dBus_cmd_ready_5;
+  wire                when_DataCache_l345;
+  reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1_string;
-  reg [39:0] _zz_2_string;
-  reg [39:0] _zz_3_string;
-  reg [39:0] _zz_4_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_string;
+  reg [39:0] _zz_execute_to_memory_ENV_CTRL_1_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5_string;
-  reg [39:0] _zz_6_string;
-  reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
-  reg [71:0] _zz_13_string;
-  reg [71:0] _zz_14_string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_decode_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_string;
+  reg [39:0] _zz_decode_to_execute_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_decode_to_execute_BRANCH_CTRL_1_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_to_memory_SHIFT_CTRL_1_string;
+  reg [55:0] decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_decode_to_execute_SHIFT_CTRL_1_string;
+  reg [23:0] decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_string;
+  reg [23:0] _zz_decode_to_execute_SRC2_CTRL_1_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_decode_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_string;
+  reg [63:0] _zz_decode_to_execute_ALU_CTRL_1_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_string;
+  reg [95:0] _zz_decode_to_execute_SRC1_CTRL_1_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_memory_ENV_CTRL_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_execute_ENV_CTRL_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_writeBack_ENV_CTRL_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
-  reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
-  reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [31:0] _zz_execute_BRANCH_CTRL_string;
+  reg [55:0] memory_SHIFT_CTRL_string;
+  reg [55:0] _zz_memory_SHIFT_CTRL_string;
+  reg [55:0] execute_SHIFT_CTRL_string;
+  reg [55:0] _zz_execute_SHIFT_CTRL_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_execute_SRC2_CTRL_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_execute_SRC1_CTRL_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
-  reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
+  reg [63:0] _zz_execute_ALU_CTRL_string;
+  reg [23:0] execute_ALU_BITWISE_CTRL_string;
+  reg [23:0] _zz_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_decode_ENV_CTRL_1_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_1_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_1_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_1_string;
+  reg [63:0] _zz_decode_ALU_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_1_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_51_string;
-  reg [95:0] _zz_514_string;
-  reg [63:0] _zz_515_string;
-  reg [23:0] _zz_516_string;
-  reg [39:0] _zz_517_string;
-  reg [71:0] _zz_518_string;
-  reg [31:0] _zz_519_string;
-  reg [39:0] _zz_520_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_1_string;
+  reg [95:0] _zz_decode_SRC1_CTRL_2_string;
+  reg [63:0] _zz_decode_ALU_CTRL_2_string;
+  reg [23:0] _zz_decode_SRC2_CTRL_2_string;
+  reg [23:0] _zz_decode_ALU_BITWISE_CTRL_2_string;
+  reg [55:0] _zz_decode_SHIFT_CTRL_2_string;
+  reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
+  reg [39:0] _zz_decode_ENV_CTRL_2_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [23:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [55:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [55:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [255:0] execute_PmpPlugin_fsm_stateReg_string;
+  reg [255:0] execute_PmpPlugin_fsm_stateNext_string;
   `endif
 
+  (* ram_style = "distributed" *) reg [31:0] PmpPlugin_pmpaddr [0:15];
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_674 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_675 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_676 = 1'b1;
-  assign _zz_677 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_678 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_679 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_680 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_681 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_682 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_683 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_684 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_685 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_686 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_687 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_688 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_689 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_690 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_691 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_692 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_693 = (_zz_824 == 5'h0);
-  assign _zz_694 = (_zz_834 == 5'h0);
-  assign _zz_695 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_696 = (1'b0 || (! 1'b1));
-  assign _zz_697 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_698 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_699 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_700 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_701 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_702 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_703 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_704 = execute_INSTRUCTION[13 : 12];
-  assign _zz_705 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_706 = (! memory_arbitration_isStuck);
-  assign _zz_707 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_708 = (iBus_cmd_valid || (_zz_616 != 3'b000));
-  assign _zz_709 = (_zz_652 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_710 = (! _zz_90);
-  assign _zz_711 = (! _zz_109);
-  assign _zz_712 = (! _zz_128);
-  assign _zz_713 = (! _zz_147);
-  assign _zz_714 = (! _zz_166);
-  assign _zz_715 = (! _zz_185);
-  assign _zz_716 = (! _zz_204);
-  assign _zz_717 = (! _zz_223);
-  assign _zz_718 = (! _zz_242);
-  assign _zz_719 = (! _zz_261);
-  assign _zz_720 = (! _zz_280);
-  assign _zz_721 = (! _zz_299);
-  assign _zz_722 = (! _zz_318);
-  assign _zz_723 = (! _zz_337);
-  assign _zz_724 = (! _zz_356);
-  assign _zz_725 = (! _zz_375);
-  assign _zz_726 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_727 = ((_zz_559 && 1'b1) && (! 1'b0));
-  assign _zz_728 = ((_zz_560 && 1'b1) && (! 1'b0));
-  assign _zz_729 = ((_zz_561 && 1'b1) && (! 1'b0));
-  assign _zz_730 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_731 = execute_INSTRUCTION[13];
-  assign _zz_732 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_733 = ($signed(_zz_734) + $signed(_zz_739));
-  assign _zz_734 = ($signed(_zz_735) + $signed(_zz_737));
-  assign _zz_735 = 52'h0;
-  assign _zz_736 = {1'b0,memory_MUL_LL};
-  assign _zz_737 = {{19{_zz_736[32]}}, _zz_736};
-  assign _zz_738 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_739 = {{2{_zz_738[49]}}, _zz_738};
-  assign _zz_740 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_741 = {{2{_zz_740[49]}}, _zz_740};
-  assign _zz_742 = ($signed(_zz_744) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_743 = _zz_742[31 : 0];
-  assign _zz_744 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_745 = _zz_509[31 : 31];
-  assign _zz_746 = _zz_509[30 : 30];
-  assign _zz_747 = _zz_509[29 : 29];
-  assign _zz_748 = _zz_509[28 : 28];
-  assign _zz_749 = _zz_509[25 : 25];
-  assign _zz_750 = _zz_509[17 : 17];
-  assign _zz_751 = _zz_509[16 : 16];
-  assign _zz_752 = _zz_509[13 : 13];
-  assign _zz_753 = _zz_509[12 : 12];
-  assign _zz_754 = _zz_509[11 : 11];
-  assign _zz_755 = _zz_509[32 : 32];
-  assign _zz_756 = _zz_509[15 : 15];
-  assign _zz_757 = _zz_509[5 : 5];
-  assign _zz_758 = _zz_509[3 : 3];
-  assign _zz_759 = _zz_509[20 : 20];
-  assign _zz_760 = _zz_509[10 : 10];
-  assign _zz_761 = _zz_509[4 : 4];
-  assign _zz_762 = _zz_509[0 : 0];
-  assign _zz_763 = (_zz_55 - 4'b0001);
-  assign _zz_764 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_765 = {29'd0, _zz_764};
-  assign _zz_766 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_767 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_768 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_769 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_770 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_771 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_772 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_773 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_774 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_775 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_776 = (_zz_92 + 32'h00000001);
-  assign _zz_777 = (_zz_778 <<< 3);
-  assign _zz_778 = (_zz_104 + 32'h00000001);
-  assign _zz_779 = (_zz_111 + 32'h00000001);
-  assign _zz_780 = (_zz_781 <<< 3);
-  assign _zz_781 = (_zz_123 + 32'h00000001);
-  assign _zz_782 = (_zz_130 + 32'h00000001);
-  assign _zz_783 = (_zz_784 <<< 3);
-  assign _zz_784 = (_zz_142 + 32'h00000001);
-  assign _zz_785 = (_zz_149 + 32'h00000001);
-  assign _zz_786 = (_zz_787 <<< 3);
-  assign _zz_787 = (_zz_161 + 32'h00000001);
-  assign _zz_788 = (_zz_168 + 32'h00000001);
-  assign _zz_789 = (_zz_790 <<< 3);
-  assign _zz_790 = (_zz_180 + 32'h00000001);
-  assign _zz_791 = (_zz_187 + 32'h00000001);
-  assign _zz_792 = (_zz_793 <<< 3);
-  assign _zz_793 = (_zz_199 + 32'h00000001);
-  assign _zz_794 = (_zz_206 + 32'h00000001);
-  assign _zz_795 = (_zz_796 <<< 3);
-  assign _zz_796 = (_zz_218 + 32'h00000001);
-  assign _zz_797 = (_zz_225 + 32'h00000001);
-  assign _zz_798 = (_zz_799 <<< 3);
-  assign _zz_799 = (_zz_237 + 32'h00000001);
-  assign _zz_800 = (_zz_244 + 32'h00000001);
-  assign _zz_801 = (_zz_802 <<< 3);
-  assign _zz_802 = (_zz_256 + 32'h00000001);
-  assign _zz_803 = (_zz_263 + 32'h00000001);
-  assign _zz_804 = (_zz_805 <<< 3);
-  assign _zz_805 = (_zz_275 + 32'h00000001);
-  assign _zz_806 = (_zz_282 + 32'h00000001);
-  assign _zz_807 = (_zz_808 <<< 3);
-  assign _zz_808 = (_zz_294 + 32'h00000001);
-  assign _zz_809 = (_zz_301 + 32'h00000001);
-  assign _zz_810 = (_zz_811 <<< 3);
-  assign _zz_811 = (_zz_313 + 32'h00000001);
-  assign _zz_812 = (_zz_320 + 32'h00000001);
-  assign _zz_813 = (_zz_814 <<< 3);
-  assign _zz_814 = (_zz_332 + 32'h00000001);
-  assign _zz_815 = (_zz_339 + 32'h00000001);
-  assign _zz_816 = (_zz_817 <<< 3);
-  assign _zz_817 = (_zz_351 + 32'h00000001);
-  assign _zz_818 = (_zz_358 + 32'h00000001);
-  assign _zz_819 = (_zz_820 <<< 3);
-  assign _zz_820 = (_zz_370 + 32'h00000001);
-  assign _zz_821 = (_zz_377 + 32'h00000001);
-  assign _zz_822 = (_zz_823 <<< 3);
-  assign _zz_823 = (_zz_389 + 32'h00000001);
-  assign _zz_824 = (_zz_825 + _zz_828);
-  assign _zz_825 = (_zz_826 + _zz_827);
-  assign _zz_826 = (_zz_656 + _zz_657);
-  assign _zz_827 = (_zz_658 + _zz_659);
-  assign _zz_828 = (_zz_660 + _zz_661);
-  assign _zz_829 = PmpPlugin_ports_0_hits_15;
-  assign _zz_830 = {2'd0, _zz_829};
-  assign _zz_831 = (_zz_399 - 16'h0001);
-  assign _zz_832 = (_zz_416 - 16'h0001);
-  assign _zz_833 = (_zz_433 - 16'h0001);
-  assign _zz_834 = (_zz_835 + _zz_838);
-  assign _zz_835 = (_zz_836 + _zz_837);
-  assign _zz_836 = (_zz_665 + _zz_666);
-  assign _zz_837 = (_zz_667 + _zz_668);
-  assign _zz_838 = (_zz_669 + _zz_670);
-  assign _zz_839 = PmpPlugin_ports_1_hits_15;
-  assign _zz_840 = {2'd0, _zz_839};
-  assign _zz_841 = (_zz_458 - 16'h0001);
-  assign _zz_842 = (_zz_475 - 16'h0001);
-  assign _zz_843 = (_zz_492 - 16'h0001);
-  assign _zz_844 = execute_SRC_LESS;
-  assign _zz_845 = 3'b100;
-  assign _zz_846 = execute_INSTRUCTION[19 : 15];
-  assign _zz_847 = execute_INSTRUCTION[31 : 20];
-  assign _zz_848 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_849 = ($signed(_zz_850) + $signed(_zz_853));
-  assign _zz_850 = ($signed(_zz_851) + $signed(_zz_852));
-  assign _zz_851 = execute_SRC1;
-  assign _zz_852 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_853 = (execute_SRC_USE_SUB_LESS ? _zz_854 : _zz_855);
-  assign _zz_854 = 32'h00000001;
-  assign _zz_855 = 32'h0;
-  assign _zz_856 = execute_INSTRUCTION[31 : 20];
-  assign _zz_857 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_858 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_859 = {_zz_546,execute_INSTRUCTION[31 : 20]};
-  assign _zz_860 = {{_zz_548,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_861 = {{_zz_550,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_862 = execute_INSTRUCTION[31 : 20];
-  assign _zz_863 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_864 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_865 = 3'b100;
-  assign _zz_866 = (_zz_562 & (~ _zz_867));
-  assign _zz_867 = (_zz_562 - 2'b01);
-  assign _zz_868 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_869 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_870 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_871 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_872 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_873 = {5'd0, _zz_872};
-  assign _zz_874 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_875 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_876 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_877 = {_zz_564,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_878 = _zz_879;
-  assign _zz_879 = _zz_880;
-  assign _zz_880 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_565) : _zz_565)} + _zz_882);
-  assign _zz_881 = memory_DivPlugin_div_needRevert;
-  assign _zz_882 = {32'd0, _zz_881};
-  assign _zz_883 = _zz_567;
-  assign _zz_884 = {32'd0, _zz_883};
-  assign _zz_885 = _zz_566;
-  assign _zz_886 = {31'd0, _zz_885};
-  assign _zz_887 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_888 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_889 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_890 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_891 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_892 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_893 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_894 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_895 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_896 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_897 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_898 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_899 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_900 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_901 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_902 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_903 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_904 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_905 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_906 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_907 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_908 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_909 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_910 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_911 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_912 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_913 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_914 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_915 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_916 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_917 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_918 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_919 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_920 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_921 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_922 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_923 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_924 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_925 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_926 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_927 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_928 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_929 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_930 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_931 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_932 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_933 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_934 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_935 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_936 = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_937 = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_938 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_939 = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_940 = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_941 = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_942 = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_943 = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_944 = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_945 = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_946 = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_947 = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_948 = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_949 = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_950 = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_951 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_952 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_953 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_954 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_955 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_956 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_957 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_958 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_959 = 1'b1;
-  assign _zz_960 = 1'b1;
-  assign _zz_961 = {_zz_59,_zz_58};
-  assign _zz_962 = {PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}};
-  assign _zz_963 = {PmpPlugin_ports_0_hits_5,{PmpPlugin_ports_0_hits_4,PmpPlugin_ports_0_hits_3}};
-  assign _zz_964 = {PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,PmpPlugin_ports_0_hits_6}};
-  assign _zz_965 = {PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,PmpPlugin_ports_0_hits_9}};
-  assign _zz_966 = {PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,PmpPlugin_ports_0_hits_12}};
-  assign _zz_967 = {_zz_415,{_zz_414,{_zz_413,_zz_412}}};
-  assign _zz_968 = {_zz_432,{_zz_431,{_zz_430,_zz_429}}};
-  assign _zz_969 = {_zz_449,{_zz_448,{_zz_447,_zz_446}}};
-  assign _zz_970 = {PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}};
-  assign _zz_971 = {PmpPlugin_ports_1_hits_5,{PmpPlugin_ports_1_hits_4,PmpPlugin_ports_1_hits_3}};
-  assign _zz_972 = {PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,PmpPlugin_ports_1_hits_6}};
-  assign _zz_973 = {PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,PmpPlugin_ports_1_hits_9}};
-  assign _zz_974 = {PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,PmpPlugin_ports_1_hits_12}};
-  assign _zz_975 = {_zz_474,{_zz_473,{_zz_472,_zz_471}}};
-  assign _zz_976 = {_zz_491,{_zz_490,{_zz_489,_zz_488}}};
-  assign _zz_977 = {_zz_508,{_zz_507,{_zz_506,_zz_505}}};
-  assign _zz_978 = 32'h0000107f;
-  assign _zz_979 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_980 = 32'h00002073;
-  assign _zz_981 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_982 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_983 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_984) == 32'h00000003),{(_zz_985 == _zz_986),{_zz_987,{_zz_988,_zz_989}}}}}};
-  assign _zz_984 = 32'h0000505f;
-  assign _zz_985 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_986 = 32'h00000063;
-  assign _zz_987 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_988 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_989 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_990) == 32'h00001013),{(_zz_991 == _zz_992),{_zz_993,{_zz_994,_zz_995}}}}}};
-  assign _zz_990 = 32'hfc00307f;
-  assign _zz_991 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_992 = 32'h00005033;
-  assign _zz_993 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_994 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_995 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_996 = decode_INSTRUCTION[31];
-  assign _zz_997 = decode_INSTRUCTION[31];
-  assign _zz_998 = decode_INSTRUCTION[7];
-  assign _zz_999 = PmpPlugin_ports_0_hits_5;
-  assign _zz_1000 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_1001 = PmpPlugin_ports_0_hits_5;
-  assign _zz_1002 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_1003 = PmpPlugin_ports_0_hits_5;
-  assign _zz_1004 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_1005 = PmpPlugin_ports_1_hits_5;
-  assign _zz_1006 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_1007 = PmpPlugin_ports_1_hits_5;
-  assign _zz_1008 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_1009 = PmpPlugin_ports_1_hits_5;
-  assign _zz_1010 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_1011 = 32'h10103050;
-  assign _zz_1012 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_1013 = 1'b0;
-  assign _zz_1014 = (((decode_INSTRUCTION & _zz_1017) == 32'h02000030) != 1'b0);
-  assign _zz_1015 = ({_zz_1018,_zz_1019} != 2'b00);
-  assign _zz_1016 = {(_zz_1020 != 1'b0),{(_zz_1021 != _zz_1022),{_zz_1023,{_zz_1024,_zz_1025}}}};
-  assign _zz_1017 = 32'h02004074;
-  assign _zz_1018 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz_1019 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_1020 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz_1021 = {(_zz_1026 == _zz_1027),(_zz_1028 == _zz_1029)};
-  assign _zz_1022 = 2'b00;
-  assign _zz_1023 = ({_zz_512,_zz_1030} != 2'b00);
-  assign _zz_1024 = (_zz_1031 != 1'b0);
-  assign _zz_1025 = {(_zz_1032 != _zz_1033),{_zz_1034,{_zz_1035,_zz_1036}}};
-  assign _zz_1026 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_1027 = 32'h00001050;
-  assign _zz_1028 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_1029 = 32'h00002050;
-  assign _zz_1030 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_1031 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_1032 = {(_zz_1037 == _zz_1038),(_zz_1039 == _zz_1040)};
-  assign _zz_1033 = 2'b00;
-  assign _zz_1034 = ({_zz_1041,{_zz_1042,_zz_1043}} != 3'b000);
-  assign _zz_1035 = (_zz_1044 != 1'b0);
-  assign _zz_1036 = {(_zz_1045 != _zz_1046),{_zz_1047,{_zz_1048,_zz_1049}}};
-  assign _zz_1037 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_1038 = 32'h00005010;
-  assign _zz_1039 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_1040 = 32'h00005020;
-  assign _zz_1041 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_1042 = ((decode_INSTRUCTION & _zz_1050) == 32'h00001010);
-  assign _zz_1043 = ((decode_INSTRUCTION & _zz_1051) == 32'h00001010);
-  assign _zz_1044 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_1045 = ((decode_INSTRUCTION & _zz_1052) == 32'h00001000);
-  assign _zz_1046 = 1'b0;
-  assign _zz_1047 = ((_zz_1053 == _zz_1054) != 1'b0);
-  assign _zz_1048 = ({_zz_1055,_zz_1056} != 2'b00);
-  assign _zz_1049 = {(_zz_1057 != _zz_1058),{_zz_1059,{_zz_1060,_zz_1061}}};
-  assign _zz_1050 = 32'h00007034;
-  assign _zz_1051 = 32'h02007054;
-  assign _zz_1052 = 32'h00001000;
-  assign _zz_1053 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_1054 = 32'h00002000;
-  assign _zz_1055 = ((decode_INSTRUCTION & _zz_1062) == 32'h00002000);
-  assign _zz_1056 = ((decode_INSTRUCTION & _zz_1063) == 32'h00001000);
-  assign _zz_1057 = ((decode_INSTRUCTION & _zz_1064) == 32'h00004008);
-  assign _zz_1058 = 1'b0;
-  assign _zz_1059 = ({_zz_1065,_zz_1066} != 2'b00);
-  assign _zz_1060 = ({_zz_1067,_zz_1068} != 5'h0);
-  assign _zz_1061 = {(_zz_1069 != _zz_1070),{_zz_1071,{_zz_1072,_zz_1073}}};
-  assign _zz_1062 = 32'h00002010;
-  assign _zz_1063 = 32'h00005000;
-  assign _zz_1064 = 32'h00004048;
-  assign _zz_1065 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_1066 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_1067 = ((decode_INSTRUCTION & _zz_1074) == 32'h00002040);
-  assign _zz_1068 = {(_zz_1075 == _zz_1076),{_zz_1077,{_zz_1078,_zz_1079}}};
-  assign _zz_1069 = ((decode_INSTRUCTION & _zz_1080) == 32'h00000020);
-  assign _zz_1070 = 1'b0;
-  assign _zz_1071 = ({_zz_1081,{_zz_1082,_zz_1083}} != 5'h0);
-  assign _zz_1072 = ({_zz_1084,_zz_1085} != 5'h0);
-  assign _zz_1073 = {(_zz_1086 != _zz_1087),{_zz_1088,{_zz_1089,_zz_1090}}};
-  assign _zz_1074 = 32'h00002040;
-  assign _zz_1075 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_1076 = 32'h00001040;
-  assign _zz_1077 = ((decode_INSTRUCTION & _zz_1091) == 32'h00000040);
-  assign _zz_1078 = (_zz_1092 == _zz_1093);
-  assign _zz_1079 = (_zz_1094 == _zz_1095);
-  assign _zz_1080 = 32'h00000020;
-  assign _zz_1081 = ((decode_INSTRUCTION & _zz_1096) == 32'h00000040);
-  assign _zz_1082 = _zz_511;
-  assign _zz_1083 = {_zz_1097,{_zz_1098,_zz_1099}};
-  assign _zz_1084 = _zz_511;
-  assign _zz_1085 = {_zz_1100,{_zz_1101,_zz_1102}};
-  assign _zz_1086 = {_zz_512,{_zz_1103,_zz_1104}};
-  assign _zz_1087 = 6'h0;
-  assign _zz_1088 = ({_zz_1105,_zz_1106} != 2'b00);
-  assign _zz_1089 = (_zz_1107 != _zz_1108);
-  assign _zz_1090 = {_zz_1109,{_zz_1110,_zz_1111}};
-  assign _zz_1091 = 32'h00100040;
-  assign _zz_1092 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_1093 = 32'h00000040;
-  assign _zz_1094 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_1095 = 32'h0;
-  assign _zz_1096 = 32'h00000040;
-  assign _zz_1097 = ((decode_INSTRUCTION & _zz_1112) == 32'h00004020);
-  assign _zz_1098 = (_zz_1113 == _zz_1114);
-  assign _zz_1099 = (_zz_1115 == _zz_1116);
-  assign _zz_1100 = ((decode_INSTRUCTION & _zz_1117) == 32'h00002010);
-  assign _zz_1101 = (_zz_1118 == _zz_1119);
-  assign _zz_1102 = {_zz_1120,_zz_1121};
-  assign _zz_1103 = (_zz_1122 == _zz_1123);
-  assign _zz_1104 = {_zz_1124,{_zz_1125,_zz_1126}};
-  assign _zz_1105 = _zz_511;
-  assign _zz_1106 = (_zz_1127 == _zz_1128);
-  assign _zz_1107 = {_zz_511,_zz_1129};
-  assign _zz_1108 = 2'b00;
-  assign _zz_1109 = (_zz_1130 != 1'b0);
-  assign _zz_1110 = (_zz_1131 != _zz_1132);
-  assign _zz_1111 = {_zz_1133,{_zz_1134,_zz_1135}};
-  assign _zz_1112 = 32'h00004020;
-  assign _zz_1113 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_1114 = 32'h00000010;
-  assign _zz_1115 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_1116 = 32'h00000020;
-  assign _zz_1117 = 32'h00002030;
-  assign _zz_1118 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_1119 = 32'h00000010;
-  assign _zz_1120 = ((decode_INSTRUCTION & _zz_1136) == 32'h00002020);
-  assign _zz_1121 = ((decode_INSTRUCTION & _zz_1137) == 32'h00000020);
-  assign _zz_1122 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_1123 = 32'h00001010;
-  assign _zz_1124 = ((decode_INSTRUCTION & _zz_1138) == 32'h00002010);
-  assign _zz_1125 = (_zz_1139 == _zz_1140);
-  assign _zz_1126 = {_zz_1141,_zz_1142};
-  assign _zz_1127 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_1128 = 32'h00000020;
-  assign _zz_1129 = ((decode_INSTRUCTION & _zz_1143) == 32'h0);
-  assign _zz_1130 = ((decode_INSTRUCTION & _zz_1144) == 32'h00004010);
-  assign _zz_1131 = (_zz_1145 == _zz_1146);
-  assign _zz_1132 = 1'b0;
-  assign _zz_1133 = ({_zz_1147,_zz_1148} != 4'b0000);
-  assign _zz_1134 = (_zz_1149 != _zz_1150);
-  assign _zz_1135 = {_zz_1151,{_zz_1152,_zz_1153}};
-  assign _zz_1136 = 32'h02002060;
-  assign _zz_1137 = 32'h02003020;
-  assign _zz_1138 = 32'h00002010;
-  assign _zz_1139 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_1140 = 32'h00000010;
-  assign _zz_1141 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_1142 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_1143 = 32'h00000020;
-  assign _zz_1144 = 32'h00004014;
-  assign _zz_1145 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_1146 = 32'h00002010;
-  assign _zz_1147 = ((decode_INSTRUCTION & _zz_1154) == 32'h0);
-  assign _zz_1148 = {(_zz_1155 == _zz_1156),{_zz_1157,_zz_1158}};
-  assign _zz_1149 = ((decode_INSTRUCTION & _zz_1159) == 32'h0);
-  assign _zz_1150 = 1'b0;
-  assign _zz_1151 = ({_zz_1160,{_zz_1161,_zz_1162}} != 3'b000);
-  assign _zz_1152 = ({_zz_1163,_zz_1164} != 2'b00);
-  assign _zz_1153 = {(_zz_1165 != _zz_1166),(_zz_1167 != _zz_1168)};
-  assign _zz_1154 = 32'h00000044;
-  assign _zz_1155 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_1156 = 32'h0;
-  assign _zz_1157 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_1158 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_1159 = 32'h00000058;
-  assign _zz_1160 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_1161 = ((decode_INSTRUCTION & _zz_1169) == 32'h00002010);
-  assign _zz_1162 = ((decode_INSTRUCTION & _zz_1170) == 32'h40000030);
-  assign _zz_1163 = ((decode_INSTRUCTION & _zz_1171) == 32'h00000004);
-  assign _zz_1164 = _zz_510;
-  assign _zz_1165 = {(_zz_1172 == _zz_1173),_zz_510};
-  assign _zz_1166 = 2'b00;
-  assign _zz_1167 = ((decode_INSTRUCTION & _zz_1174) == 32'h00001008);
-  assign _zz_1168 = 1'b0;
-  assign _zz_1169 = 32'h00002014;
-  assign _zz_1170 = 32'h40000034;
-  assign _zz_1171 = 32'h00000014;
-  assign _zz_1172 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_1173 = 32'h00000004;
-  assign _zz_1174 = 32'h00005048;
-  assign _zz_1175 = execute_INSTRUCTION[31];
-  assign _zz_1176 = execute_INSTRUCTION[31];
-  assign _zz_1177 = execute_INSTRUCTION[7];
-  assign _zz_1178 = (_zz_573 | _zz_574);
-  assign _zz_1179 = (_zz_575 | _zz_576);
-  assign _zz_1180 = (_zz_577 | _zz_578);
-  assign _zz_1181 = (_zz_579 | _zz_580);
-  assign _zz_1182 = (_zz_581 | _zz_582);
-  assign _zz_1183 = (_zz_583 | _zz_584);
-  assign _zz_1184 = (_zz_585 | _zz_586);
-  assign _zz_1185 = (_zz_587 | _zz_588);
-  assign _zz_1186 = (_zz_589 | _zz_590);
-  assign _zz_1187 = (_zz_591 | _zz_592);
-  assign _zz_1188 = (_zz_593 | _zz_594);
-  assign _zz_1189 = (_zz_595 | _zz_596);
-  assign _zz_1190 = (_zz_1194 | _zz_597);
-  assign _zz_1191 = (_zz_598 | _zz_599);
-  assign _zz_1192 = (_zz_600 | _zz_601);
-  assign _zz_1193 = (_zz_602 | _zz_603);
-  assign _zz_1194 = 32'h0;
-  always @ (posedge clk) begin
-    if(_zz_959) begin
-      _zz_653 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+  assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
+  assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
+  assign _zz_memory_MUL_LOW_2 = 52'h0;
+  assign _zz_memory_MUL_LOW_4 = {1'b0,memory_MUL_LL};
+  assign _zz_memory_MUL_LOW_3 = {{19{_zz_memory_MUL_LOW_4[32]}}, _zz_memory_MUL_LOW_4};
+  assign _zz_memory_MUL_LOW_6 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_memory_MUL_LOW_5 = {{2{_zz_memory_MUL_LOW_6[49]}}, _zz_memory_MUL_LOW_6};
+  assign _zz_memory_MUL_LOW_8 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
+  assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
+  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_3 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_5 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_7 = {{_zz_4,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_7_1 = {{_zz_6,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
+  assign _zz__zz_execute_SRC1 = 3'b100;
+  assign _zz__zz_execute_SRC1_1 = execute_INSTRUCTION[19 : 15];
+  assign _zz__zz_execute_SRC2_3 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_execute_SrcPlugin_addSub = ($signed(_zz_execute_SrcPlugin_addSub_1) + $signed(_zz_execute_SrcPlugin_addSub_4));
+  assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
+  assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
+  assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? _zz_execute_SrcPlugin_addSub_5 : _zz_execute_SrcPlugin_addSub_6);
+  assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
+  assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6 = {_zz_execute_BranchPlugin_missAlignedTarget_1,execute_INSTRUCTION[31 : 20]};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1 = {{_zz_execute_BranchPlugin_missAlignedTarget_3,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2 = {{_zz_execute_BranchPlugin_missAlignedTarget_5,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_execute_BranchPlugin_branch_src2_9 = 3'b100;
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
+  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
+  assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
+  assign _zz__zz_decode_RS2_2_1 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_memory_DivPlugin_div_counter_valueNext_1 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_memory_DivPlugin_div_counter_valueNext = {5'd0, _zz_memory_DivPlugin_div_counter_valueNext_1};
+  assign _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outRemainder_1 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_memory_DivPlugin_div_stage_0_outNumerator = {_zz_memory_DivPlugin_div_stage_0_remainderShifted,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_memory_DivPlugin_div_result_1 = _zz_memory_DivPlugin_div_result_2;
+  assign _zz_memory_DivPlugin_div_result_2 = _zz_memory_DivPlugin_div_result_3;
+  assign _zz_memory_DivPlugin_div_result_3 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_memory_DivPlugin_div_result) : _zz_memory_DivPlugin_div_result)} + _zz_memory_DivPlugin_div_result_4);
+  assign _zz_memory_DivPlugin_div_result_5 = memory_DivPlugin_div_needRevert;
+  assign _zz_memory_DivPlugin_div_result_4 = {32'd0, _zz_memory_DivPlugin_div_result_5};
+  assign _zz_memory_DivPlugin_rs1_3 = _zz_memory_DivPlugin_rs1;
+  assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
+  assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
+  assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
+  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_PmpPlugin_pmpaddr_port = execute_PmpPlugin_writeData_;
+  assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
+  assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
+  assign _zz_PmpPlugin_dGuard_hits_0_2 = 4'b0000;
+  assign _zz_PmpPlugin_dGuard_hits_0_4 = 4'b0000;
+  assign _zz_PmpPlugin_dGuard_hits_1_1 = 4'b0001;
+  assign _zz_PmpPlugin_dGuard_hits_1_3 = 4'b0001;
+  assign _zz_PmpPlugin_dGuard_hits_2_1 = 4'b0010;
+  assign _zz_PmpPlugin_dGuard_hits_2_3 = 4'b0010;
+  assign _zz_PmpPlugin_dGuard_hits_3_1 = 4'b0011;
+  assign _zz_PmpPlugin_dGuard_hits_3_3 = 4'b0011;
+  assign _zz_PmpPlugin_dGuard_hits_4_1 = 4'b0100;
+  assign _zz_PmpPlugin_dGuard_hits_4_3 = 4'b0100;
+  assign _zz_PmpPlugin_dGuard_hits_5_1 = 4'b0101;
+  assign _zz_PmpPlugin_dGuard_hits_5_3 = 4'b0101;
+  assign _zz_PmpPlugin_dGuard_hits_6_1 = 4'b0110;
+  assign _zz_PmpPlugin_dGuard_hits_6_3 = 4'b0110;
+  assign _zz_PmpPlugin_dGuard_hits_7_1 = 4'b0111;
+  assign _zz_PmpPlugin_dGuard_hits_7_3 = 4'b0111;
+  assign _zz_PmpPlugin_dGuard_hits_8_1 = 4'b1000;
+  assign _zz_PmpPlugin_dGuard_hits_8_3 = 4'b1000;
+  assign _zz_PmpPlugin_dGuard_hits_9_1 = 4'b1001;
+  assign _zz_PmpPlugin_dGuard_hits_9_3 = 4'b1001;
+  assign _zz_PmpPlugin_dGuard_hits_10_1 = 4'b1010;
+  assign _zz_PmpPlugin_dGuard_hits_10_3 = 4'b1010;
+  assign _zz_PmpPlugin_dGuard_hits_11_1 = 4'b1011;
+  assign _zz_PmpPlugin_dGuard_hits_11_3 = 4'b1011;
+  assign _zz_PmpPlugin_dGuard_hits_12_1 = 4'b1100;
+  assign _zz_PmpPlugin_dGuard_hits_12_3 = 4'b1100;
+  assign _zz_PmpPlugin_dGuard_hits_13_1 = 4'b1101;
+  assign _zz_PmpPlugin_dGuard_hits_13_3 = 4'b1101;
+  assign _zz_PmpPlugin_dGuard_hits_14_1 = 4'b1110;
+  assign _zz_PmpPlugin_dGuard_hits_14_3 = 4'b1110;
+  assign _zz_PmpPlugin_dGuard_hits_15_1 = 4'b1111;
+  assign _zz_PmpPlugin_dGuard_hits_15_3 = 4'b1111;
+  assign _zz_PmpPlugin_iGuard_hits_0_2 = 4'b0000;
+  assign _zz_PmpPlugin_iGuard_hits_0_4 = 4'b0000;
+  assign _zz_PmpPlugin_iGuard_hits_1_1 = 4'b0001;
+  assign _zz_PmpPlugin_iGuard_hits_1_3 = 4'b0001;
+  assign _zz_PmpPlugin_iGuard_hits_2_1 = 4'b0010;
+  assign _zz_PmpPlugin_iGuard_hits_2_3 = 4'b0010;
+  assign _zz_PmpPlugin_iGuard_hits_3_1 = 4'b0011;
+  assign _zz_PmpPlugin_iGuard_hits_3_3 = 4'b0011;
+  assign _zz_PmpPlugin_iGuard_hits_4_1 = 4'b0100;
+  assign _zz_PmpPlugin_iGuard_hits_4_3 = 4'b0100;
+  assign _zz_PmpPlugin_iGuard_hits_5_1 = 4'b0101;
+  assign _zz_PmpPlugin_iGuard_hits_5_3 = 4'b0101;
+  assign _zz_PmpPlugin_iGuard_hits_6_1 = 4'b0110;
+  assign _zz_PmpPlugin_iGuard_hits_6_3 = 4'b0110;
+  assign _zz_PmpPlugin_iGuard_hits_7_1 = 4'b0111;
+  assign _zz_PmpPlugin_iGuard_hits_7_3 = 4'b0111;
+  assign _zz_PmpPlugin_iGuard_hits_8_1 = 4'b1000;
+  assign _zz_PmpPlugin_iGuard_hits_8_3 = 4'b1000;
+  assign _zz_PmpPlugin_iGuard_hits_9_1 = 4'b1001;
+  assign _zz_PmpPlugin_iGuard_hits_9_3 = 4'b1001;
+  assign _zz_PmpPlugin_iGuard_hits_10_1 = 4'b1010;
+  assign _zz_PmpPlugin_iGuard_hits_10_3 = 4'b1010;
+  assign _zz_PmpPlugin_iGuard_hits_11_1 = 4'b1011;
+  assign _zz_PmpPlugin_iGuard_hits_11_3 = 4'b1011;
+  assign _zz_PmpPlugin_iGuard_hits_12_1 = 4'b1100;
+  assign _zz_PmpPlugin_iGuard_hits_12_3 = 4'b1100;
+  assign _zz_PmpPlugin_iGuard_hits_13_1 = 4'b1101;
+  assign _zz_PmpPlugin_iGuard_hits_13_3 = 4'b1101;
+  assign _zz_PmpPlugin_iGuard_hits_14_1 = 4'b1110;
+  assign _zz_PmpPlugin_iGuard_hits_14_3 = 4'b1110;
+  assign _zz_PmpPlugin_iGuard_hits_15_1 = 4'b1111;
+  assign _zz_PmpPlugin_iGuard_hits_15_3 = 4'b1111;
+  assign _zz_when_PmpPlugin_l209_1 = {execute_PmpPlugin_pmpcfgN_,2'b00};
+  assign _zz_when_PmpPlugin_l209_1_2 = {execute_PmpPlugin_pmpcfgN_,2'b01};
+  assign _zz_when_PmpPlugin_l209_2_1 = {execute_PmpPlugin_pmpcfgN_,2'b10};
+  assign _zz_when_PmpPlugin_l209_3_1 = {execute_PmpPlugin_pmpcfgN_,2'b11};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_1 = {execute_PmpPlugin_pmpcfgN,2'b11};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_3 = {execute_PmpPlugin_pmpcfgN,2'b10};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_5 = {execute_PmpPlugin_pmpcfgN,2'b01};
+  assign _zz_CsrPlugin_csrMapping_readDataSignal_7 = {execute_PmpPlugin_pmpcfgN,2'b00};
+  assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
+  assign _zz_decode_LEGAL_INSTRUCTION_1 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_decode_LEGAL_INSTRUCTION_2 = 32'h00002073;
+  assign _zz_decode_LEGAL_INSTRUCTION_3 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_decode_LEGAL_INSTRUCTION_4 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_decode_LEGAL_INSTRUCTION_5 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_6) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_7 == _zz_decode_LEGAL_INSTRUCTION_8),{_zz_decode_LEGAL_INSTRUCTION_9,{_zz_decode_LEGAL_INSTRUCTION_10,_zz_decode_LEGAL_INSTRUCTION_11}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_6 = 32'h0000505f;
+  assign _zz_decode_LEGAL_INSTRUCTION_7 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_decode_LEGAL_INSTRUCTION_8 = 32'h00000063;
+  assign _zz_decode_LEGAL_INSTRUCTION_9 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_decode_LEGAL_INSTRUCTION_10 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_11 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION_12) == 32'h00001013),{(_zz_decode_LEGAL_INSTRUCTION_13 == _zz_decode_LEGAL_INSTRUCTION_14),{_zz_decode_LEGAL_INSTRUCTION_15,{_zz_decode_LEGAL_INSTRUCTION_16,_zz_decode_LEGAL_INSTRUCTION_17}}}}}};
+  assign _zz_decode_LEGAL_INSTRUCTION_12 = 32'hfc00307f;
+  assign _zz_decode_LEGAL_INSTRUCTION_13 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_decode_LEGAL_INSTRUCTION_14 = 32'h00005033;
+  assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
+  assign _zz_when_PmpPlugin_l277 = PmpPlugin_dGuard_hits_6;
+  assign _zz_when_PmpPlugin_l277_1 = {PmpPlugin_dGuard_hits_5,{PmpPlugin_dGuard_hits_4,{PmpPlugin_dGuard_hits_3,{PmpPlugin_dGuard_hits_2,{PmpPlugin_dGuard_hits_1,PmpPlugin_dGuard_hits_0}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead = PmpPlugin_pmpcfg_11[0];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1 = (PmpPlugin_dGuard_hits_10 && PmpPlugin_pmpcfg_10[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2 = (PmpPlugin_dGuard_hits_9 && PmpPlugin_pmpcfg_9[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3 = {(PmpPlugin_dGuard_hits_8 && PmpPlugin_pmpcfg_8[0]),{(PmpPlugin_dGuard_hits_7 && PmpPlugin_pmpcfg_7[0]),{(PmpPlugin_dGuard_hits_6 && PmpPlugin_pmpcfg_6[0]),{(PmpPlugin_dGuard_hits_5 && PmpPlugin_pmpcfg_5[0]),{(PmpPlugin_dGuard_hits_4 && _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4),{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6,_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_4 = PmpPlugin_pmpcfg_4[0];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_5 = (PmpPlugin_dGuard_hits_3 && PmpPlugin_pmpcfg_3[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_6 = (PmpPlugin_dGuard_hits_2 && PmpPlugin_pmpcfg_2[0]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowRead_7 = {(PmpPlugin_dGuard_hits_1 && PmpPlugin_pmpcfg_1[0]),(PmpPlugin_dGuard_hits_0 && PmpPlugin_pmpcfg_0[0])};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite = PmpPlugin_pmpcfg_11[1];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1 = (PmpPlugin_dGuard_hits_10 && PmpPlugin_pmpcfg_10[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2 = (PmpPlugin_dGuard_hits_9 && PmpPlugin_pmpcfg_9[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3 = {(PmpPlugin_dGuard_hits_8 && PmpPlugin_pmpcfg_8[1]),{(PmpPlugin_dGuard_hits_7 && PmpPlugin_pmpcfg_7[1]),{(PmpPlugin_dGuard_hits_6 && PmpPlugin_pmpcfg_6[1]),{(PmpPlugin_dGuard_hits_5 && PmpPlugin_pmpcfg_5[1]),{(PmpPlugin_dGuard_hits_4 && _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4),{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6,_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7}}}}}}};
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_4 = PmpPlugin_pmpcfg_4[1];
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_5 = (PmpPlugin_dGuard_hits_3 && PmpPlugin_pmpcfg_3[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_6 = (PmpPlugin_dGuard_hits_2 && PmpPlugin_pmpcfg_2[1]);
+  assign _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_7 = {(PmpPlugin_dGuard_hits_1 && PmpPlugin_pmpcfg_1[1]),(PmpPlugin_dGuard_hits_0 && PmpPlugin_pmpcfg_0[1])};
+  assign _zz_when_PmpPlugin_l299 = PmpPlugin_iGuard_hits_6;
+  assign _zz_when_PmpPlugin_l299_1 = {PmpPlugin_iGuard_hits_5,{PmpPlugin_iGuard_hits_4,{PmpPlugin_iGuard_hits_3,{PmpPlugin_iGuard_hits_2,{PmpPlugin_iGuard_hits_1,PmpPlugin_iGuard_hits_0}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute = PmpPlugin_pmpcfg_11[2];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1 = (PmpPlugin_iGuard_hits_10 && PmpPlugin_pmpcfg_10[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2 = (PmpPlugin_iGuard_hits_9 && PmpPlugin_pmpcfg_9[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3 = {(PmpPlugin_iGuard_hits_8 && PmpPlugin_pmpcfg_8[2]),{(PmpPlugin_iGuard_hits_7 && PmpPlugin_pmpcfg_7[2]),{(PmpPlugin_iGuard_hits_6 && PmpPlugin_pmpcfg_6[2]),{(PmpPlugin_iGuard_hits_5 && PmpPlugin_pmpcfg_5[2]),{(PmpPlugin_iGuard_hits_4 && _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4),{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7}}}}}}};
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_4 = PmpPlugin_pmpcfg_4[2];
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_5 = (PmpPlugin_iGuard_hits_3 && PmpPlugin_pmpcfg_3[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_6 = (PmpPlugin_iGuard_hits_2 && PmpPlugin_pmpcfg_2[2]);
+  assign _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_7 = {(PmpPlugin_iGuard_hits_1 && PmpPlugin_pmpcfg_1[2]),(PmpPlugin_iGuard_hits_0 && PmpPlugin_pmpcfg_0[2])};
+  assign _zz__zz_decode_IS_RS2_SIGNED = 32'h10103050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_2 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_3 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_4) == 32'h02000030) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = ({_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_7} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = {(_zz__zz_decode_IS_RS2_SIGNED_9 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_10 != _zz__zz_decode_IS_RS2_SIGNED_15),{_zz__zz_decode_IS_RS2_SIGNED_16,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_20}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 32'h02004074;
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {(_zz__zz_decode_IS_RS2_SIGNED_11 == _zz__zz_decode_IS_RS2_SIGNED_12),(_zz__zz_decode_IS_RS2_SIGNED_13 == _zz__zz_decode_IS_RS2_SIGNED_14)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ({_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_17} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (_zz__zz_decode_IS_RS2_SIGNED_19 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = {(_zz__zz_decode_IS_RS2_SIGNED_21 != _zz__zz_decode_IS_RS2_SIGNED_26),{_zz__zz_decode_IS_RS2_SIGNED_27,{_zz__zz_decode_IS_RS2_SIGNED_33,_zz__zz_decode_IS_RS2_SIGNED_35}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h00001050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00002050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ({_zz__zz_decode_IS_RS2_SIGNED_28,{_zz__zz_decode_IS_RS2_SIGNED_29,_zz__zz_decode_IS_RS2_SIGNED_31}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (_zz__zz_decode_IS_RS2_SIGNED_34 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {(_zz__zz_decode_IS_RS2_SIGNED_36 != _zz__zz_decode_IS_RS2_SIGNED_38),{_zz__zz_decode_IS_RS2_SIGNED_39,{_zz__zz_decode_IS_RS2_SIGNED_42,_zz__zz_decode_IS_RS2_SIGNED_47}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00005010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00005020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_32) == 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = ((_zz__zz_decode_IS_RS2_SIGNED_40 == _zz__zz_decode_IS_RS2_SIGNED_41) != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ({_zz__zz_decode_IS_RS2_SIGNED_43,_zz__zz_decode_IS_RS2_SIGNED_45} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = {(_zz__zz_decode_IS_RS2_SIGNED_48 != _zz__zz_decode_IS_RS2_SIGNED_50),{_zz__zz_decode_IS_RS2_SIGNED_51,{_zz__zz_decode_IS_RS2_SIGNED_54,_zz__zz_decode_IS_RS2_SIGNED_68}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00007034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = 32'h02007054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = 32'h00002000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_44) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_46) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00004008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = ({_zz__zz_decode_IS_RS2_SIGNED_52,_zz__zz_decode_IS_RS2_SIGNED_53} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = ({_zz__zz_decode_IS_RS2_SIGNED_55,_zz__zz_decode_IS_RS2_SIGNED_57} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = {(_zz__zz_decode_IS_RS2_SIGNED_69 != _zz__zz_decode_IS_RS2_SIGNED_71),{_zz__zz_decode_IS_RS2_SIGNED_72,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_98}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = {(_zz__zz_decode_IS_RS2_SIGNED_58 == _zz__zz_decode_IS_RS2_SIGNED_59),{_zz__zz_decode_IS_RS2_SIGNED_60,{_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_65}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_70) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = ({_zz__zz_decode_IS_RS2_SIGNED_73,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_76}} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_85 = ({_zz__zz_decode_IS_RS2_SIGNED_86,_zz__zz_decode_IS_RS2_SIGNED_87} != 5'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = {(_zz__zz_decode_IS_RS2_SIGNED_99 != _zz__zz_decode_IS_RS2_SIGNED_112),{_zz__zz_decode_IS_RS2_SIGNED_113,{_zz__zz_decode_IS_RS2_SIGNED_118,_zz__zz_decode_IS_RS2_SIGNED_123}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_61) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = (_zz__zz_decode_IS_RS2_SIGNED_63 == _zz__zz_decode_IS_RS2_SIGNED_64);
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (_zz__zz_decode_IS_RS2_SIGNED_66 == _zz__zz_decode_IS_RS2_SIGNED_67);
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_75 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = {_zz__zz_decode_IS_RS2_SIGNED_77,{_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_82}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = {_zz__zz_decode_IS_RS2_SIGNED_88,{_zz__zz_decode_IS_RS2_SIGNED_90,_zz__zz_decode_IS_RS2_SIGNED_93}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = {_zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_100,_zz__zz_decode_IS_RS2_SIGNED_103}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = 6'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = ({_zz__zz_decode_IS_RS2_SIGNED_114,_zz__zz_decode_IS_RS2_SIGNED_115} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = (_zz__zz_decode_IS_RS2_SIGNED_119 != _zz__zz_decode_IS_RS2_SIGNED_122);
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = {_zz__zz_decode_IS_RS2_SIGNED_124,{_zz__zz_decode_IS_RS2_SIGNED_127,_zz__zz_decode_IS_RS2_SIGNED_132}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = 32'h00100040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_78) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = (_zz__zz_decode_IS_RS2_SIGNED_80 == _zz__zz_decode_IS_RS2_SIGNED_81);
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = (_zz__zz_decode_IS_RS2_SIGNED_83 == _zz__zz_decode_IS_RS2_SIGNED_84);
+  assign _zz__zz_decode_IS_RS2_SIGNED_88 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_89) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = (_zz__zz_decode_IS_RS2_SIGNED_91 == _zz__zz_decode_IS_RS2_SIGNED_92);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = {_zz__zz_decode_IS_RS2_SIGNED_94,_zz__zz_decode_IS_RS2_SIGNED_96};
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (_zz__zz_decode_IS_RS2_SIGNED_101 == _zz__zz_decode_IS_RS2_SIGNED_102);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz__zz_decode_IS_RS2_SIGNED_104,{_zz__zz_decode_IS_RS2_SIGNED_106,_zz__zz_decode_IS_RS2_SIGNED_109}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (_zz__zz_decode_IS_RS2_SIGNED_116 == _zz__zz_decode_IS_RS2_SIGNED_117);
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_120};
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (_zz__zz_decode_IS_RS2_SIGNED_125 != 1'b0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (_zz__zz_decode_IS_RS2_SIGNED_128 != _zz__zz_decode_IS_RS2_SIGNED_131);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = {_zz__zz_decode_IS_RS2_SIGNED_133,{_zz__zz_decode_IS_RS2_SIGNED_141,_zz__zz_decode_IS_RS2_SIGNED_145}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_78 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_81 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_91 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_95) == 32'h00002020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_97) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_105) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = (_zz__zz_decode_IS_RS2_SIGNED_107 == _zz__zz_decode_IS_RS2_SIGNED_108);
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = {_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_111};
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_121) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (_zz__zz_decode_IS_RS2_SIGNED_129 == _zz__zz_decode_IS_RS2_SIGNED_130);
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ({_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_136} != 4'b0000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (_zz__zz_decode_IS_RS2_SIGNED_142 != _zz__zz_decode_IS_RS2_SIGNED_144);
+  assign _zz__zz_decode_IS_RS2_SIGNED_145 = {_zz__zz_decode_IS_RS2_SIGNED_146,{_zz__zz_decode_IS_RS2_SIGNED_152,_zz__zz_decode_IS_RS2_SIGNED_156}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = 32'h02002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_135) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {(_zz__zz_decode_IS_RS2_SIGNED_137 == _zz__zz_decode_IS_RS2_SIGNED_138),{_zz__zz_decode_IS_RS2_SIGNED_139,_zz__zz_decode_IS_RS2_SIGNED_140}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_146 = ({_zz__zz_decode_IS_RS2_SIGNED_147,{_zz__zz_decode_IS_RS2_SIGNED_148,_zz__zz_decode_IS_RS2_SIGNED_150}} != 3'b000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_152 = ({_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_155} != 2'b00);
+  assign _zz__zz_decode_IS_RS2_SIGNED_156 = {(_zz__zz_decode_IS_RS2_SIGNED_157 != _zz__zz_decode_IS_RS2_SIGNED_160),(_zz__zz_decode_IS_RS2_SIGNED_161 != _zz__zz_decode_IS_RS2_SIGNED_163)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = 32'h0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_147 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_149) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_151) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_154) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_155 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_157 = {(_zz__zz_decode_IS_RS2_SIGNED_158 == _zz__zz_decode_IS_RS2_SIGNED_159),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_160 = 2'b00;
+  assign _zz__zz_decode_IS_RS2_SIGNED_161 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_162) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = 1'b0;
+  assign _zz__zz_decode_IS_RS2_SIGNED_149 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_151 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_154 = 32'h00000014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_158 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_159 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_162 = 32'h00005048;
+  assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
+  assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
+  assign _zz_CsrPlugin_csrMapping_readDataInit_25 = 32'h0;
+  assign _zz_PmpPlugin_pmpaddr_port0 = PmpPlugin_pmpaddr[execute_PmpPlugin_fsm_fsmCounter];
+  always @(posedge clk) begin
+    if(_zz_1) begin
+      PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg_] <= _zz_PmpPlugin_pmpaddr_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_960) begin
-      _zz_654 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+  assign _zz_PmpPlugin_pmpaddr_port2 = PmpPlugin_pmpaddr[execute_PmpPlugin_pmpNcfg];
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs1Data) begin
+      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_42) begin
+  always @(posedge clk) begin
+    if(_zz_decode_RegFilePlugin_rs2Data) begin
+      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    end
+  end
+
+  always @(posedge clk) begin
+    if(_zz_2) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
+  PmpSetter PmpPlugin_setter (
+    .io_addr    (PmpPlugin_setter_io_addr  ), //i
+    .io_base    (PmpPlugin_setter_io_base  ), //o
+    .io_mask    (PmpPlugin_setter_io_mask  )  //o
+  );
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_625                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_626                                                     ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_627                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_628                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_629                                                     ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_630                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_631                                                     ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_632                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_633                                                     ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_572[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
-    .clk                                      (clk                                                         ), //i
-    .reset                                    (reset                                                       )  //i
+    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
+    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
+    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
+    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
+    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
+    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
+    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
+    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
+    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
+    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
+    .clk                                      (clk                                                   ), //i
+    .reset                                    (reset                                                 )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_634                                            ), //i
-    .io_cpu_execute_address                    (_zz_635[31:0]                                      ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_636                                            ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_637[31:0]                                      ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_638                                            ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_639                                            ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_640                                            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_641[31:0]                                      ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_642                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_643                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_644                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_645                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_646                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_647                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_648                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_649                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_650[3:0]                                       ), //i
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_651                                            ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_652                                            ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
-    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
-    .clk                                       (clk                                                ), //i
-    .reset                                     (reset                                              )  //i
+    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
+    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
+    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
+    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
+    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
+    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
+    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
+    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
+    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
+    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
+    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
+    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
+    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
+    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
+    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
+    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
+    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
+    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
+    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
+    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
+    .clk                                       (clk                                            ), //i
+    .reset                                     (reset                                          )  //i
   );
   always @(*) begin
-    case(_zz_961)
+    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
       2'b00 : begin
-        _zz_655 = DBusCachedPlugin_redoBranch_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_655 = CsrPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_655 = BranchPlugin_jumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_655 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_962)
-      3'b000 : begin
-        _zz_656 = _zz_391;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
+      2'b00 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
       end
-      3'b001 : begin
-        _zz_656 = _zz_392;
+      2'b01 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
       end
-      3'b010 : begin
-        _zz_656 = _zz_393;
-      end
-      3'b011 : begin
-        _zz_656 = _zz_394;
-      end
-      3'b100 : begin
-        _zz_656 = _zz_395;
-      end
-      3'b101 : begin
-        _zz_656 = _zz_396;
-      end
-      3'b110 : begin
-        _zz_656 = _zz_397;
+      2'b10 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
       end
       default : begin
-        _zz_656 = _zz_398;
+        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_963)
-      3'b000 : begin
-        _zz_657 = _zz_391;
-      end
-      3'b001 : begin
-        _zz_657 = _zz_392;
-      end
-      3'b010 : begin
-        _zz_657 = _zz_393;
-      end
-      3'b011 : begin
-        _zz_657 = _zz_394;
-      end
-      3'b100 : begin
-        _zz_657 = _zz_395;
-      end
-      3'b101 : begin
-        _zz_657 = _zz_396;
-      end
-      3'b110 : begin
-        _zz_657 = _zz_397;
+    case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
+      1'b0 : begin
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
       end
       default : begin
-        _zz_657 = _zz_398;
+        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_964)
-      3'b000 : begin
-        _zz_658 = _zz_391;
-      end
-      3'b001 : begin
-        _zz_658 = _zz_392;
-      end
-      3'b010 : begin
-        _zz_658 = _zz_393;
-      end
-      3'b011 : begin
-        _zz_658 = _zz_394;
-      end
-      3'b100 : begin
-        _zz_658 = _zz_395;
-      end
-      3'b101 : begin
-        _zz_658 = _zz_396;
-      end
-      3'b110 : begin
-        _zz_658 = _zz_397;
-      end
-      default : begin
-        _zz_658 = _zz_398;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_965)
-      3'b000 : begin
-        _zz_659 = _zz_391;
-      end
-      3'b001 : begin
-        _zz_659 = _zz_392;
-      end
-      3'b010 : begin
-        _zz_659 = _zz_393;
-      end
-      3'b011 : begin
-        _zz_659 = _zz_394;
-      end
-      3'b100 : begin
-        _zz_659 = _zz_395;
-      end
-      3'b101 : begin
-        _zz_659 = _zz_396;
-      end
-      3'b110 : begin
-        _zz_659 = _zz_397;
-      end
-      default : begin
-        _zz_659 = _zz_398;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_966)
-      3'b000 : begin
-        _zz_660 = _zz_391;
-      end
-      3'b001 : begin
-        _zz_660 = _zz_392;
-      end
-      3'b010 : begin
-        _zz_660 = _zz_393;
-      end
-      3'b011 : begin
-        _zz_660 = _zz_394;
-      end
-      3'b100 : begin
-        _zz_660 = _zz_395;
-      end
-      3'b101 : begin
-        _zz_660 = _zz_396;
-      end
-      3'b110 : begin
-        _zz_660 = _zz_397;
-      end
-      default : begin
-        _zz_660 = _zz_398;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_830)
-      3'b000 : begin
-        _zz_661 = _zz_391;
-      end
-      3'b001 : begin
-        _zz_661 = _zz_392;
-      end
-      3'b010 : begin
-        _zz_661 = _zz_393;
-      end
-      3'b011 : begin
-        _zz_661 = _zz_394;
-      end
-      3'b100 : begin
-        _zz_661 = _zz_395;
-      end
-      3'b101 : begin
-        _zz_661 = _zz_396;
-      end
-      3'b110 : begin
-        _zz_661 = _zz_397;
-      end
-      default : begin
-        _zz_661 = _zz_398;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_967)
+    case(execute_PmpPlugin_fsm_fsmCounter)
       4'b0000 : begin
-        _zz_662 = _zz_87;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_0;
       end
       4'b0001 : begin
-        _zz_662 = _zz_106;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_1;
       end
       4'b0010 : begin
-        _zz_662 = _zz_125;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_2;
       end
       4'b0011 : begin
-        _zz_662 = _zz_144;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_3;
       end
       4'b0100 : begin
-        _zz_662 = _zz_163;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_4;
       end
       4'b0101 : begin
-        _zz_662 = _zz_182;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_5;
       end
       4'b0110 : begin
-        _zz_662 = _zz_201;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_6;
       end
       4'b0111 : begin
-        _zz_662 = _zz_220;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_7;
       end
       4'b1000 : begin
-        _zz_662 = _zz_239;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_8;
       end
       4'b1001 : begin
-        _zz_662 = _zz_258;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_9;
       end
       4'b1010 : begin
-        _zz_662 = _zz_277;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_10;
       end
       4'b1011 : begin
-        _zz_662 = _zz_296;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_11;
       end
       4'b1100 : begin
-        _zz_662 = _zz_315;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_12;
       end
       4'b1101 : begin
-        _zz_662 = _zz_334;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_13;
       end
       4'b1110 : begin
-        _zz_662 = _zz_353;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_14;
       end
       default : begin
-        _zz_662 = _zz_372;
+        _zz_when_PmpPlugin_l246 = PmpPlugin_pmpcfg_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_968)
+    case(_zz_PmpPlugin_dGuard_hits_0_2)
       4'b0000 : begin
-        _zz_663 = _zz_88;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_0;
       end
       4'b0001 : begin
-        _zz_663 = _zz_107;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_1;
       end
       4'b0010 : begin
-        _zz_663 = _zz_126;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_2;
       end
       4'b0011 : begin
-        _zz_663 = _zz_145;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_3;
       end
       4'b0100 : begin
-        _zz_663 = _zz_164;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_4;
       end
       4'b0101 : begin
-        _zz_663 = _zz_183;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_5;
       end
       4'b0110 : begin
-        _zz_663 = _zz_202;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_6;
       end
       4'b0111 : begin
-        _zz_663 = _zz_221;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_7;
       end
       4'b1000 : begin
-        _zz_663 = _zz_240;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_8;
       end
       4'b1001 : begin
-        _zz_663 = _zz_259;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_9;
       end
       4'b1010 : begin
-        _zz_663 = _zz_278;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_10;
       end
       4'b1011 : begin
-        _zz_663 = _zz_297;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_11;
       end
       4'b1100 : begin
-        _zz_663 = _zz_316;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_12;
       end
       4'b1101 : begin
-        _zz_663 = _zz_335;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_13;
       end
       4'b1110 : begin
-        _zz_663 = _zz_354;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_14;
       end
       default : begin
-        _zz_663 = _zz_373;
+        _zz_PmpPlugin_dGuard_hits_0_1 = PmpPlugin_mask_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_969)
+    case(_zz_PmpPlugin_dGuard_hits_0_4)
       4'b0000 : begin
-        _zz_664 = _zz_89;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_0;
       end
       4'b0001 : begin
-        _zz_664 = _zz_108;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_1;
       end
       4'b0010 : begin
-        _zz_664 = _zz_127;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_2;
       end
       4'b0011 : begin
-        _zz_664 = _zz_146;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_3;
       end
       4'b0100 : begin
-        _zz_664 = _zz_165;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_4;
       end
       4'b0101 : begin
-        _zz_664 = _zz_184;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_5;
       end
       4'b0110 : begin
-        _zz_664 = _zz_203;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_6;
       end
       4'b0111 : begin
-        _zz_664 = _zz_222;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_7;
       end
       4'b1000 : begin
-        _zz_664 = _zz_241;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_8;
       end
       4'b1001 : begin
-        _zz_664 = _zz_260;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_9;
       end
       4'b1010 : begin
-        _zz_664 = _zz_279;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_10;
       end
       4'b1011 : begin
-        _zz_664 = _zz_298;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_11;
       end
       4'b1100 : begin
-        _zz_664 = _zz_317;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_12;
       end
       4'b1101 : begin
-        _zz_664 = _zz_336;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_13;
       end
       4'b1110 : begin
-        _zz_664 = _zz_355;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_14;
       end
       default : begin
-        _zz_664 = _zz_374;
+        _zz_PmpPlugin_dGuard_hits_0_3 = PmpPlugin_base_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_970)
-      3'b000 : begin
-        _zz_665 = _zz_450;
-      end
-      3'b001 : begin
-        _zz_665 = _zz_451;
-      end
-      3'b010 : begin
-        _zz_665 = _zz_452;
-      end
-      3'b011 : begin
-        _zz_665 = _zz_453;
-      end
-      3'b100 : begin
-        _zz_665 = _zz_454;
-      end
-      3'b101 : begin
-        _zz_665 = _zz_455;
-      end
-      3'b110 : begin
-        _zz_665 = _zz_456;
-      end
-      default : begin
-        _zz_665 = _zz_457;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_971)
-      3'b000 : begin
-        _zz_666 = _zz_450;
-      end
-      3'b001 : begin
-        _zz_666 = _zz_451;
-      end
-      3'b010 : begin
-        _zz_666 = _zz_452;
-      end
-      3'b011 : begin
-        _zz_666 = _zz_453;
-      end
-      3'b100 : begin
-        _zz_666 = _zz_454;
-      end
-      3'b101 : begin
-        _zz_666 = _zz_455;
-      end
-      3'b110 : begin
-        _zz_666 = _zz_456;
-      end
-      default : begin
-        _zz_666 = _zz_457;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_972)
-      3'b000 : begin
-        _zz_667 = _zz_450;
-      end
-      3'b001 : begin
-        _zz_667 = _zz_451;
-      end
-      3'b010 : begin
-        _zz_667 = _zz_452;
-      end
-      3'b011 : begin
-        _zz_667 = _zz_453;
-      end
-      3'b100 : begin
-        _zz_667 = _zz_454;
-      end
-      3'b101 : begin
-        _zz_667 = _zz_455;
-      end
-      3'b110 : begin
-        _zz_667 = _zz_456;
-      end
-      default : begin
-        _zz_667 = _zz_457;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_973)
-      3'b000 : begin
-        _zz_668 = _zz_450;
-      end
-      3'b001 : begin
-        _zz_668 = _zz_451;
-      end
-      3'b010 : begin
-        _zz_668 = _zz_452;
-      end
-      3'b011 : begin
-        _zz_668 = _zz_453;
-      end
-      3'b100 : begin
-        _zz_668 = _zz_454;
-      end
-      3'b101 : begin
-        _zz_668 = _zz_455;
-      end
-      3'b110 : begin
-        _zz_668 = _zz_456;
-      end
-      default : begin
-        _zz_668 = _zz_457;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_974)
-      3'b000 : begin
-        _zz_669 = _zz_450;
-      end
-      3'b001 : begin
-        _zz_669 = _zz_451;
-      end
-      3'b010 : begin
-        _zz_669 = _zz_452;
-      end
-      3'b011 : begin
-        _zz_669 = _zz_453;
-      end
-      3'b100 : begin
-        _zz_669 = _zz_454;
-      end
-      3'b101 : begin
-        _zz_669 = _zz_455;
-      end
-      3'b110 : begin
-        _zz_669 = _zz_456;
-      end
-      default : begin
-        _zz_669 = _zz_457;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_840)
-      3'b000 : begin
-        _zz_670 = _zz_450;
-      end
-      3'b001 : begin
-        _zz_670 = _zz_451;
-      end
-      3'b010 : begin
-        _zz_670 = _zz_452;
-      end
-      3'b011 : begin
-        _zz_670 = _zz_453;
-      end
-      3'b100 : begin
-        _zz_670 = _zz_454;
-      end
-      3'b101 : begin
-        _zz_670 = _zz_455;
-      end
-      3'b110 : begin
-        _zz_670 = _zz_456;
-      end
-      default : begin
-        _zz_670 = _zz_457;
-      end
-    endcase
-  end
-
-  always @(*) begin
-    case(_zz_975)
+    case(_zz_PmpPlugin_dGuard_hits_1_1)
       4'b0000 : begin
-        _zz_671 = _zz_87;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_0;
       end
       4'b0001 : begin
-        _zz_671 = _zz_106;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_1;
       end
       4'b0010 : begin
-        _zz_671 = _zz_125;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_2;
       end
       4'b0011 : begin
-        _zz_671 = _zz_144;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_3;
       end
       4'b0100 : begin
-        _zz_671 = _zz_163;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_4;
       end
       4'b0101 : begin
-        _zz_671 = _zz_182;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_5;
       end
       4'b0110 : begin
-        _zz_671 = _zz_201;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_6;
       end
       4'b0111 : begin
-        _zz_671 = _zz_220;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_7;
       end
       4'b1000 : begin
-        _zz_671 = _zz_239;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_8;
       end
       4'b1001 : begin
-        _zz_671 = _zz_258;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_9;
       end
       4'b1010 : begin
-        _zz_671 = _zz_277;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_10;
       end
       4'b1011 : begin
-        _zz_671 = _zz_296;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_11;
       end
       4'b1100 : begin
-        _zz_671 = _zz_315;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_12;
       end
       4'b1101 : begin
-        _zz_671 = _zz_334;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_13;
       end
       4'b1110 : begin
-        _zz_671 = _zz_353;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_14;
       end
       default : begin
-        _zz_671 = _zz_372;
+        _zz_PmpPlugin_dGuard_hits_1 = PmpPlugin_mask_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_976)
+    case(_zz_PmpPlugin_dGuard_hits_1_3)
       4'b0000 : begin
-        _zz_672 = _zz_88;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_0;
       end
       4'b0001 : begin
-        _zz_672 = _zz_107;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_1;
       end
       4'b0010 : begin
-        _zz_672 = _zz_126;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_2;
       end
       4'b0011 : begin
-        _zz_672 = _zz_145;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_3;
       end
       4'b0100 : begin
-        _zz_672 = _zz_164;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_4;
       end
       4'b0101 : begin
-        _zz_672 = _zz_183;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_5;
       end
       4'b0110 : begin
-        _zz_672 = _zz_202;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_6;
       end
       4'b0111 : begin
-        _zz_672 = _zz_221;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_7;
       end
       4'b1000 : begin
-        _zz_672 = _zz_240;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_8;
       end
       4'b1001 : begin
-        _zz_672 = _zz_259;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_9;
       end
       4'b1010 : begin
-        _zz_672 = _zz_278;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_10;
       end
       4'b1011 : begin
-        _zz_672 = _zz_297;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_11;
       end
       4'b1100 : begin
-        _zz_672 = _zz_316;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_12;
       end
       4'b1101 : begin
-        _zz_672 = _zz_335;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_13;
       end
       4'b1110 : begin
-        _zz_672 = _zz_354;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_14;
       end
       default : begin
-        _zz_672 = _zz_373;
+        _zz_PmpPlugin_dGuard_hits_1_2 = PmpPlugin_base_15;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_977)
+    case(_zz_PmpPlugin_dGuard_hits_2_1)
       4'b0000 : begin
-        _zz_673 = _zz_89;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_0;
       end
       4'b0001 : begin
-        _zz_673 = _zz_108;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_1;
       end
       4'b0010 : begin
-        _zz_673 = _zz_127;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_2;
       end
       4'b0011 : begin
-        _zz_673 = _zz_146;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_3;
       end
       4'b0100 : begin
-        _zz_673 = _zz_165;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_4;
       end
       4'b0101 : begin
-        _zz_673 = _zz_184;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_5;
       end
       4'b0110 : begin
-        _zz_673 = _zz_203;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_6;
       end
       4'b0111 : begin
-        _zz_673 = _zz_222;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_7;
       end
       4'b1000 : begin
-        _zz_673 = _zz_241;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_8;
       end
       4'b1001 : begin
-        _zz_673 = _zz_260;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_9;
       end
       4'b1010 : begin
-        _zz_673 = _zz_279;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_10;
       end
       4'b1011 : begin
-        _zz_673 = _zz_298;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_11;
       end
       4'b1100 : begin
-        _zz_673 = _zz_317;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_12;
       end
       4'b1101 : begin
-        _zz_673 = _zz_336;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_13;
       end
       4'b1110 : begin
-        _zz_673 = _zz_355;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_14;
       end
       default : begin
-        _zz_673 = _zz_374;
+        _zz_PmpPlugin_dGuard_hits_2 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_2_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_2_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_3_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_3 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_3_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_3_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_4_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_4 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_4_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_4_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_5_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_5 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_5_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_5_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_6_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_6 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_6_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_6_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_7_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_7 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_7_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_7_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_8_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_8 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_8_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_8_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_9_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_9 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_9_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_9_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_10_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_10 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_10_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_10_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_11_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_11 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_11_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_11_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_12_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_12 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_12_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_12_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_13_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_13 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_13_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_13_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_14_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_14 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_14_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_14_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_15_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_15 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_dGuard_hits_15_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_dGuard_hits_15_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_0_2)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_0_1 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_0_4)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_0_3 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_1_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_1 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_1_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_1_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_2_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_2 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_2_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_2_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_3_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_3 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_3_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_3_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_4_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_4 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_4_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_4_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_5_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_5 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_5_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_5_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_6_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_6 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_6_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_6_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_7_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_7 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_7_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_7_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_8_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_8 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_8_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_8_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_9_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_9 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_9_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_9_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_10_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_10 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_10_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_10_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_11_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_11 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_11_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_11_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_12_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_12 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_12_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_12_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_13_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_13 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_13_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_13_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_14_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_14 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_14_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_14_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_15_1)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_15 = PmpPlugin_mask_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_PmpPlugin_iGuard_hits_15_3)
+      4'b0000 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_0;
+      end
+      4'b0001 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_1;
+      end
+      4'b0010 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_2;
+      end
+      4'b0011 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_3;
+      end
+      4'b0100 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_4;
+      end
+      4'b0101 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_5;
+      end
+      4'b0110 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_6;
+      end
+      4'b0111 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_7;
+      end
+      4'b1000 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_8;
+      end
+      4'b1001 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_9;
+      end
+      4'b1010 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_10;
+      end
+      4'b1011 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_11;
+      end
+      4'b1100 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_12;
+      end
+      4'b1101 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_13;
+      end
+      4'b1110 : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_14;
+      end
+      default : begin
+        _zz_PmpPlugin_iGuard_hits_15_2 = PmpPlugin_base_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_1)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_1_2)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209_1_1 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_2_1)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209_2 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_when_PmpPlugin_l209_3_1)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l209_3 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(execute_PmpPlugin_pmpNcfg_)
+      4'b0000 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_when_PmpPlugin_l216 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_1)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_3)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_2 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_5)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_4 = PmpPlugin_pmpcfg_15;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_CsrPlugin_csrMapping_readDataSignal_7)
+      4'b0000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_0;
+      end
+      4'b0001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_1;
+      end
+      4'b0010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_2;
+      end
+      4'b0011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_3;
+      end
+      4'b0100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_4;
+      end
+      4'b0101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_5;
+      end
+      4'b0110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_6;
+      end
+      4'b0111 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_7;
+      end
+      4'b1000 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_8;
+      end
+      4'b1001 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_9;
+      end
+      4'b1010 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_10;
+      end
+      4'b1011 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_11;
+      end
+      4'b1100 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_12;
+      end
+      4'b1101 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_13;
+      end
+      4'b1110 : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_14;
+      end
+      default : begin
+        _zz_CsrPlugin_csrMapping_readDataSignal_6 = PmpPlugin_pmpcfg_15;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
-      default : _zz_1_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
-      default : _zz_2_string = "?????";
+    case(_zz_memory_to_writeBack_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
-      default : _zz_3_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
-      default : _zz_4_string = "?????";
+    case(_zz_execute_to_memory_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3385,134 +6286,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
-      default : _zz_5_string = "?????";
+    case(_zz_decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
-      default : _zz_6_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
-      default : _zz_7_string = "?????";
+    case(_zz_decode_to_execute_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+    case(_zz_decode_to_execute_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
+    case(_zz_execute_to_memory_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_SHIFT_CTRL_string = "SRA    ";
+      default : decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_13)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
-      default : _zz_13_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_14)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
-      default : _zz_14_string = "?????????";
+    case(_zz_decode_to_execute_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -3525,30 +6426,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_decode_to_execute_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
@@ -3560,27 +6461,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_decode_to_execute_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3593,30 +6494,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_decode_to_execute_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3629,12 +6530,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3647,12 +6548,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3665,12 +6566,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3683,48 +6584,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : memory_SHIFT_CTRL_string = "SRA    ";
+      default : memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_memory_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_SHIFT_CTRL_string = "SRA    ";
+      default : execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_execute_SHIFT_CTRL_string = "SRA    ";
+      default : _zz_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -3737,12 +6638,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -3755,12 +6656,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3772,88 +6673,88 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : execute_ALU_BITWISE_CTRL_string = "AND";
+      default : execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
+    case(_zz_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : _zz_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
+    case(_zz_decode_ENV_CTRL_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
+    case(_zz_decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_1)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_1_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_1_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_1_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_1_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_1_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_1)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
+    case(_zz_decode_SRC2_CTRL_1)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+    case(_zz_decode_ALU_CTRL_1)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_1)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3866,73 +6767,73 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_51)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
-      default : _zz_51_string = "????";
+    case(_zz_decode_BRANCH_CTRL_1)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_514)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_514_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_514_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_514_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_514_string = "URS1        ";
-      default : _zz_514_string = "????????????";
+    case(_zz_decode_SRC1_CTRL_2)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_515)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_515_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_515_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_515_string = "BITWISE ";
-      default : _zz_515_string = "????????";
+    case(_zz_decode_ALU_CTRL_2)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_516)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_516_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_516_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_516_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_516_string = "PC ";
-      default : _zz_516_string = "???";
+    case(_zz_decode_SRC2_CTRL_2)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_517)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_517_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_517_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_517_string = "AND_1";
-      default : _zz_517_string = "?????";
+    case(_zz_decode_ALU_BITWISE_CTRL_2)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND";
+      default : _zz_decode_ALU_BITWISE_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_518)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_518_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_518_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_518_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_518_string = "SRA_1    ";
-      default : _zz_518_string = "?????????";
+    case(_zz_decode_SHIFT_CTRL_2)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : _zz_decode_SHIFT_CTRL_2_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : _zz_decode_SHIFT_CTRL_2_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : _zz_decode_SHIFT_CTRL_2_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : _zz_decode_SHIFT_CTRL_2_string = "SRA    ";
+      default : _zz_decode_SHIFT_CTRL_2_string = "???????";
     endcase
   end
   always @(*) begin
-    case(_zz_519)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_519_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_519_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_519_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_519_string = "JALR";
-      default : _zz_519_string = "????";
+    case(_zz_decode_BRANCH_CTRL_2)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_520)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_520_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_520_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_520_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_520_string = "ECALL";
-      default : _zz_520_string = "?????";
+    case(_zz_decode_ENV_CTRL_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3963,28 +6864,28 @@ module VexRiscv (
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : decode_to_execute_ALU_BITWISE_CTRL_string = "OR ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : decode_to_execute_ALU_BITWISE_CTRL_string = "AND";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : decode_to_execute_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : decode_to_execute_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : decode_to_execute_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : decode_to_execute_SHIFT_CTRL_string = "SRA    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+      `ShiftCtrlEnum_defaultEncoding_DISABLE : execute_to_memory_SHIFT_CTRL_string = "DISABLE";
+      `ShiftCtrlEnum_defaultEncoding_SLL : execute_to_memory_SHIFT_CTRL_string = "SLL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL : execute_to_memory_SHIFT_CTRL_string = "SRL    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA : execute_to_memory_SHIFT_CTRL_string = "SRA    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "???????";
     endcase
   end
   always @(*) begin
@@ -4023,9 +6924,50 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
+  always @(*) begin
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_BOOT      ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateIdle ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateWrite";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateCfg  ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : execute_PmpPlugin_fsm_stateReg_string = "execute_PmpPlugin_fsm_stateAddr ";
+      default : execute_PmpPlugin_fsm_stateReg_string = "????????????????????????????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_PmpPlugin_fsm_stateNext)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_BOOT      ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateIdle ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateWrite";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateCfg  ";
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : execute_PmpPlugin_fsm_stateNext_string = "execute_PmpPlugin_fsm_stateAddr ";
+      default : execute_PmpPlugin_fsm_stateNext_string = "????????????????????????????????";
+    endcase
+  end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_733) + $signed(_zz_741));
+  always @(*) begin
+    _zz_1 = 1'b0;
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
+        if(execute_PmpPlugin_pmpaddrCsr_) begin
+          if(when_PmpPlugin_l216) begin
+            _zz_1 = 1'b1;
+          end
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
+      end
+      default : begin
+      end
+    endcase
+  end
+
+  assign memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW) + $signed(_zz_memory_MUL_LOW_7));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
@@ -4033,45 +6975,45 @@ module VexRiscv (
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_743;
-  assign execute_REGFILE_WRITE_DATA = _zz_522;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_635[1 : 0];
+  assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
+  assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
+  assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
+  assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_745[0];
-  assign decode_IS_RS1_SIGNED = _zz_746[0];
-  assign decode_IS_DIV = _zz_747[0];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[30];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[29];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_748[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
-  assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_749[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
-  assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
-  assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_750[0];
-  assign decode_MEMORY_MANAGMENT = _zz_751[0];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[28];
+  assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
+  assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
+  assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
+  assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[25];
+  assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
+  assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
+  assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
+  assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[17];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[16];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_752[0];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_753[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_754[0];
-  assign decode_SRC2_CTRL = _zz_18;
-  assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
-  assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
-  assign _zz_25 = _zz_26;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
+  assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
+  assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign decode_SRC1_CTRL = _zz_decode_SRC1_CTRL;
+  assign _zz_decode_to_execute_SRC1_CTRL = _zz_decode_to_execute_SRC1_CTRL_1;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
@@ -4079,7 +7021,7 @@ module VexRiscv (
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_755[0];
+  assign decode_IS_EBREAK = _zz_decode_IS_RS2_SIGNED[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -4093,22 +7035,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
+  assign memory_ENV_CTRL = _zz_memory_ENV_CTRL;
+  assign execute_ENV_CTRL = _zz_execute_ENV_CTRL;
+  assign writeBack_ENV_CTRL = _zz_writeBack_ENV_CTRL;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_544;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_756[0];
-  assign decode_RS1_USE = _zz_757[0];
-  always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_674)begin
-      _zz_31 = execute_CsrPlugin_readData;
+  assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
+  assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  always @(*) begin
+    _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
+    if(when_CsrPlugin_l1176) begin
+      _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
 
@@ -4118,139 +7060,139 @@ module VexRiscv (
   assign memory_INSTRUCTION = execute_to_memory_INSTRUCTION;
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
+  always @(*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_533)begin
-      if((_zz_534 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_535;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr1Match) begin
+        decode_RS2 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_675)begin
-      if(_zz_676)begin
-        if(_zz_537)begin
-          decode_RS2 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l51) begin
+          decode_RS2 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_677)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_539)begin
-          decode_RS2 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          decode_RS2 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_678)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_541)begin
-          decode_RS2 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          decode_RS2 = _zz_decode_RS2;
         end
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_533)begin
-      if((_zz_534 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_535;
+    if(HazardSimplePlugin_writeBackBuffer_valid) begin
+      if(HazardSimplePlugin_addr0Match) begin
+        decode_RS1 = HazardSimplePlugin_writeBackBuffer_payload_data;
       end
     end
-    if(_zz_675)begin
-      if(_zz_676)begin
-        if(_zz_536)begin
-          decode_RS1 = _zz_50;
+    if(when_HazardSimplePlugin_l45) begin
+      if(when_HazardSimplePlugin_l47) begin
+        if(when_HazardSimplePlugin_l48) begin
+          decode_RS1 = _zz_decode_RS2_2;
         end
       end
     end
-    if(_zz_677)begin
-      if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_538)begin
-          decode_RS1 = _zz_32;
+    if(when_HazardSimplePlugin_l45_1) begin
+      if(memory_BYPASSABLE_MEMORY_STAGE) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          decode_RS1 = _zz_decode_RS2_1;
         end
       end
     end
-    if(_zz_678)begin
-      if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_540)begin
-          decode_RS1 = _zz_31;
+    if(when_HazardSimplePlugin_l45_2) begin
+      if(execute_BYPASSABLE_EXECUTE_STAGE) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          decode_RS1 = _zz_decode_RS2;
         end
       end
     end
   end
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
-  always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
-    if(memory_arbitration_isValid)begin
+  always @(*) begin
+    _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
+    if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_530;
+        `ShiftCtrlEnum_defaultEncoding_SLL : begin
+          _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+        `ShiftCtrlEnum_defaultEncoding_SRL, `ShiftCtrlEnum_defaultEncoding_SRA : begin
+          _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_679)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(when_MulDivIterativePlugin_l128) begin
+      _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_memory_SHIFT_CTRL;
+  assign execute_SHIFT_CTRL = _zz_execute_SHIFT_CTRL;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_758[0];
-  assign decode_SRC_ADD_ZERO = _zz_759[0];
+  assign _zz_execute_SRC2 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
+  assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[20];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_528;
-  assign execute_SRC1 = _zz_523;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
-  always @ (*) begin
-    _zz_42 = 1'b0;
-    if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+  assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
+  assign execute_SRC2 = _zz_execute_SRC2_5;
+  assign execute_SRC1 = _zz_execute_SRC1;
+  assign execute_ALU_BITWISE_CTRL = _zz_execute_ALU_BITWISE_CTRL;
+  assign _zz_lastStageRegFileWrite_payload_address = writeBack_INSTRUCTION;
+  assign _zz_lastStageRegFileWrite_valid = writeBack_REGFILE_WRITE_VALID;
+  always @(*) begin
+    _zz_2 = 1'b0;
+    if(lastStageRegFileWrite_valid) begin
+      _zz_2 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
-  always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_760[0];
-    if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
+  always @(*) begin
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_978) == 32'h00001073),{(_zz_979 == _zz_980),{_zz_981,{_zz_982,_zz_983}}}}}}} != 21'h0);
-  always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
-    if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  always @(*) begin
+    _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
+    if(when_DBusCachedPlugin_l484) begin
+      _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
-    if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_732)
+    if(when_MulPlugin_l147) begin
+      case(switch_MulPlugin_l148)
         2'b00 : begin
-          _zz_50 = _zz_870;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2;
         end
         default : begin
-          _zz_50 = _zz_871;
+          _zz_decode_RS2_2 = _zz__zz_decode_RS2_2_1;
         end
       endcase
     end
   end
 
-  assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_WR = memory_to_writeBack_MEMORY_WR;
+  assign writeBack_MEMORY_STORE_DATA_RF = memory_to_writeBack_MEMORY_STORE_DATA_RF;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
@@ -4262,61 +7204,61 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_761[0];
-  assign decode_FLUSH_ALL = _zz_762[0];
-  always @ (*) begin
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
+  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_680)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_681)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_682)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_683)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
-    if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+  always @(*) begin
+    _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
+    if(BranchPlugin_jumpInterface_valid) begin
+      _zz_memory_to_writeBack_FORMAL_PC_NEXT = BranchPlugin_jumpInterface_payload;
     end
   end
 
-  always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+  always @(*) begin
+    _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
+    if(when_DBusCachedPlugin_l303) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_572)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -4325,166 +7267,171 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_531 || _zz_532)))begin
+    if(when_HazardSimplePlugin_l113) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(CsrPlugin_pipelineLiberator_active)begin
+    if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
+    if(when_CsrPlugin_l1116) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_684)begin
+    if(_zz_when) begin
       decode_arbitration_removeIt = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       decode_arbitration_removeIt = 1'b1;
     end
   end
 
   assign decode_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid)begin
+    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_684)begin
+    if(_zz_when) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_651 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(when_DBusCachedPlugin_l343) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_685)begin
-      if((! execute_CsrPlugin_wfiWake))begin
+    if(when_CsrPlugin_l1108) begin
+      if(when_CsrPlugin_l1110) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_674)begin
-      if(execute_CsrPlugin_blockedBySideEffects)begin
+    if(when_CsrPlugin_l1180) begin
+      if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
+      end
+    end
+    if(execute_CsrPlugin_writeInstruction) begin
+      if(when_PmpPlugin_l172) begin
+        execute_arbitration_haltItself = (! execute_PmpPlugin_fsmComplete);
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+    if(when_DBusCachedPlugin_l359) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_686)begin
+    if(when_DebugPlugin_l284) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_removeIt = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       execute_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_686)begin
-      if(_zz_687)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_686)begin
-      if(_zz_687)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_679)begin
-      if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l129) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
   end
 
   assign memory_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_removeIt = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       memory_arbitration_removeIt = 1'b1;
     end
   end
 
   assign memory_arbitration_flushIt = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
+    if(BranchPlugin_jumpInterface_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1_io_cpu_writeBack_haltIt)begin
+    if(when_DBusCachedPlugin_l458) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
 
   assign writeBack_arbitration_haltByOther = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_removeIt = 1'b0;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       writeBack_arbitration_removeIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushIt = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushIt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(DBusCachedPlugin_redoBranch_valid)begin
+    if(DBusCachedPlugin_redoBranch_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_688)begin
+    if(when_CsrPlugin_l1019) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_689)begin
+    if(when_CsrPlugin_l1064) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4493,75 +7440,108 @@ module VexRiscv (
   assign lastStagePc = writeBack_PC;
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
+    if(when_CsrPlugin_l922) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_688)begin
+    if(when_CsrPlugin_l1019) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_689)begin
+    if(when_CsrPlugin_l1064) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_686)begin
-      if(_zz_687)begin
+    if(when_DebugPlugin_l284) begin
+      if(when_DebugPlugin_l287) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_690)begin
+    if(when_DebugPlugin_l300) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if((IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid))begin
+    if(when_Fetcher_l240) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_54 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_54 = 1'b1;
+  always @(*) begin
+    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    if(DebugPlugin_godmode) begin
+      _zz_when_DBusCachedPlugin_l386 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
+    CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
+    if(execute_CsrPlugin_readInstruction) begin
+      if(when_PmpPlugin_l155) begin
+        if(execute_PmpPlugin_pmpcfgCsr) begin
+          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+        end
+        if(execute_PmpPlugin_pmpaddrCsr) begin
+          CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+        end
+      end
+    end
+    if(execute_CsrPlugin_writeInstruction) begin
+      if(when_PmpPlugin_l172) begin
+        CsrPlugin_csrMapping_allowCsrSignal = 1'b1;
+      end
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
+    if(execute_CsrPlugin_readInstruction) begin
+      if(when_PmpPlugin_l155) begin
+        if(execute_PmpPlugin_pmpcfgCsr) begin
+          CsrPlugin_csrMapping_readDataSignal = {{{_zz_CsrPlugin_csrMapping_readDataSignal,_zz_CsrPlugin_csrMapping_readDataSignal_2},_zz_CsrPlugin_csrMapping_readDataSignal_4},_zz_CsrPlugin_csrMapping_readDataSignal_6};
+        end
+        if(execute_PmpPlugin_pmpaddrCsr) begin
+          CsrPlugin_csrMapping_readDataSignal = _zz_PmpPlugin_pmpaddr_port2;
+        end
+      end
+    end
+  end
+
+  always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_685)begin
+    if(when_CsrPlugin_l1108) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
+    if(DebugPlugin_haltIt) begin
       CsrPlugin_thirdPartyWake = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_688)begin
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_689)begin
+    if(when_CsrPlugin_l1064) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_688)begin
+  always @(*) begin
+    CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(when_CsrPlugin_l1019) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_689)begin
-      case(_zz_691)
+    if(when_CsrPlugin_l1064) begin
+      case(switch_CsrPlugin_l1068)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4571,80 +7551,92 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_forceMachineWire = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
+    if(when_DebugPlugin_l316) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
+    if(DebugPlugin_godmode) begin
       CsrPlugin_allowException = 1'b0;
+    end
+  end
+
+  always @(*) begin
+    CsrPlugin_allowEbreakException = 1'b1;
+    if(DebugPlugin_allowEBreak) begin
+      CsrPlugin_allowEbreakException = 1'b0;
     end
   end
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_763));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_655;
-  always @ (*) begin
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  always @(*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_correction = 1'b1;
     end
   end
 
+  assign when_Fetcher_l127 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
   assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_765);
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l131_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l131_2 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  always @(*) begin
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
     end
     IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
     IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid)begin
+    if(IBusCachedPlugin_fetchPc_redo_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid)begin
+    if(IBusCachedPlugin_jump_pcLoad_valid) begin
       IBusCachedPlugin_fetchPc_flushed = 1'b1;
     end
   end
 
+  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch)begin
+    if(IBusCachedPlugin_rsp_redoFetch) begin
       IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
     end
   end
@@ -4652,66 +7644,75 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt)begin
+    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
       IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy)begin
+    if(IBusCachedPlugin_mmuBus_busy) begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if(when_IBusCachedPlugin_l267) begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_2_input_ready);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
-  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64 = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1 = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_1;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
-  always @ (*) begin
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid)) || IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload = _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_ready = IBusCachedPlugin_iBusRsp_stages_2_input_ready;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
+  always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if((! IBusCachedPlugin_pcValids_0))begin
+    if(when_Fetcher_l320) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
+  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  always @ (*) begin
+  always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_572)
+    case(switch_Fetcher_l362)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -4723,207 +7724,213 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_69 = _zz_766[11];
-  always @ (*) begin
-    _zz_70[18] = _zz_69;
-    _zz_70[17] = _zz_69;
-    _zz_70[16] = _zz_69;
-    _zz_70[15] = _zz_69;
-    _zz_70[14] = _zz_69;
-    _zz_70[13] = _zz_69;
-    _zz_70[12] = _zz_69;
-    _zz_70[11] = _zz_69;
-    _zz_70[10] = _zz_69;
-    _zz_70[9] = _zz_69;
-    _zz_70[8] = _zz_69;
-    _zz_70[7] = _zz_69;
-    _zz_70[6] = _zz_69;
-    _zz_70[5] = _zz_69;
-    _zz_70[4] = _zz_69;
-    _zz_70[3] = _zz_69;
-    _zz_70[2] = _zz_69;
-    _zz_70[1] = _zz_69;
-    _zz_70[0] = _zz_69;
+  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_767[31]));
-    if(_zz_75)begin
+  always @(*) begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    if(_zz_7) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_71 = _zz_768[19];
-  always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+  assign _zz_3 = _zz__zz_3[19];
+  always @(*) begin
+    _zz_4[10] = _zz_3;
+    _zz_4[9] = _zz_3;
+    _zz_4[8] = _zz_3;
+    _zz_4[7] = _zz_3;
+    _zz_4[6] = _zz_3;
+    _zz_4[5] = _zz_3;
+    _zz_4[4] = _zz_3;
+    _zz_4[3] = _zz_3;
+    _zz_4[2] = _zz_3;
+    _zz_4[1] = _zz_3;
+    _zz_4[0] = _zz_3;
   end
 
-  assign _zz_73 = _zz_769[11];
-  always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+  assign _zz_5 = _zz__zz_5[11];
+  always @(*) begin
+    _zz_6[18] = _zz_5;
+    _zz_6[17] = _zz_5;
+    _zz_6[16] = _zz_5;
+    _zz_6[15] = _zz_5;
+    _zz_6[14] = _zz_5;
+    _zz_6[13] = _zz_5;
+    _zz_6[12] = _zz_5;
+    _zz_6[11] = _zz_5;
+    _zz_6[10] = _zz_5;
+    _zz_6[9] = _zz_5;
+    _zz_6[8] = _zz_5;
+    _zz_6[7] = _zz_5;
+    _zz_6[6] = _zz_5;
+    _zz_6[5] = _zz_5;
+    _zz_6[4] = _zz_5;
+    _zz_6[3] = _zz_5;
+    _zz_6[2] = _zz_5;
+    _zz_6[1] = _zz_5;
+    _zz_6[0] = _zz_5;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75 = _zz_770[1];
+        _zz_7 = _zz__zz_7[1];
       end
       default : begin
-        _zz_75 = _zz_771[1];
+        _zz_7 = _zz__zz_7_1[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76 = _zz_772[19];
-  always @ (*) begin
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_78 = _zz_773[11];
-  always @ (*) begin
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15] = _zz_78;
-    _zz_79[14] = _zz_78;
-    _zz_79[13] = _zz_78;
-    _zz_79[12] = _zz_78;
-    _zz_79[11] = _zz_78;
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  always @(*) begin
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_996,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_997,_zz_998},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
-  always @ (*) begin
+  always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   end
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_626 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_627 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_628 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_627;
+  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_630 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_631 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_632 = (CsrPlugin_privilege == 2'b00);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isValid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign IBusCachedPlugin_cache_io_cpu_decode_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_cache_io_cpu_decode_isUser = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_683)begin
+    if(when_IBusCachedPlugin_l239) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_681)begin
+    if(when_IBusCachedPlugin_l250) begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_633 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_681)begin
-      _zz_633 = 1'b1;
+  always @(*) begin
+    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(when_IBusCachedPlugin_l250) begin
+      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_682)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_680)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_682)begin
+    if(when_IBusCachedPlugin_l244) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_680)begin
+    if(when_IBusCachedPlugin_l256) begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
   assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
+  assign when_IBusCachedPlugin_l239 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign when_IBusCachedPlugin_l244 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_decode_isValid && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign when_IBusCachedPlugin_l267 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_625 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_652 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_ready = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
-  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_size = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_size : dataCache_1_io_mem_cmd_payload_size);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign when_Stream_l365 = (dataCache_1_io_mem_cmd_ready && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
   assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_rData_address_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_rData_data_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size = dataCache_1_io_mem_cmd_s2mPipe_rData_size_1;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_rData_last_1;
   assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
   assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
@@ -4931,2143 +7938,350 @@ module VexRiscv (
   assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
   assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_634 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_635 = execute_SRC_ADD;
-  always @ (*) begin
+  assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
+  always @(*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_execute_MEMORY_STORE_DATA_RF = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82 = execute_RS2[31 : 0];
+        _zz_execute_MEMORY_STORE_DATA_RF = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_651 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_636 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_637 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_636;
+  assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign when_DBusCachedPlugin_l343 = ((dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_637;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = dataCache_1_io_cpu_memory_address;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
-  always @ (*) begin
-    _zz_638 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_638 = 1'b1;
+  always @(*) begin
+    dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if(when_DBusCachedPlugin_l386) begin
+      dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign _zz_639 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_640 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_641 = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  always @(*) begin
+    dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    if(writeBack_arbitration_haltByOther) begin
+      dataCache_1_io_cpu_writeBack_isValid = 1'b0;
+    end
+  end
+
+  assign dataCache_1_io_cpu_writeBack_isUser = (CsrPlugin_privilege == 2'b00);
+  assign dataCache_1_io_cpu_writeBack_address = writeBack_REGFILE_WRITE_DATA;
+  assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
+  always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_692)begin
-      if(dataCache_1_io_cpu_redo)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
   end
 
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_692)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1_io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
   end
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
-  always @ (*) begin
+  always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_692)begin
-      if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_774};
+    if(when_DBusCachedPlugin_l438) begin
+      if(dataCache_1_io_cpu_writeBack_accessError) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
-      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException) begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_775};
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess) begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code_1};
       end
     end
   end
 
-  always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
-    case(writeBack_MEMORY_ADDRESS_LOW)
-      2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
-      end
-      2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
-      end
-      2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
-      end
-      default : begin
-      end
-    endcase
+  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
+  assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
+  assign writeBack_DBusCachedPlugin_rspSplits_3 = dataCache_1_io_cpu_writeBack_data[31 : 24];
+  always @(*) begin
+    writeBack_DBusCachedPlugin_rspShifted[7 : 0] = _zz_writeBack_DBusCachedPlugin_rspShifted;
+    writeBack_DBusCachedPlugin_rspShifted[15 : 8] = _zz_writeBack_DBusCachedPlugin_rspShifted_2;
+    writeBack_DBusCachedPlugin_rspShifted[23 : 16] = writeBack_DBusCachedPlugin_rspSplits_2;
+    writeBack_DBusCachedPlugin_rspShifted[31 : 24] = writeBack_DBusCachedPlugin_rspSplits_3;
   end
 
-  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_84[31] = _zz_83;
-    _zz_84[30] = _zz_83;
-    _zz_84[29] = _zz_83;
-    _zz_84[28] = _zz_83;
-    _zz_84[27] = _zz_83;
-    _zz_84[26] = _zz_83;
-    _zz_84[25] = _zz_83;
-    _zz_84[24] = _zz_83;
-    _zz_84[23] = _zz_83;
-    _zz_84[22] = _zz_83;
-    _zz_84[21] = _zz_83;
-    _zz_84[20] = _zz_83;
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+  assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
+  assign switch_Misc_l199 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[30] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[29] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[28] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[27] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[26] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[25] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[24] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[23] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[22] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[21] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[20] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[19] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[18] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[17] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[16] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[15] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[14] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[13] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[12] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[11] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[10] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[9] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[8] = _zz_writeBack_DBusCachedPlugin_rspFormated;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_1[7 : 0] = writeBack_DBusCachedPlugin_rspRf[7 : 0];
   end
 
-  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
-  always @ (*) begin
-    _zz_86[31] = _zz_85;
-    _zz_86[30] = _zz_85;
-    _zz_86[29] = _zz_85;
-    _zz_86[28] = _zz_85;
-    _zz_86[27] = _zz_85;
-    _zz_86[26] = _zz_85;
-    _zz_86[25] = _zz_85;
-    _zz_86[24] = _zz_85;
-    _zz_86[23] = _zz_85;
-    _zz_86[22] = _zz_85;
-    _zz_86[21] = _zz_85;
-    _zz_86[20] = _zz_85;
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+  assign _zz_writeBack_DBusCachedPlugin_rspFormated_2 = (writeBack_DBusCachedPlugin_rspRf[15] && (! writeBack_INSTRUCTION[14]));
+  always @(*) begin
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[31] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[30] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[29] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[28] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[27] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[26] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[25] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[24] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[23] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[22] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[21] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[20] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[19] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[18] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[17] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[16] = _zz_writeBack_DBusCachedPlugin_rspFormated_2;
+    _zz_writeBack_DBusCachedPlugin_rspFormated_3[15 : 0] = writeBack_DBusCachedPlugin_rspRf[15 : 0];
   end
 
-  always @ (*) begin
-    case(_zz_730)
+  always @(*) begin
+    case(switch_Misc_l199)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_3;
       end
       default : begin
-        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
+        writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspRf;
       end
     endcase
   end
 
-  always @ (*) begin
-    _zz_93 = _zz_87;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_93 = _zz_902[0];
-      end
+  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_PmpPlugin_l138 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    execute_PmpPlugin_fsmComplete = 1'b0;
+    if(when_StateMachine_l230) begin
+      execute_PmpPlugin_fsmComplete = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_94 = _zz_88;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_94 = _zz_901[0];
+  assign execute_PmpPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
+  assign execute_PmpPlugin_pmpNcfg = execute_PmpPlugin_csrAddress[3 : 0];
+  assign execute_PmpPlugin_pmpcfgN = execute_PmpPlugin_pmpNcfg[1 : 0];
+  assign execute_PmpPlugin_pmpcfgCsr = (execute_INSTRUCTION[31 : 24] == 8'h3a);
+  assign execute_PmpPlugin_pmpaddrCsr = (execute_INSTRUCTION[31 : 24] == 8'h3b);
+  assign execute_PmpPlugin_fsm_wantExit = 1'b0;
+  always @(*) begin
+    execute_PmpPlugin_fsm_wantStart = 1'b0;
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
       end
-    end
-  end
-
-  always @ (*) begin
-    _zz_95 = _zz_89;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_95 = _zz_900[0];
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
       end
-    end
-  end
-
-  always @ (*) begin
-    _zz_96 = _zz_90;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_96 = _zz_890[0];
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
       end
-    end
-  end
-
-  always @ (*) begin
-    _zz_97 = _zz_91;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_97 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_98 = _zz_92;
-    if(execute_CsrPlugin_csr_944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_98 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_103 = (_zz_92 <<< 2);
-  assign _zz_104 = (_zz_92 & (~ _zz_776));
-  assign _zz_105 = ((_zz_92 & (~ _zz_104)) <<< 2);
-  assign _zz_100 = _zz_90;
-  always @ (*) begin
-    _zz_99 = 1'b1;
-    case(_zz_97)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
       end
       default : begin
-        _zz_99 = 1'b0;
+        execute_PmpPlugin_fsm_wantStart = 1'b1;
       end
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_97)
-      2'b01 : begin
-        _zz_101 = 32'h0;
-      end
-      2'b10 : begin
-        _zz_101 = _zz_103;
-      end
-      2'b11 : begin
-        _zz_101 = _zz_105;
-      end
-      default : begin
-        _zz_101 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_97)
-      2'b01 : begin
-        _zz_102 = _zz_103;
-      end
-      2'b10 : begin
-        _zz_102 = (_zz_103 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_102 = (_zz_105 + _zz_777);
-      end
-      default : begin
-        _zz_102 = _zz_103;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_112 = _zz_106;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_112 = _zz_899[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_113 = _zz_107;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_113 = _zz_898[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_114 = _zz_108;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_114 = _zz_897[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_115 = _zz_109;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_115 = _zz_889[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_116 = _zz_110;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_116 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_117 = _zz_111;
-    if(execute_CsrPlugin_csr_945)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_117 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_122 = (_zz_111 <<< 2);
-  assign _zz_123 = (_zz_111 & (~ _zz_779));
-  assign _zz_124 = ((_zz_111 & (~ _zz_123)) <<< 2);
-  assign _zz_119 = _zz_109;
-  always @ (*) begin
-    _zz_118 = 1'b1;
-    case(_zz_116)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_118 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_116)
-      2'b01 : begin
-        _zz_120 = _zz_102;
-      end
-      2'b10 : begin
-        _zz_120 = _zz_122;
-      end
-      2'b11 : begin
-        _zz_120 = _zz_124;
-      end
-      default : begin
-        _zz_120 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_116)
-      2'b01 : begin
-        _zz_121 = _zz_122;
-      end
-      2'b10 : begin
-        _zz_121 = (_zz_122 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_121 = (_zz_124 + _zz_780);
-      end
-      default : begin
-        _zz_121 = _zz_122;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_131 = _zz_125;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_131 = _zz_896[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_132 = _zz_126;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_132 = _zz_895[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_133 = _zz_127;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_133 = _zz_894[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_134 = _zz_128;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_134 = _zz_888[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_135 = _zz_129;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_135 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_136 = _zz_130;
-    if(execute_CsrPlugin_csr_946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_136 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_141 = (_zz_130 <<< 2);
-  assign _zz_142 = (_zz_130 & (~ _zz_782));
-  assign _zz_143 = ((_zz_130 & (~ _zz_142)) <<< 2);
-  assign _zz_138 = _zz_128;
-  always @ (*) begin
-    _zz_137 = 1'b1;
-    case(_zz_135)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_137 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_135)
-      2'b01 : begin
-        _zz_139 = _zz_121;
-      end
-      2'b10 : begin
-        _zz_139 = _zz_141;
-      end
-      2'b11 : begin
-        _zz_139 = _zz_143;
-      end
-      default : begin
-        _zz_139 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_135)
-      2'b01 : begin
-        _zz_140 = _zz_141;
-      end
-      2'b10 : begin
-        _zz_140 = (_zz_141 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_140 = (_zz_143 + _zz_783);
-      end
-      default : begin
-        _zz_140 = _zz_141;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_150 = _zz_144;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_150 = _zz_893[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_151 = _zz_145;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_151 = _zz_892[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_152 = _zz_146;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_152 = _zz_891[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_153 = _zz_147;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_153 = _zz_887[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_154 = _zz_148;
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_154 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_155 = _zz_149;
-    if(execute_CsrPlugin_csr_947)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_155 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_160 = (_zz_149 <<< 2);
-  assign _zz_161 = (_zz_149 & (~ _zz_785));
-  assign _zz_162 = ((_zz_149 & (~ _zz_161)) <<< 2);
-  assign _zz_157 = _zz_147;
-  always @ (*) begin
-    _zz_156 = 1'b1;
-    case(_zz_154)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_156 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_154)
-      2'b01 : begin
-        _zz_158 = _zz_140;
-      end
-      2'b10 : begin
-        _zz_158 = _zz_160;
-      end
-      2'b11 : begin
-        _zz_158 = _zz_162;
-      end
-      default : begin
-        _zz_158 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_154)
-      2'b01 : begin
-        _zz_159 = _zz_160;
-      end
-      2'b10 : begin
-        _zz_159 = (_zz_160 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_159 = (_zz_162 + _zz_786);
-      end
-      default : begin
-        _zz_159 = _zz_160;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_169 = _zz_163;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_169 = _zz_918[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_170 = _zz_164;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_170 = _zz_917[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_171 = _zz_165;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_171 = _zz_916[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_172 = _zz_166;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_172 = _zz_906[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_173 = _zz_167;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_173 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_174 = _zz_168;
-    if(execute_CsrPlugin_csr_948)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_174 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_179 = (_zz_168 <<< 2);
-  assign _zz_180 = (_zz_168 & (~ _zz_788));
-  assign _zz_181 = ((_zz_168 & (~ _zz_180)) <<< 2);
-  assign _zz_176 = _zz_166;
-  always @ (*) begin
-    _zz_175 = 1'b1;
-    case(_zz_173)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_175 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_173)
-      2'b01 : begin
-        _zz_177 = _zz_159;
-      end
-      2'b10 : begin
-        _zz_177 = _zz_179;
-      end
-      2'b11 : begin
-        _zz_177 = _zz_181;
-      end
-      default : begin
-        _zz_177 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_173)
-      2'b01 : begin
-        _zz_178 = _zz_179;
-      end
-      2'b10 : begin
-        _zz_178 = (_zz_179 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_178 = (_zz_181 + _zz_789);
-      end
-      default : begin
-        _zz_178 = _zz_179;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_188 = _zz_182;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_188 = _zz_915[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_189 = _zz_183;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_189 = _zz_914[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_190 = _zz_184;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_190 = _zz_913[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_191 = _zz_185;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_191 = _zz_905[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_192 = _zz_186;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_192 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_193 = _zz_187;
-    if(execute_CsrPlugin_csr_949)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_193 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_198 = (_zz_187 <<< 2);
-  assign _zz_199 = (_zz_187 & (~ _zz_791));
-  assign _zz_200 = ((_zz_187 & (~ _zz_199)) <<< 2);
-  assign _zz_195 = _zz_185;
-  always @ (*) begin
-    _zz_194 = 1'b1;
-    case(_zz_192)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_194 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_192)
-      2'b01 : begin
-        _zz_196 = _zz_178;
-      end
-      2'b10 : begin
-        _zz_196 = _zz_198;
-      end
-      2'b11 : begin
-        _zz_196 = _zz_200;
-      end
-      default : begin
-        _zz_196 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_192)
-      2'b01 : begin
-        _zz_197 = _zz_198;
-      end
-      2'b10 : begin
-        _zz_197 = (_zz_198 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_197 = (_zz_200 + _zz_792);
-      end
-      default : begin
-        _zz_197 = _zz_198;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_207 = _zz_201;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_207 = _zz_912[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_208 = _zz_202;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_208 = _zz_911[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_209 = _zz_203;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_209 = _zz_910[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_210 = _zz_204;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_210 = _zz_904[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_211 = _zz_205;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_211 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_212 = _zz_206;
-    if(execute_CsrPlugin_csr_950)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_212 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_217 = (_zz_206 <<< 2);
-  assign _zz_218 = (_zz_206 & (~ _zz_794));
-  assign _zz_219 = ((_zz_206 & (~ _zz_218)) <<< 2);
-  assign _zz_214 = _zz_204;
-  always @ (*) begin
-    _zz_213 = 1'b1;
-    case(_zz_211)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_213 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_211)
-      2'b01 : begin
-        _zz_215 = _zz_197;
-      end
-      2'b10 : begin
-        _zz_215 = _zz_217;
-      end
-      2'b11 : begin
-        _zz_215 = _zz_219;
-      end
-      default : begin
-        _zz_215 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_211)
-      2'b01 : begin
-        _zz_216 = _zz_217;
-      end
-      2'b10 : begin
-        _zz_216 = (_zz_217 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_216 = (_zz_219 + _zz_795);
-      end
-      default : begin
-        _zz_216 = _zz_217;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_226 = _zz_220;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_226 = _zz_909[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_227 = _zz_221;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_227 = _zz_908[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_228 = _zz_222;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_228 = _zz_907[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_229 = _zz_223;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_229 = _zz_903[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_230 = _zz_224;
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_230 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_231 = _zz_225;
-    if(execute_CsrPlugin_csr_951)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_231 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_236 = (_zz_225 <<< 2);
-  assign _zz_237 = (_zz_225 & (~ _zz_797));
-  assign _zz_238 = ((_zz_225 & (~ _zz_237)) <<< 2);
-  assign _zz_233 = _zz_223;
-  always @ (*) begin
-    _zz_232 = 1'b1;
-    case(_zz_230)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_232 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_230)
-      2'b01 : begin
-        _zz_234 = _zz_216;
-      end
-      2'b10 : begin
-        _zz_234 = _zz_236;
-      end
-      2'b11 : begin
-        _zz_234 = _zz_238;
-      end
-      default : begin
-        _zz_234 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_230)
-      2'b01 : begin
-        _zz_235 = _zz_236;
-      end
-      2'b10 : begin
-        _zz_235 = (_zz_236 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_235 = (_zz_238 + _zz_798);
-      end
-      default : begin
-        _zz_235 = _zz_236;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_245 = _zz_239;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_245 = _zz_934[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_246 = _zz_240;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_246 = _zz_933[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_247 = _zz_241;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_247 = _zz_932[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_248 = _zz_242;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_248 = _zz_922[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_249 = _zz_243;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_249 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_250 = _zz_244;
-    if(execute_CsrPlugin_csr_952)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_250 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_255 = (_zz_244 <<< 2);
-  assign _zz_256 = (_zz_244 & (~ _zz_800));
-  assign _zz_257 = ((_zz_244 & (~ _zz_256)) <<< 2);
-  assign _zz_252 = _zz_242;
-  always @ (*) begin
-    _zz_251 = 1'b1;
-    case(_zz_249)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_251 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_249)
-      2'b01 : begin
-        _zz_253 = _zz_235;
-      end
-      2'b10 : begin
-        _zz_253 = _zz_255;
-      end
-      2'b11 : begin
-        _zz_253 = _zz_257;
-      end
-      default : begin
-        _zz_253 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_249)
-      2'b01 : begin
-        _zz_254 = _zz_255;
-      end
-      2'b10 : begin
-        _zz_254 = (_zz_255 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_254 = (_zz_257 + _zz_801);
-      end
-      default : begin
-        _zz_254 = _zz_255;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_264 = _zz_258;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_264 = _zz_931[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_265 = _zz_259;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_265 = _zz_930[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_266 = _zz_260;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_266 = _zz_929[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_267 = _zz_261;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_267 = _zz_921[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_268 = _zz_262;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_268 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_269 = _zz_263;
-    if(execute_CsrPlugin_csr_953)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_269 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_274 = (_zz_263 <<< 2);
-  assign _zz_275 = (_zz_263 & (~ _zz_803));
-  assign _zz_276 = ((_zz_263 & (~ _zz_275)) <<< 2);
-  assign _zz_271 = _zz_261;
-  always @ (*) begin
-    _zz_270 = 1'b1;
-    case(_zz_268)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_270 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_268)
-      2'b01 : begin
-        _zz_272 = _zz_254;
-      end
-      2'b10 : begin
-        _zz_272 = _zz_274;
-      end
-      2'b11 : begin
-        _zz_272 = _zz_276;
-      end
-      default : begin
-        _zz_272 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_268)
-      2'b01 : begin
-        _zz_273 = _zz_274;
-      end
-      2'b10 : begin
-        _zz_273 = (_zz_274 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_273 = (_zz_276 + _zz_804);
-      end
-      default : begin
-        _zz_273 = _zz_274;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_283 = _zz_277;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_283 = _zz_928[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_284 = _zz_278;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_284 = _zz_927[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_285 = _zz_279;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_285 = _zz_926[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_286 = _zz_280;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_286 = _zz_920[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_287 = _zz_281;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_287 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_288 = _zz_282;
-    if(execute_CsrPlugin_csr_954)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_288 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_293 = (_zz_282 <<< 2);
-  assign _zz_294 = (_zz_282 & (~ _zz_806));
-  assign _zz_295 = ((_zz_282 & (~ _zz_294)) <<< 2);
-  assign _zz_290 = _zz_280;
-  always @ (*) begin
-    _zz_289 = 1'b1;
-    case(_zz_287)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_289 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_287)
-      2'b01 : begin
-        _zz_291 = _zz_273;
-      end
-      2'b10 : begin
-        _zz_291 = _zz_293;
-      end
-      2'b11 : begin
-        _zz_291 = _zz_295;
-      end
-      default : begin
-        _zz_291 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_287)
-      2'b01 : begin
-        _zz_292 = _zz_293;
-      end
-      2'b10 : begin
-        _zz_292 = (_zz_293 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_292 = (_zz_295 + _zz_807);
-      end
-      default : begin
-        _zz_292 = _zz_293;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_302 = _zz_296;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_302 = _zz_925[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_303 = _zz_297;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_303 = _zz_924[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_304 = _zz_298;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_304 = _zz_923[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_305 = _zz_299;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_305 = _zz_919[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_306 = _zz_300;
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_306 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_307 = _zz_301;
-    if(execute_CsrPlugin_csr_955)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_307 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_312 = (_zz_301 <<< 2);
-  assign _zz_313 = (_zz_301 & (~ _zz_809));
-  assign _zz_314 = ((_zz_301 & (~ _zz_313)) <<< 2);
-  assign _zz_309 = _zz_299;
-  always @ (*) begin
-    _zz_308 = 1'b1;
-    case(_zz_306)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_308 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_306)
-      2'b01 : begin
-        _zz_310 = _zz_292;
-      end
-      2'b10 : begin
-        _zz_310 = _zz_312;
-      end
-      2'b11 : begin
-        _zz_310 = _zz_314;
-      end
-      default : begin
-        _zz_310 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_306)
-      2'b01 : begin
-        _zz_311 = _zz_312;
-      end
-      2'b10 : begin
-        _zz_311 = (_zz_312 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_311 = (_zz_314 + _zz_810);
-      end
-      default : begin
-        _zz_311 = _zz_312;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_321 = _zz_315;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_321 = _zz_950[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_322 = _zz_316;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_322 = _zz_949[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_323 = _zz_317;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_323 = _zz_948[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_324 = _zz_318;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_324 = _zz_938[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_325 = _zz_319;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_325 = execute_CsrPlugin_writeData[4 : 3];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_326 = _zz_320;
-    if(execute_CsrPlugin_csr_956)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_326 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_331 = (_zz_320 <<< 2);
-  assign _zz_332 = (_zz_320 & (~ _zz_812));
-  assign _zz_333 = ((_zz_320 & (~ _zz_332)) <<< 2);
-  assign _zz_328 = _zz_318;
-  always @ (*) begin
-    _zz_327 = 1'b1;
-    case(_zz_325)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_327 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_325)
-      2'b01 : begin
-        _zz_329 = _zz_311;
-      end
-      2'b10 : begin
-        _zz_329 = _zz_331;
-      end
-      2'b11 : begin
-        _zz_329 = _zz_333;
-      end
-      default : begin
-        _zz_329 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_325)
-      2'b01 : begin
-        _zz_330 = _zz_331;
-      end
-      2'b10 : begin
-        _zz_330 = (_zz_331 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_330 = (_zz_333 + _zz_813);
-      end
-      default : begin
-        _zz_330 = _zz_331;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_340 = _zz_334;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_340 = _zz_947[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_341 = _zz_335;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_341 = _zz_946[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_342 = _zz_336;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_342 = _zz_945[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_343 = _zz_337;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_343 = _zz_937[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_344 = _zz_338;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_344 = execute_CsrPlugin_writeData[12 : 11];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_345 = _zz_339;
-    if(execute_CsrPlugin_csr_957)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_345 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_350 = (_zz_339 <<< 2);
-  assign _zz_351 = (_zz_339 & (~ _zz_815));
-  assign _zz_352 = ((_zz_339 & (~ _zz_351)) <<< 2);
-  assign _zz_347 = _zz_337;
-  always @ (*) begin
-    _zz_346 = 1'b1;
-    case(_zz_344)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_346 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_344)
-      2'b01 : begin
-        _zz_348 = _zz_330;
-      end
-      2'b10 : begin
-        _zz_348 = _zz_350;
-      end
-      2'b11 : begin
-        _zz_348 = _zz_352;
-      end
-      default : begin
-        _zz_348 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_344)
-      2'b01 : begin
-        _zz_349 = _zz_350;
-      end
-      2'b10 : begin
-        _zz_349 = (_zz_350 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_349 = (_zz_352 + _zz_816);
-      end
-      default : begin
-        _zz_349 = _zz_350;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_359 = _zz_353;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_359 = _zz_944[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_360 = _zz_354;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_360 = _zz_943[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_361 = _zz_355;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_361 = _zz_942[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_362 = _zz_356;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_362 = _zz_936[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_363 = _zz_357;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_363 = execute_CsrPlugin_writeData[20 : 19];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_364 = _zz_358;
-    if(execute_CsrPlugin_csr_958)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_364 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_369 = (_zz_358 <<< 2);
-  assign _zz_370 = (_zz_358 & (~ _zz_818));
-  assign _zz_371 = ((_zz_358 & (~ _zz_370)) <<< 2);
-  assign _zz_366 = _zz_356;
-  always @ (*) begin
-    _zz_365 = 1'b1;
-    case(_zz_363)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_365 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_363)
-      2'b01 : begin
-        _zz_367 = _zz_349;
-      end
-      2'b10 : begin
-        _zz_367 = _zz_369;
-      end
-      2'b11 : begin
-        _zz_367 = _zz_371;
-      end
-      default : begin
-        _zz_367 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_363)
-      2'b01 : begin
-        _zz_368 = _zz_369;
-      end
-      2'b10 : begin
-        _zz_368 = (_zz_369 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_368 = (_zz_371 + _zz_819);
-      end
-      default : begin
-        _zz_368 = _zz_369;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_378 = _zz_372;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_378 = _zz_941[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_379 = _zz_373;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_379 = _zz_940[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_380 = _zz_374;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_380 = _zz_939[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_381 = _zz_375;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_381 = _zz_935[0];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_382 = _zz_376;
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_382 = execute_CsrPlugin_writeData[28 : 27];
-      end
-    end
-  end
-
-  always @ (*) begin
-    _zz_383 = _zz_377;
-    if(execute_CsrPlugin_csr_959)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_383 = execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-  end
-
-  assign _zz_388 = (_zz_377 <<< 2);
-  assign _zz_389 = (_zz_377 & (~ _zz_821));
-  assign _zz_390 = ((_zz_377 & (~ _zz_389)) <<< 2);
-  assign _zz_385 = _zz_375;
-  always @ (*) begin
-    _zz_384 = 1'b1;
-    case(_zz_382)
-      2'b01 : begin
-      end
-      2'b10 : begin
-      end
-      2'b11 : begin
-      end
-      default : begin
-        _zz_384 = 1'b0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_382)
-      2'b01 : begin
-        _zz_386 = _zz_368;
-      end
-      2'b10 : begin
-        _zz_386 = _zz_388;
-      end
-      2'b11 : begin
-        _zz_386 = _zz_390;
-      end
-      default : begin
-        _zz_386 = 32'h0;
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    case(_zz_382)
-      2'b01 : begin
-        _zz_387 = _zz_388;
-      end
-      2'b10 : begin
-        _zz_387 = (_zz_388 + 32'h00000004);
-      end
-      2'b11 : begin
-        _zz_387 = (_zz_390 + _zz_822);
-      end
-      default : begin
-        _zz_387 = _zz_388;
-      end
-    endcase
-  end
-
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign PmpPlugin_ports_0_hits_0 = (((_zz_99 && (_zz_101 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_102)) && (_zz_100 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_1 = (((_zz_118 && (_zz_120 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_121)) && (_zz_119 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_2 = (((_zz_137 && (_zz_139 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_140)) && (_zz_138 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_3 = (((_zz_156 && (_zz_158 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_159)) && (_zz_157 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_4 = (((_zz_175 && (_zz_177 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_178)) && (_zz_176 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_5 = (((_zz_194 && (_zz_196 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_197)) && (_zz_195 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_6 = (((_zz_213 && (_zz_215 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_216)) && (_zz_214 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_7 = (((_zz_232 && (_zz_234 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_235)) && (_zz_233 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_8 = (((_zz_251 && (_zz_253 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_254)) && (_zz_252 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_9 = (((_zz_270 && (_zz_272 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_273)) && (_zz_271 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_10 = (((_zz_289 && (_zz_291 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_292)) && (_zz_290 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_11 = (((_zz_308 && (_zz_310 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_311)) && (_zz_309 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_12 = (((_zz_327 && (_zz_329 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_330)) && (_zz_328 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_13 = (((_zz_346 && (_zz_348 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_349)) && (_zz_347 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_14 = (((_zz_365 && (_zz_367 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_368)) && (_zz_366 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_0_hits_15 = (((_zz_384 && (_zz_386 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_387)) && (_zz_385 || (! (CsrPlugin_privilege == 2'b11))));
-  assign _zz_391 = 5'h0;
-  assign _zz_392 = 5'h01;
-  assign _zz_393 = 5'h01;
-  assign _zz_394 = 5'h02;
-  assign _zz_395 = 5'h01;
-  assign _zz_396 = 5'h02;
-  assign _zz_397 = 5'h02;
-  assign _zz_398 = 5'h03;
-  always @ (*) begin
-    if(_zz_693)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+  assign execute_PmpPlugin_fsm_wantKill = 1'b0;
+  always @(*) begin
+    if(execute_PmpPlugin_pmpaddrCsr_) begin
+      PmpPlugin_setter_io_addr = execute_PmpPlugin_writeData_;
     end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_662;
+      PmpPlugin_setter_io_addr = _zz_PmpPlugin_pmpaddr_port0;
     end
   end
 
-  always @ (*) begin
-    if(_zz_693)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_663;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_693)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_664;
-    end
-  end
-
-  assign _zz_399 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_999,_zz_1000}}}}}}}}}}};
-  assign _zz_400 = (_zz_399 & (~ _zz_831));
-  assign _zz_401 = _zz_400[3];
-  assign _zz_402 = _zz_400[5];
-  assign _zz_403 = _zz_400[6];
-  assign _zz_404 = _zz_400[7];
-  assign _zz_405 = _zz_400[9];
-  assign _zz_406 = _zz_400[10];
-  assign _zz_407 = _zz_400[11];
-  assign _zz_408 = _zz_400[12];
-  assign _zz_409 = _zz_400[13];
-  assign _zz_410 = _zz_400[14];
-  assign _zz_411 = _zz_400[15];
-  assign _zz_412 = (((((((_zz_400[1] || _zz_401) || _zz_402) || _zz_404) || _zz_405) || _zz_407) || _zz_409) || _zz_411);
-  assign _zz_413 = (((((((_zz_400[2] || _zz_401) || _zz_403) || _zz_404) || _zz_406) || _zz_407) || _zz_410) || _zz_411);
-  assign _zz_414 = (((((((_zz_400[4] || _zz_402) || _zz_403) || _zz_404) || _zz_408) || _zz_409) || _zz_410) || _zz_411);
-  assign _zz_415 = (((((((_zz_400[8] || _zz_405) || _zz_406) || _zz_407) || _zz_408) || _zz_409) || _zz_410) || _zz_411);
-  assign _zz_416 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_1001,_zz_1002}}}}}}}}}}};
-  assign _zz_417 = (_zz_416 & (~ _zz_832));
-  assign _zz_418 = _zz_417[3];
-  assign _zz_419 = _zz_417[5];
-  assign _zz_420 = _zz_417[6];
-  assign _zz_421 = _zz_417[7];
-  assign _zz_422 = _zz_417[9];
-  assign _zz_423 = _zz_417[10];
-  assign _zz_424 = _zz_417[11];
-  assign _zz_425 = _zz_417[12];
-  assign _zz_426 = _zz_417[13];
-  assign _zz_427 = _zz_417[14];
-  assign _zz_428 = _zz_417[15];
-  assign _zz_429 = (((((((_zz_417[1] || _zz_418) || _zz_419) || _zz_421) || _zz_422) || _zz_424) || _zz_426) || _zz_428);
-  assign _zz_430 = (((((((_zz_417[2] || _zz_418) || _zz_420) || _zz_421) || _zz_423) || _zz_424) || _zz_427) || _zz_428);
-  assign _zz_431 = (((((((_zz_417[4] || _zz_419) || _zz_420) || _zz_421) || _zz_425) || _zz_426) || _zz_427) || _zz_428);
-  assign _zz_432 = (((((((_zz_417[8] || _zz_422) || _zz_423) || _zz_424) || _zz_425) || _zz_426) || _zz_427) || _zz_428);
-  assign _zz_433 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_1003,_zz_1004}}}}}}}}}}};
-  assign _zz_434 = (_zz_433 & (~ _zz_833));
-  assign _zz_435 = _zz_434[3];
-  assign _zz_436 = _zz_434[5];
-  assign _zz_437 = _zz_434[6];
-  assign _zz_438 = _zz_434[7];
-  assign _zz_439 = _zz_434[9];
-  assign _zz_440 = _zz_434[10];
-  assign _zz_441 = _zz_434[11];
-  assign _zz_442 = _zz_434[12];
-  assign _zz_443 = _zz_434[13];
-  assign _zz_444 = _zz_434[14];
-  assign _zz_445 = _zz_434[15];
-  assign _zz_446 = (((((((_zz_434[1] || _zz_435) || _zz_436) || _zz_438) || _zz_439) || _zz_441) || _zz_443) || _zz_445);
-  assign _zz_447 = (((((((_zz_434[2] || _zz_435) || _zz_437) || _zz_438) || _zz_440) || _zz_441) || _zz_444) || _zz_445);
-  assign _zz_448 = (((((((_zz_434[4] || _zz_436) || _zz_437) || _zz_438) || _zz_442) || _zz_443) || _zz_444) || _zz_445);
-  assign _zz_449 = (((((((_zz_434[8] || _zz_439) || _zz_440) || _zz_441) || _zz_442) || _zz_443) || _zz_444) || _zz_445);
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
-  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
+  assign when_PmpPlugin_l246 = (execute_PmpPlugin_fsm_fsmEnable && (! _zz_when_PmpPlugin_l246[7]));
+  assign _zz_8 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
+  assign _zz_9 = ({15'd0,1'b1} <<< execute_PmpPlugin_fsm_fsmCounter);
   assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign PmpPlugin_ports_1_hits_0 = (((_zz_99 && (_zz_101 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_102)) && (_zz_100 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_1 = (((_zz_118 && (_zz_120 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_121)) && (_zz_119 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_2 = (((_zz_137 && (_zz_139 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_140)) && (_zz_138 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_3 = (((_zz_156 && (_zz_158 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_159)) && (_zz_157 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_4 = (((_zz_175 && (_zz_177 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_178)) && (_zz_176 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_5 = (((_zz_194 && (_zz_196 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_197)) && (_zz_195 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_6 = (((_zz_213 && (_zz_215 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_216)) && (_zz_214 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_7 = (((_zz_232 && (_zz_234 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_235)) && (_zz_233 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_8 = (((_zz_251 && (_zz_253 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_254)) && (_zz_252 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_9 = (((_zz_270 && (_zz_272 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_273)) && (_zz_271 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_10 = (((_zz_289 && (_zz_291 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_292)) && (_zz_290 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_11 = (((_zz_308 && (_zz_310 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_311)) && (_zz_309 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_12 = (((_zz_327 && (_zz_329 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_330)) && (_zz_328 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_13 = (((_zz_346 && (_zz_348 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_349)) && (_zz_347 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_14 = (((_zz_365 && (_zz_367 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_368)) && (_zz_366 || (! (CsrPlugin_privilege == 2'b11))));
-  assign PmpPlugin_ports_1_hits_15 = (((_zz_384 && (_zz_386 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_387)) && (_zz_385 || (! (CsrPlugin_privilege == 2'b11))));
-  assign _zz_450 = 5'h0;
-  assign _zz_451 = 5'h01;
-  assign _zz_452 = 5'h01;
-  assign _zz_453 = 5'h02;
-  assign _zz_454 = 5'h01;
-  assign _zz_455 = 5'h02;
-  assign _zz_456 = 5'h02;
-  assign _zz_457 = 5'h03;
-  always @ (*) begin
-    if(_zz_694)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_671;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_694)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_672;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_694)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_673;
-    end
-  end
-
-  assign _zz_458 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1005,_zz_1006}}}}}}}}}}};
-  assign _zz_459 = (_zz_458 & (~ _zz_841));
-  assign _zz_460 = _zz_459[3];
-  assign _zz_461 = _zz_459[5];
-  assign _zz_462 = _zz_459[6];
-  assign _zz_463 = _zz_459[7];
-  assign _zz_464 = _zz_459[9];
-  assign _zz_465 = _zz_459[10];
-  assign _zz_466 = _zz_459[11];
-  assign _zz_467 = _zz_459[12];
-  assign _zz_468 = _zz_459[13];
-  assign _zz_469 = _zz_459[14];
-  assign _zz_470 = _zz_459[15];
-  assign _zz_471 = (((((((_zz_459[1] || _zz_460) || _zz_461) || _zz_463) || _zz_464) || _zz_466) || _zz_468) || _zz_470);
-  assign _zz_472 = (((((((_zz_459[2] || _zz_460) || _zz_462) || _zz_463) || _zz_465) || _zz_466) || _zz_469) || _zz_470);
-  assign _zz_473 = (((((((_zz_459[4] || _zz_461) || _zz_462) || _zz_463) || _zz_467) || _zz_468) || _zz_469) || _zz_470);
-  assign _zz_474 = (((((((_zz_459[8] || _zz_464) || _zz_465) || _zz_466) || _zz_467) || _zz_468) || _zz_469) || _zz_470);
-  assign _zz_475 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1007,_zz_1008}}}}}}}}}}};
-  assign _zz_476 = (_zz_475 & (~ _zz_842));
-  assign _zz_477 = _zz_476[3];
-  assign _zz_478 = _zz_476[5];
-  assign _zz_479 = _zz_476[6];
-  assign _zz_480 = _zz_476[7];
-  assign _zz_481 = _zz_476[9];
-  assign _zz_482 = _zz_476[10];
-  assign _zz_483 = _zz_476[11];
-  assign _zz_484 = _zz_476[12];
-  assign _zz_485 = _zz_476[13];
-  assign _zz_486 = _zz_476[14];
-  assign _zz_487 = _zz_476[15];
-  assign _zz_488 = (((((((_zz_476[1] || _zz_477) || _zz_478) || _zz_480) || _zz_481) || _zz_483) || _zz_485) || _zz_487);
-  assign _zz_489 = (((((((_zz_476[2] || _zz_477) || _zz_479) || _zz_480) || _zz_482) || _zz_483) || _zz_486) || _zz_487);
-  assign _zz_490 = (((((((_zz_476[4] || _zz_478) || _zz_479) || _zz_480) || _zz_484) || _zz_485) || _zz_486) || _zz_487);
-  assign _zz_491 = (((((((_zz_476[8] || _zz_481) || _zz_482) || _zz_483) || _zz_484) || _zz_485) || _zz_486) || _zz_487);
-  assign _zz_492 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1009,_zz_1010}}}}}}}}}}};
-  assign _zz_493 = (_zz_492 & (~ _zz_843));
-  assign _zz_494 = _zz_493[3];
-  assign _zz_495 = _zz_493[5];
-  assign _zz_496 = _zz_493[6];
-  assign _zz_497 = _zz_493[7];
-  assign _zz_498 = _zz_493[9];
-  assign _zz_499 = _zz_493[10];
-  assign _zz_500 = _zz_493[11];
-  assign _zz_501 = _zz_493[12];
-  assign _zz_502 = _zz_493[13];
-  assign _zz_503 = _zz_493[14];
-  assign _zz_504 = _zz_493[15];
-  assign _zz_505 = (((((((_zz_493[1] || _zz_494) || _zz_495) || _zz_497) || _zz_498) || _zz_500) || _zz_502) || _zz_504);
-  assign _zz_506 = (((((((_zz_493[2] || _zz_494) || _zz_496) || _zz_497) || _zz_499) || _zz_500) || _zz_503) || _zz_504);
-  assign _zz_507 = (((((((_zz_493[4] || _zz_495) || _zz_496) || _zz_497) || _zz_501) || _zz_502) || _zz_503) || _zz_504);
-  assign _zz_508 = (((((((_zz_493[8] || _zz_498) || _zz_499) || _zz_500) || _zz_501) || _zz_502) || _zz_503) || _zz_504);
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
   assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_510 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_511 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_512 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_513 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_509 = {(((decode_INSTRUCTION & _zz_1011) == 32'h00100050) != 1'b0),{(_zz_513 != 1'b0),{(_zz_513 != 1'b0),{(_zz_1012 != _zz_1013),{_zz_1014,{_zz_1015,_zz_1016}}}}}};
-  assign _zz_514 = _zz_509[2 : 1];
-  assign _zz_49 = _zz_514;
-  assign _zz_515 = _zz_509[7 : 6];
-  assign _zz_48 = _zz_515;
-  assign _zz_516 = _zz_509[9 : 8];
-  assign _zz_47 = _zz_516;
-  assign _zz_517 = _zz_509[19 : 18];
-  assign _zz_46 = _zz_517;
-  assign _zz_518 = _zz_509[22 : 21];
-  assign _zz_45 = _zz_518;
-  assign _zz_519 = _zz_509[24 : 23];
-  assign _zz_44 = _zz_519;
-  assign _zz_520 = _zz_509[27 : 26];
-  assign _zz_43 = _zz_520;
+  assign _zz_PmpPlugin_dGuard_hits_0 = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
+  assign PmpPlugin_dGuard_hits_0 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_0_1) == _zz_PmpPlugin_dGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_1 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_1) == _zz_PmpPlugin_dGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_2 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_2) == _zz_PmpPlugin_dGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_3 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_3) == _zz_PmpPlugin_dGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_4 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_4) == _zz_PmpPlugin_dGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_5 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_5) == _zz_PmpPlugin_dGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_6 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_6) == _zz_PmpPlugin_dGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_7 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_7) == _zz_PmpPlugin_dGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_8 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_8) == _zz_PmpPlugin_dGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_9 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_9) == _zz_PmpPlugin_dGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_10 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_10) == _zz_PmpPlugin_dGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_11 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_11) == _zz_PmpPlugin_dGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_12 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_12) == _zz_PmpPlugin_dGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_13 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_13) == _zz_PmpPlugin_dGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_14 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_14) == _zz_PmpPlugin_dGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
+  assign PmpPlugin_dGuard_hits_15 = ((((_zz_PmpPlugin_dGuard_hits_0 & _zz_PmpPlugin_dGuard_hits_15) == _zz_PmpPlugin_dGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
+  assign when_PmpPlugin_l277 = (! ({PmpPlugin_dGuard_hits_15,{PmpPlugin_dGuard_hits_14,{PmpPlugin_dGuard_hits_13,{PmpPlugin_dGuard_hits_12,{PmpPlugin_dGuard_hits_11,{PmpPlugin_dGuard_hits_10,{PmpPlugin_dGuard_hits_9,{PmpPlugin_dGuard_hits_8,{PmpPlugin_dGuard_hits_7,{_zz_when_PmpPlugin_l277,_zz_when_PmpPlugin_l277_1}}}}}}}}}} != 16'h0));
+  always @(*) begin
+    if(when_PmpPlugin_l277) begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = ({(PmpPlugin_dGuard_hits_15 && PmpPlugin_pmpcfg_15[0]),{(PmpPlugin_dGuard_hits_14 && PmpPlugin_pmpcfg_14[0]),{(PmpPlugin_dGuard_hits_13 && PmpPlugin_pmpcfg_13[0]),{(PmpPlugin_dGuard_hits_12 && PmpPlugin_pmpcfg_12[0]),{(PmpPlugin_dGuard_hits_11 && _zz_DBusCachedPlugin_mmuBus_rsp_allowRead),{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_1,{_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_2,_zz_DBusCachedPlugin_mmuBus_rsp_allowRead_3}}}}}}} != 16'h0);
+    end
+  end
+
+  always @(*) begin
+    if(when_PmpPlugin_l277) begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = ({(PmpPlugin_dGuard_hits_15 && PmpPlugin_pmpcfg_15[1]),{(PmpPlugin_dGuard_hits_14 && PmpPlugin_pmpcfg_14[1]),{(PmpPlugin_dGuard_hits_13 && PmpPlugin_pmpcfg_13[1]),{(PmpPlugin_dGuard_hits_12 && PmpPlugin_pmpcfg_12[1]),{(PmpPlugin_dGuard_hits_11 && _zz_DBusCachedPlugin_mmuBus_rsp_allowWrite),{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_1,{_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_2,_zz_DBusCachedPlugin_mmuBus_rsp_allowWrite_3}}}}}}} != 16'h0);
+    end
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b0;
+  assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b0;
+  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
+  assign _zz_PmpPlugin_iGuard_hits_0 = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 7];
+  assign PmpPlugin_iGuard_hits_0 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_0_1) == _zz_PmpPlugin_iGuard_hits_0_3) && (PmpPlugin_pmpcfg_0[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_0[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_1 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_1) == _zz_PmpPlugin_iGuard_hits_1_2) && (PmpPlugin_pmpcfg_1[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_1[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_2 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_2) == _zz_PmpPlugin_iGuard_hits_2_2) && (PmpPlugin_pmpcfg_2[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_2[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_3 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_3) == _zz_PmpPlugin_iGuard_hits_3_2) && (PmpPlugin_pmpcfg_3[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_3[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_4 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_4) == _zz_PmpPlugin_iGuard_hits_4_2) && (PmpPlugin_pmpcfg_4[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_4[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_5 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_5) == _zz_PmpPlugin_iGuard_hits_5_2) && (PmpPlugin_pmpcfg_5[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_5[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_6 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_6) == _zz_PmpPlugin_iGuard_hits_6_2) && (PmpPlugin_pmpcfg_6[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_6[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_7 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_7) == _zz_PmpPlugin_iGuard_hits_7_2) && (PmpPlugin_pmpcfg_7[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_7[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_8 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_8) == _zz_PmpPlugin_iGuard_hits_8_2) && (PmpPlugin_pmpcfg_8[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_8[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_9 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_9) == _zz_PmpPlugin_iGuard_hits_9_2) && (PmpPlugin_pmpcfg_9[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_9[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_10 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_10) == _zz_PmpPlugin_iGuard_hits_10_2) && (PmpPlugin_pmpcfg_10[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_10[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_11 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_11) == _zz_PmpPlugin_iGuard_hits_11_2) && (PmpPlugin_pmpcfg_11[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_11[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_12 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_12) == _zz_PmpPlugin_iGuard_hits_12_2) && (PmpPlugin_pmpcfg_12[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_12[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_13 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_13) == _zz_PmpPlugin_iGuard_hits_13_2) && (PmpPlugin_pmpcfg_13[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_13[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_14 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_14) == _zz_PmpPlugin_iGuard_hits_14_2) && (PmpPlugin_pmpcfg_14[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_14[4 : 3] == 2'b11));
+  assign PmpPlugin_iGuard_hits_15 = ((((_zz_PmpPlugin_iGuard_hits_0 & _zz_PmpPlugin_iGuard_hits_15) == _zz_PmpPlugin_iGuard_hits_15_2) && (PmpPlugin_pmpcfg_15[7] || (! (CsrPlugin_privilege == 2'b11)))) && (PmpPlugin_pmpcfg_15[4 : 3] == 2'b11));
+  assign when_PmpPlugin_l299 = (! ({PmpPlugin_iGuard_hits_15,{PmpPlugin_iGuard_hits_14,{PmpPlugin_iGuard_hits_13,{PmpPlugin_iGuard_hits_12,{PmpPlugin_iGuard_hits_11,{PmpPlugin_iGuard_hits_10,{PmpPlugin_iGuard_hits_9,{PmpPlugin_iGuard_hits_8,{PmpPlugin_iGuard_hits_7,{_zz_when_PmpPlugin_l299,_zz_when_PmpPlugin_l299_1}}}}}}}}}} != 16'h0));
+  always @(*) begin
+    if(when_PmpPlugin_l299) begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = ({(PmpPlugin_iGuard_hits_15 && PmpPlugin_pmpcfg_15[2]),{(PmpPlugin_iGuard_hits_14 && PmpPlugin_pmpcfg_14[2]),{(PmpPlugin_iGuard_hits_13 && PmpPlugin_pmpcfg_13[2]),{(PmpPlugin_iGuard_hits_12 && PmpPlugin_pmpcfg_12[2]),{(PmpPlugin_iGuard_hits_11 && _zz_IBusCachedPlugin_mmuBus_rsp_allowExecute),{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_1,{_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_2,_zz_IBusCachedPlugin_mmuBus_rsp_allowExecute_3}}}}}}} != 16'h0);
+    end
+  end
+
+  assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED) == 32'h00100050) != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_1 != _zz__zz_decode_IS_RS2_SIGNED_2),{_zz__zz_decode_IS_RS2_SIGNED_3,{_zz__zz_decode_IS_RS2_SIGNED_5,_zz__zz_decode_IS_RS2_SIGNED_8}}}}}};
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[19 : 18];
+  assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[27 : 26];
+  assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_653;
-  assign decode_RegFilePlugin_rs2Data = _zz_654;
-  always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_521)begin
+  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
+  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  always @(*) begin
+    lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+    if(_zz_10) begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_521)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+    if(_zz_10) begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
-  always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_521)begin
+  always @(*) begin
+    lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
+    if(_zz_10) begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_AND : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : begin
+      `AluBitwiseCtrlEnum_defaultEncoding_OR : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -7076,353 +8290,376 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_522 = execute_IntAluPlugin_bitwise;
+        _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_522 = {31'd0, _zz_844};
+        _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
-        _zz_522 = execute_SRC_ADD_SUB;
+        _zz_execute_REGFILE_WRITE_DATA = execute_SRC_ADD_SUB;
       end
     endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_523 = execute_RS1;
+        _zz_execute_SRC1 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_523 = {29'd0, _zz_845};
+        _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_523 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_523 = {27'd0, _zz_846};
+        _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
       end
     endcase
   end
 
-  assign _zz_524 = _zz_847[11];
-  always @ (*) begin
-    _zz_525[19] = _zz_524;
-    _zz_525[18] = _zz_524;
-    _zz_525[17] = _zz_524;
-    _zz_525[16] = _zz_524;
-    _zz_525[15] = _zz_524;
-    _zz_525[14] = _zz_524;
-    _zz_525[13] = _zz_524;
-    _zz_525[12] = _zz_524;
-    _zz_525[11] = _zz_524;
-    _zz_525[10] = _zz_524;
-    _zz_525[9] = _zz_524;
-    _zz_525[8] = _zz_524;
-    _zz_525[7] = _zz_524;
-    _zz_525[6] = _zz_524;
-    _zz_525[5] = _zz_524;
-    _zz_525[4] = _zz_524;
-    _zz_525[3] = _zz_524;
-    _zz_525[2] = _zz_524;
-    _zz_525[1] = _zz_524;
-    _zz_525[0] = _zz_524;
+  assign _zz_execute_SRC2_1 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_SRC2_2[19] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[18] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[17] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[16] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[15] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[14] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[13] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[12] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[11] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[10] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[9] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[8] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[7] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[6] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[5] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[4] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[3] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[2] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[1] = _zz_execute_SRC2_1;
+    _zz_execute_SRC2_2[0] = _zz_execute_SRC2_1;
   end
 
-  assign _zz_526 = _zz_848[11];
-  always @ (*) begin
-    _zz_527[19] = _zz_526;
-    _zz_527[18] = _zz_526;
-    _zz_527[17] = _zz_526;
-    _zz_527[16] = _zz_526;
-    _zz_527[15] = _zz_526;
-    _zz_527[14] = _zz_526;
-    _zz_527[13] = _zz_526;
-    _zz_527[12] = _zz_526;
-    _zz_527[11] = _zz_526;
-    _zz_527[10] = _zz_526;
-    _zz_527[9] = _zz_526;
-    _zz_527[8] = _zz_526;
-    _zz_527[7] = _zz_526;
-    _zz_527[6] = _zz_526;
-    _zz_527[5] = _zz_526;
-    _zz_527[4] = _zz_526;
-    _zz_527[3] = _zz_526;
-    _zz_527[2] = _zz_526;
-    _zz_527[1] = _zz_526;
-    _zz_527[0] = _zz_526;
+  assign _zz_execute_SRC2_3 = _zz__zz_execute_SRC2_3[11];
+  always @(*) begin
+    _zz_execute_SRC2_4[19] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[18] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[17] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[16] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[15] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[14] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[13] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[12] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[11] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[10] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[9] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[8] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[7] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[6] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[5] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[4] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[3] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[2] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[1] = _zz_execute_SRC2_3;
+    _zz_execute_SRC2_4[0] = _zz_execute_SRC2_3;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_528 = execute_RS2;
+        _zz_execute_SRC2_5 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_528 = {_zz_525,execute_INSTRUCTION[31 : 20]};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_528 = {_zz_527,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_528 = _zz_35;
+        _zz_execute_SRC2_5 = _zz_execute_SRC2;
       end
     endcase
   end
 
-  always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_849;
-    if(execute_SRC2_FORCE_ZERO)begin
+  always @(*) begin
+    execute_SrcPlugin_addSub = _zz_execute_SrcPlugin_addSub;
+    if(execute_SRC2_FORCE_ZERO) begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
-  always @ (*) begin
-    _zz_529[0] = execute_SRC1[31];
-    _zz_529[1] = execute_SRC1[30];
-    _zz_529[2] = execute_SRC1[29];
-    _zz_529[3] = execute_SRC1[28];
-    _zz_529[4] = execute_SRC1[27];
-    _zz_529[5] = execute_SRC1[26];
-    _zz_529[6] = execute_SRC1[25];
-    _zz_529[7] = execute_SRC1[24];
-    _zz_529[8] = execute_SRC1[23];
-    _zz_529[9] = execute_SRC1[22];
-    _zz_529[10] = execute_SRC1[21];
-    _zz_529[11] = execute_SRC1[20];
-    _zz_529[12] = execute_SRC1[19];
-    _zz_529[13] = execute_SRC1[18];
-    _zz_529[14] = execute_SRC1[17];
-    _zz_529[15] = execute_SRC1[16];
-    _zz_529[16] = execute_SRC1[15];
-    _zz_529[17] = execute_SRC1[14];
-    _zz_529[18] = execute_SRC1[13];
-    _zz_529[19] = execute_SRC1[12];
-    _zz_529[20] = execute_SRC1[11];
-    _zz_529[21] = execute_SRC1[10];
-    _zz_529[22] = execute_SRC1[9];
-    _zz_529[23] = execute_SRC1[8];
-    _zz_529[24] = execute_SRC1[7];
-    _zz_529[25] = execute_SRC1[6];
-    _zz_529[26] = execute_SRC1[5];
-    _zz_529[27] = execute_SRC1[4];
-    _zz_529[28] = execute_SRC1[3];
-    _zz_529[29] = execute_SRC1[2];
-    _zz_529[30] = execute_SRC1[1];
-    _zz_529[31] = execute_SRC1[0];
+  always @(*) begin
+    _zz_execute_FullBarrelShifterPlugin_reversed[0] = execute_SRC1[31];
+    _zz_execute_FullBarrelShifterPlugin_reversed[1] = execute_SRC1[30];
+    _zz_execute_FullBarrelShifterPlugin_reversed[2] = execute_SRC1[29];
+    _zz_execute_FullBarrelShifterPlugin_reversed[3] = execute_SRC1[28];
+    _zz_execute_FullBarrelShifterPlugin_reversed[4] = execute_SRC1[27];
+    _zz_execute_FullBarrelShifterPlugin_reversed[5] = execute_SRC1[26];
+    _zz_execute_FullBarrelShifterPlugin_reversed[6] = execute_SRC1[25];
+    _zz_execute_FullBarrelShifterPlugin_reversed[7] = execute_SRC1[24];
+    _zz_execute_FullBarrelShifterPlugin_reversed[8] = execute_SRC1[23];
+    _zz_execute_FullBarrelShifterPlugin_reversed[9] = execute_SRC1[22];
+    _zz_execute_FullBarrelShifterPlugin_reversed[10] = execute_SRC1[21];
+    _zz_execute_FullBarrelShifterPlugin_reversed[11] = execute_SRC1[20];
+    _zz_execute_FullBarrelShifterPlugin_reversed[12] = execute_SRC1[19];
+    _zz_execute_FullBarrelShifterPlugin_reversed[13] = execute_SRC1[18];
+    _zz_execute_FullBarrelShifterPlugin_reversed[14] = execute_SRC1[17];
+    _zz_execute_FullBarrelShifterPlugin_reversed[15] = execute_SRC1[16];
+    _zz_execute_FullBarrelShifterPlugin_reversed[16] = execute_SRC1[15];
+    _zz_execute_FullBarrelShifterPlugin_reversed[17] = execute_SRC1[14];
+    _zz_execute_FullBarrelShifterPlugin_reversed[18] = execute_SRC1[13];
+    _zz_execute_FullBarrelShifterPlugin_reversed[19] = execute_SRC1[12];
+    _zz_execute_FullBarrelShifterPlugin_reversed[20] = execute_SRC1[11];
+    _zz_execute_FullBarrelShifterPlugin_reversed[21] = execute_SRC1[10];
+    _zz_execute_FullBarrelShifterPlugin_reversed[22] = execute_SRC1[9];
+    _zz_execute_FullBarrelShifterPlugin_reversed[23] = execute_SRC1[8];
+    _zz_execute_FullBarrelShifterPlugin_reversed[24] = execute_SRC1[7];
+    _zz_execute_FullBarrelShifterPlugin_reversed[25] = execute_SRC1[6];
+    _zz_execute_FullBarrelShifterPlugin_reversed[26] = execute_SRC1[5];
+    _zz_execute_FullBarrelShifterPlugin_reversed[27] = execute_SRC1[4];
+    _zz_execute_FullBarrelShifterPlugin_reversed[28] = execute_SRC1[3];
+    _zz_execute_FullBarrelShifterPlugin_reversed[29] = execute_SRC1[2];
+    _zz_execute_FullBarrelShifterPlugin_reversed[30] = execute_SRC1[1];
+    _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_529 : execute_SRC1);
-  always @ (*) begin
-    _zz_530[0] = memory_SHIFT_RIGHT[31];
-    _zz_530[1] = memory_SHIFT_RIGHT[30];
-    _zz_530[2] = memory_SHIFT_RIGHT[29];
-    _zz_530[3] = memory_SHIFT_RIGHT[28];
-    _zz_530[4] = memory_SHIFT_RIGHT[27];
-    _zz_530[5] = memory_SHIFT_RIGHT[26];
-    _zz_530[6] = memory_SHIFT_RIGHT[25];
-    _zz_530[7] = memory_SHIFT_RIGHT[24];
-    _zz_530[8] = memory_SHIFT_RIGHT[23];
-    _zz_530[9] = memory_SHIFT_RIGHT[22];
-    _zz_530[10] = memory_SHIFT_RIGHT[21];
-    _zz_530[11] = memory_SHIFT_RIGHT[20];
-    _zz_530[12] = memory_SHIFT_RIGHT[19];
-    _zz_530[13] = memory_SHIFT_RIGHT[18];
-    _zz_530[14] = memory_SHIFT_RIGHT[17];
-    _zz_530[15] = memory_SHIFT_RIGHT[16];
-    _zz_530[16] = memory_SHIFT_RIGHT[15];
-    _zz_530[17] = memory_SHIFT_RIGHT[14];
-    _zz_530[18] = memory_SHIFT_RIGHT[13];
-    _zz_530[19] = memory_SHIFT_RIGHT[12];
-    _zz_530[20] = memory_SHIFT_RIGHT[11];
-    _zz_530[21] = memory_SHIFT_RIGHT[10];
-    _zz_530[22] = memory_SHIFT_RIGHT[9];
-    _zz_530[23] = memory_SHIFT_RIGHT[8];
-    _zz_530[24] = memory_SHIFT_RIGHT[7];
-    _zz_530[25] = memory_SHIFT_RIGHT[6];
-    _zz_530[26] = memory_SHIFT_RIGHT[5];
-    _zz_530[27] = memory_SHIFT_RIGHT[4];
-    _zz_530[28] = memory_SHIFT_RIGHT[3];
-    _zz_530[29] = memory_SHIFT_RIGHT[2];
-    _zz_530[30] = memory_SHIFT_RIGHT[1];
-    _zz_530[31] = memory_SHIFT_RIGHT[0];
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  always @(*) begin
+    _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
+    _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
+    _zz_decode_RS2_3[2] = memory_SHIFT_RIGHT[29];
+    _zz_decode_RS2_3[3] = memory_SHIFT_RIGHT[28];
+    _zz_decode_RS2_3[4] = memory_SHIFT_RIGHT[27];
+    _zz_decode_RS2_3[5] = memory_SHIFT_RIGHT[26];
+    _zz_decode_RS2_3[6] = memory_SHIFT_RIGHT[25];
+    _zz_decode_RS2_3[7] = memory_SHIFT_RIGHT[24];
+    _zz_decode_RS2_3[8] = memory_SHIFT_RIGHT[23];
+    _zz_decode_RS2_3[9] = memory_SHIFT_RIGHT[22];
+    _zz_decode_RS2_3[10] = memory_SHIFT_RIGHT[21];
+    _zz_decode_RS2_3[11] = memory_SHIFT_RIGHT[20];
+    _zz_decode_RS2_3[12] = memory_SHIFT_RIGHT[19];
+    _zz_decode_RS2_3[13] = memory_SHIFT_RIGHT[18];
+    _zz_decode_RS2_3[14] = memory_SHIFT_RIGHT[17];
+    _zz_decode_RS2_3[15] = memory_SHIFT_RIGHT[16];
+    _zz_decode_RS2_3[16] = memory_SHIFT_RIGHT[15];
+    _zz_decode_RS2_3[17] = memory_SHIFT_RIGHT[14];
+    _zz_decode_RS2_3[18] = memory_SHIFT_RIGHT[13];
+    _zz_decode_RS2_3[19] = memory_SHIFT_RIGHT[12];
+    _zz_decode_RS2_3[20] = memory_SHIFT_RIGHT[11];
+    _zz_decode_RS2_3[21] = memory_SHIFT_RIGHT[10];
+    _zz_decode_RS2_3[22] = memory_SHIFT_RIGHT[9];
+    _zz_decode_RS2_3[23] = memory_SHIFT_RIGHT[8];
+    _zz_decode_RS2_3[24] = memory_SHIFT_RIGHT[7];
+    _zz_decode_RS2_3[25] = memory_SHIFT_RIGHT[6];
+    _zz_decode_RS2_3[26] = memory_SHIFT_RIGHT[5];
+    _zz_decode_RS2_3[27] = memory_SHIFT_RIGHT[4];
+    _zz_decode_RS2_3[28] = memory_SHIFT_RIGHT[3];
+    _zz_decode_RS2_3[29] = memory_SHIFT_RIGHT[2];
+    _zz_decode_RS2_3[30] = memory_SHIFT_RIGHT[1];
+    _zz_decode_RS2_3[31] = memory_SHIFT_RIGHT[0];
   end
 
-  always @ (*) begin
-    _zz_531 = 1'b0;
-    if(_zz_695)begin
-      if(_zz_696)begin
-        if(_zz_536)begin
-          _zz_531 = 1'b1;
+  always @(*) begin
+    HazardSimplePlugin_src0Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l48) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_697)begin
-      if(_zz_698)begin
-        if(_zz_538)begin
-          _zz_531 = 1'b1;
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l48_1) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if(_zz_699)begin
-      if(_zz_700)begin
-        if(_zz_540)begin
-          _zz_531 = 1'b1;
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l48_2) begin
+          HazardSimplePlugin_src0Hazard = 1'b1;
         end
       end
     end
-    if((! decode_RS1_USE))begin
-      _zz_531 = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    _zz_532 = 1'b0;
-    if(_zz_695)begin
-      if(_zz_696)begin
-        if(_zz_537)begin
-          _zz_532 = 1'b1;
-        end
-      end
-    end
-    if(_zz_697)begin
-      if(_zz_698)begin
-        if(_zz_539)begin
-          _zz_532 = 1'b1;
-        end
-      end
-    end
-    if(_zz_699)begin
-      if(_zz_700)begin
-        if(_zz_541)begin
-          _zz_532 = 1'b1;
-        end
-      end
-    end
-    if((! decode_RS2_USE))begin
-      _zz_532 = 1'b0;
+    if(when_HazardSimplePlugin_l105) begin
+      HazardSimplePlugin_src0Hazard = 1'b0;
     end
   end
 
-  assign _zz_536 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_537 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_538 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_539 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_540 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_541 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  always @(*) begin
+    HazardSimplePlugin_src1Hazard = 1'b0;
+    if(when_HazardSimplePlugin_l57) begin
+      if(when_HazardSimplePlugin_l58) begin
+        if(when_HazardSimplePlugin_l51) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_1) begin
+      if(when_HazardSimplePlugin_l58_1) begin
+        if(when_HazardSimplePlugin_l51_1) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l57_2) begin
+      if(when_HazardSimplePlugin_l58_2) begin
+        if(when_HazardSimplePlugin_l51_2) begin
+          HazardSimplePlugin_src1Hazard = 1'b1;
+        end
+      end
+    end
+    if(when_HazardSimplePlugin_l108) begin
+      HazardSimplePlugin_src1Hazard = 1'b0;
+    end
+  end
+
+  assign HazardSimplePlugin_writeBackWrites_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
+  assign HazardSimplePlugin_writeBackWrites_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
+  assign HazardSimplePlugin_writeBackWrites_payload_data = _zz_decode_RS2_2;
+  assign HazardSimplePlugin_addr0Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[19 : 15]);
+  assign HazardSimplePlugin_addr1Match = (HazardSimplePlugin_writeBackBuffer_payload_address == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l47 = 1'b1;
+  assign when_HazardSimplePlugin_l48 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58 = (1'b0 || (! when_HazardSimplePlugin_l47));
+  assign when_HazardSimplePlugin_l48_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_1 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_1 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_1 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign when_HazardSimplePlugin_l48_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign when_HazardSimplePlugin_l51_2 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign when_HazardSimplePlugin_l45_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l57_2 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign when_HazardSimplePlugin_l58_2 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign when_HazardSimplePlugin_l105 = (! decode_RS1_USE);
+  assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
+  assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_542 = execute_INSTRUCTION[14 : 12];
-  always @ (*) begin
-    if((_zz_542 == 3'b000)) begin
-        _zz_543 = execute_BranchPlugin_eq;
-    end else if((_zz_542 == 3'b001)) begin
-        _zz_543 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_542 & 3'b101) == 3'b101))) begin
-        _zz_543 = (! execute_SRC_LESS);
-    end else begin
-        _zz_543 = execute_SRC_LESS;
-    end
+  assign switch_Misc_l199_1 = execute_INSTRUCTION[14 : 12];
+  always @(*) begin
+    casez(switch_Misc_l199_1)
+      3'b000 : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
+      end
+      3'b001 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_BranchPlugin_eq);
+      end
+      3'b1?1 : begin
+        _zz_execute_BRANCH_COND_RESULT = (! execute_SRC_LESS);
+      end
+      default : begin
+        _zz_execute_BRANCH_COND_RESULT = execute_SRC_LESS;
+      end
+    endcase
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_544 = 1'b0;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_544 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_544 = 1'b1;
+        _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
-        _zz_544 = _zz_543;
+        _zz_execute_BRANCH_COND_RESULT_1 = _zz_execute_BRANCH_COND_RESULT;
       end
     endcase
   end
 
-  assign _zz_545 = _zz_856[11];
-  always @ (*) begin
-    _zz_546[19] = _zz_545;
-    _zz_546[18] = _zz_545;
-    _zz_546[17] = _zz_545;
-    _zz_546[16] = _zz_545;
-    _zz_546[15] = _zz_545;
-    _zz_546[14] = _zz_545;
-    _zz_546[13] = _zz_545;
-    _zz_546[12] = _zz_545;
-    _zz_546[11] = _zz_545;
-    _zz_546[10] = _zz_545;
-    _zz_546[9] = _zz_545;
-    _zz_546[8] = _zz_545;
-    _zz_546[7] = _zz_545;
-    _zz_546[6] = _zz_545;
-    _zz_546[5] = _zz_545;
-    _zz_546[4] = _zz_545;
-    _zz_546[3] = _zz_545;
-    _zz_546[2] = _zz_545;
-    _zz_546[1] = _zz_545;
-    _zz_546[0] = _zz_545;
+  assign _zz_execute_BranchPlugin_missAlignedTarget = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_1[19] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[18] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[17] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[16] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[15] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[14] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[13] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[12] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[11] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[10] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[9] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[8] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[7] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[6] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[5] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[4] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[3] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[2] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[1] = _zz_execute_BranchPlugin_missAlignedTarget;
+    _zz_execute_BranchPlugin_missAlignedTarget_1[0] = _zz_execute_BranchPlugin_missAlignedTarget;
   end
 
-  assign _zz_547 = _zz_857[19];
-  always @ (*) begin
-    _zz_548[10] = _zz_547;
-    _zz_548[9] = _zz_547;
-    _zz_548[8] = _zz_547;
-    _zz_548[7] = _zz_547;
-    _zz_548[6] = _zz_547;
-    _zz_548[5] = _zz_547;
-    _zz_548[4] = _zz_547;
-    _zz_548[3] = _zz_547;
-    _zz_548[2] = _zz_547;
-    _zz_548[1] = _zz_547;
-    _zz_548[0] = _zz_547;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_2 = _zz__zz_execute_BranchPlugin_missAlignedTarget_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_3[10] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[9] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[8] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[7] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[6] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[5] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[4] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[3] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[2] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[1] = _zz_execute_BranchPlugin_missAlignedTarget_2;
+    _zz_execute_BranchPlugin_missAlignedTarget_3[0] = _zz_execute_BranchPlugin_missAlignedTarget_2;
   end
 
-  assign _zz_549 = _zz_858[11];
-  always @ (*) begin
-    _zz_550[18] = _zz_549;
-    _zz_550[17] = _zz_549;
-    _zz_550[16] = _zz_549;
-    _zz_550[15] = _zz_549;
-    _zz_550[14] = _zz_549;
-    _zz_550[13] = _zz_549;
-    _zz_550[12] = _zz_549;
-    _zz_550[11] = _zz_549;
-    _zz_550[10] = _zz_549;
-    _zz_550[9] = _zz_549;
-    _zz_550[8] = _zz_549;
-    _zz_550[7] = _zz_549;
-    _zz_550[6] = _zz_549;
-    _zz_550[5] = _zz_549;
-    _zz_550[4] = _zz_549;
-    _zz_550[3] = _zz_549;
-    _zz_550[2] = _zz_549;
-    _zz_550[1] = _zz_549;
-    _zz_550[0] = _zz_549;
+  assign _zz_execute_BranchPlugin_missAlignedTarget_4 = _zz__zz_execute_BranchPlugin_missAlignedTarget_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_missAlignedTarget_5[18] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[17] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[16] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[15] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[14] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[13] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[12] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[11] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[10] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[9] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[8] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[7] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[6] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[5] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[4] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[3] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[2] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[1] = _zz_execute_BranchPlugin_missAlignedTarget_4;
+    _zz_execute_BranchPlugin_missAlignedTarget_5[0] = _zz_execute_BranchPlugin_missAlignedTarget_4;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_551 = (_zz_859[1] ^ execute_RS1[1]);
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_551 = _zz_860[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
-        _zz_551 = _zz_861[1];
+        _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_2[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_551);
-  always @ (*) begin
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
@@ -7433,80 +8670,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_552 = _zz_862[11];
-  always @ (*) begin
-    _zz_553[19] = _zz_552;
-    _zz_553[18] = _zz_552;
-    _zz_553[17] = _zz_552;
-    _zz_553[16] = _zz_552;
-    _zz_553[15] = _zz_552;
-    _zz_553[14] = _zz_552;
-    _zz_553[13] = _zz_552;
-    _zz_553[12] = _zz_552;
-    _zz_553[11] = _zz_552;
-    _zz_553[10] = _zz_552;
-    _zz_553[9] = _zz_552;
-    _zz_553[8] = _zz_552;
-    _zz_553[7] = _zz_552;
-    _zz_553[6] = _zz_552;
-    _zz_553[5] = _zz_552;
-    _zz_553[4] = _zz_552;
-    _zz_553[3] = _zz_552;
-    _zz_553[2] = _zz_552;
-    _zz_553[1] = _zz_552;
-    _zz_553[0] = _zz_552;
+  assign _zz_execute_BranchPlugin_branch_src2 = execute_INSTRUCTION[31];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_1[19] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[18] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[17] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[16] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[15] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[14] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[13] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[12] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[11] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[9] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[8] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[7] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[6] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[5] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[4] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[3] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[2] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[1] = _zz_execute_BranchPlugin_branch_src2;
+    _zz_execute_BranchPlugin_branch_src2_1[0] = _zz_execute_BranchPlugin_branch_src2;
   end
 
-  always @ (*) begin
+  always @(*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_553,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_555,{{{_zz_1175,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_557,{{{_zz_1176,_zz_1177},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_865};
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2) begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
       end
     endcase
   end
 
-  assign _zz_554 = _zz_863[19];
-  always @ (*) begin
-    _zz_555[10] = _zz_554;
-    _zz_555[9] = _zz_554;
-    _zz_555[8] = _zz_554;
-    _zz_555[7] = _zz_554;
-    _zz_555[6] = _zz_554;
-    _zz_555[5] = _zz_554;
-    _zz_555[4] = _zz_554;
-    _zz_555[3] = _zz_554;
-    _zz_555[2] = _zz_554;
-    _zz_555[1] = _zz_554;
-    _zz_555[0] = _zz_554;
+  assign _zz_execute_BranchPlugin_branch_src2_2 = _zz__zz_execute_BranchPlugin_branch_src2_2[19];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_3[10] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[9] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[8] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[7] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[6] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[5] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[4] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[3] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[2] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[1] = _zz_execute_BranchPlugin_branch_src2_2;
+    _zz_execute_BranchPlugin_branch_src2_3[0] = _zz_execute_BranchPlugin_branch_src2_2;
   end
 
-  assign _zz_556 = _zz_864[11];
-  always @ (*) begin
-    _zz_557[18] = _zz_556;
-    _zz_557[17] = _zz_556;
-    _zz_557[16] = _zz_556;
-    _zz_557[15] = _zz_556;
-    _zz_557[14] = _zz_556;
-    _zz_557[13] = _zz_556;
-    _zz_557[12] = _zz_556;
-    _zz_557[11] = _zz_556;
-    _zz_557[10] = _zz_556;
-    _zz_557[9] = _zz_556;
-    _zz_557[8] = _zz_556;
-    _zz_557[7] = _zz_556;
-    _zz_557[6] = _zz_556;
-    _zz_557[5] = _zz_556;
-    _zz_557[4] = _zz_556;
-    _zz_557[3] = _zz_556;
-    _zz_557[2] = _zz_556;
-    _zz_557[1] = _zz_556;
-    _zz_557[0] = _zz_556;
+  assign _zz_execute_BranchPlugin_branch_src2_4 = _zz__zz_execute_BranchPlugin_branch_src2_4[11];
+  always @(*) begin
+    _zz_execute_BranchPlugin_branch_src2_5[18] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[17] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[16] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[15] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[14] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[13] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[12] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[11] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[10] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[9] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[8] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[7] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[6] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[5] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[4] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[3] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[2] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[1] = _zz_execute_BranchPlugin_branch_src2_4;
+    _zz_execute_BranchPlugin_branch_src2_5[0] = _zz_execute_BranchPlugin_branch_src2_4;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -7516,92 +8753,106 @@ module VexRiscv (
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
-  always @ (*) begin
-    CsrPlugin_privilege = _zz_558;
-    if(CsrPlugin_forceMachineWire)begin
+  always @(*) begin
+    CsrPlugin_privilege = _zz_CsrPlugin_privilege;
+    if(CsrPlugin_forceMachineWire) begin
       CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_559 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_560 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_561 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_562 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_563 = _zz_866[0];
-  always @ (*) begin
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_684)begin
+    if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
-    if(decode_arbitration_isFlushed)begin
+    if(decode_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
-    if(execute_arbitration_isFlushed)begin
+    if(execute_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
-    if(memory_arbitration_isFlushed)begin
+    if(memory_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b1;
     end
-    if(writeBack_arbitration_isFlushed)begin
+    if(writeBack_arbitration_isFlushed) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
+  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  always @ (*) begin
+  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
+    if(when_CsrPlugin_l991) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
   end
 
+  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_targetPrivilege = CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_trapCause = CsrPlugin_interrupt_code;
-    if(CsrPlugin_hadException)begin
+    if(CsrPlugin_hadException) begin
       CsrPlugin_trapCause = CsrPlugin_exceptionPortCtrl_exceptionContext_code;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
@@ -7612,8 +8863,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    CsrPlugin_xtvec_base = 30'h0;
+  always @(*) begin
+    CsrPlugin_xtvec_base = 30'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_base = CsrPlugin_mtvec_base;
@@ -7623,195 +8874,144 @@ module VexRiscv (
     endcase
   end
 
+  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
+  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000);
   assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
-    if(execute_CsrPlugin_csr_3264)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3264) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_944)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_945)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_946)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_947)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_948)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_949)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_950)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_951)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_952)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_953)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_954)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_955)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_956)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_957)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_958)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_959)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_928)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_929)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_930)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_931)begin
-      execute_CsrPlugin_illegalAccess = 1'b0;
-    end
-    if(execute_CsrPlugin_csr_3857)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3857) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3858)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3858) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3859)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3859) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3860)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3860) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_769)begin
+    if(execute_CsrPlugin_csr_769) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_768)begin
+    if(execute_CsrPlugin_csr_768) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_836)begin
+    if(execute_CsrPlugin_csr_836) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_772)begin
+    if(execute_CsrPlugin_csr_772) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_773)begin
+    if(execute_CsrPlugin_csr_773) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_833)begin
+    if(execute_CsrPlugin_csr_833) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_832)begin
+    if(execute_CsrPlugin_csr_832) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_834)begin
+    if(execute_CsrPlugin_csr_834) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_835)begin
+    if(execute_CsrPlugin_csr_835) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2816)begin
+    if(execute_CsrPlugin_csr_2816) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2944)begin
+    if(execute_CsrPlugin_csr_2944) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2818)begin
+    if(execute_CsrPlugin_csr_2818) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_2946)begin
+    if(execute_CsrPlugin_csr_2946) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_3072)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3072) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3200)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3200) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3074)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3074) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3202)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_3202) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(execute_CsrPlugin_csr_3008)begin
+    if(execute_CsrPlugin_csr_3008) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(execute_CsrPlugin_csr_4032)begin
-      if(execute_CSR_READ_OPCODE)begin
+    if(execute_CsrPlugin_csr_4032) begin
+      if(execute_CSR_READ_OPCODE) begin
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_701)begin
+    if(CsrPlugin_csrMapping_allowCsrSignal) begin
+      execute_CsrPlugin_illegalAccess = 1'b0;
+    end
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
+    if(when_CsrPlugin_l1302) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if((execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)))begin
-      if((CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]))begin
+    if(when_CsrPlugin_l1136) begin
+      if(when_CsrPlugin_l1137) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_702)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_703)begin
+    if(when_CsrPlugin_l1144) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_702)begin
+    if(when_CsrPlugin_l1129) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_703)begin
+    if(when_CsrPlugin_l1144) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -7824,39 +9024,49 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  always @ (*) begin
+  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_701)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_701)begin
+    if(when_CsrPlugin_l1297) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
 
   assign execute_CsrPlugin_writeEnable = (execute_CsrPlugin_writeInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
-  assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
-  always @ (*) begin
-    case(_zz_731)
+  assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
+  assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
+  assign switch_Misc_l199_2 = execute_INSTRUCTION[13];
+  always @(*) begin
+    case(switch_Misc_l199_2)
       1'b0 : begin
-        execute_CsrPlugin_writeData = execute_SRC1;
+        _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
       default : begin
-        execute_CsrPlugin_writeData = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
+        _zz_CsrPlugin_csrMapping_writeDataSignal = (execute_INSTRUCTION[12] ? (execute_CsrPlugin_readToWriteData & (~ execute_SRC1)) : (execute_CsrPlugin_readToWriteData | execute_SRC1));
       end
     endcase
   end
 
+  assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
+  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
-  always @ (*) begin
-    case(_zz_704)
+  assign switch_MulPlugin_l87 = execute_INSTRUCTION[13 : 12];
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -7869,8 +9079,8 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    case(_zz_704)
+  always @(*) begin
+    case(switch_MulPlugin_l87)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -7889,58 +9099,69 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_868) + $signed(_zz_869));
+  assign writeBack_MulPlugin_result = ($signed(_zz_writeBack_MulPlugin_result) + $signed(_zz_writeBack_MulPlugin_result_1));
+  assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
+  assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign memory_DivPlugin_frontendOk = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_679)begin
-      if(_zz_705)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_706)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
 
   assign memory_DivPlugin_div_counter_willOverflowIfInc = (memory_DivPlugin_div_counter_value == 6'h21);
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
-  always @ (*) begin
-    if(memory_DivPlugin_div_counter_willOverflow)begin
+  always @(*) begin
+    if(memory_DivPlugin_div_counter_willOverflow) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_873);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
-    if(memory_DivPlugin_div_counter_willClear)begin
+    if(memory_DivPlugin_div_counter_willClear) begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_564 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_564[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_874);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_875 : _zz_876);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_877[31:0];
-  assign _zz_565 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_566 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_567 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
-  always @ (*) begin
-    _zz_568[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_568[31 : 0] = execute_RS1;
+  assign when_MulDivIterativePlugin_l126 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign when_MulDivIterativePlugin_l126_1 = (! memory_arbitration_isStuck);
+  assign when_MulDivIterativePlugin_l128 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign when_MulDivIterativePlugin_l129 = ((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done));
+  assign when_MulDivIterativePlugin_l132 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_memory_DivPlugin_div_stage_0_remainderShifted = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_memory_DivPlugin_div_stage_0_remainderShifted[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_memory_DivPlugin_div_stage_0_remainderMinusDenominator);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_memory_DivPlugin_div_stage_0_outRemainder : _zz_memory_DivPlugin_div_stage_0_outRemainder_1);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_memory_DivPlugin_div_stage_0_outNumerator[31:0];
+  assign when_MulDivIterativePlugin_l151 = (memory_DivPlugin_div_counter_value == 6'h20);
+  assign _zz_memory_DivPlugin_div_result = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign when_MulDivIterativePlugin_l162 = (! memory_arbitration_isStuck);
+  assign _zz_memory_DivPlugin_rs2 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_memory_DivPlugin_rs1 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  always @(*) begin
+    _zz_memory_DivPlugin_rs1_1[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_memory_DivPlugin_rs1_1[31 : 0] = execute_RS1;
   end
 
-  assign _zz_570 = (_zz_569 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_570 != 32'h0);
-  always @ (*) begin
+  assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
+  assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
+  always @(*) begin
     debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_707)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
         end
@@ -7950,9 +9171,9 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_571))begin
+    if(when_DebugPlugin_l244) begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -7961,12 +9182,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
+  assign when_DebugPlugin_l244 = (! _zz_when_DebugPlugin_l244);
+  always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_707)
+    if(debug_bus_cmd_valid) begin
+      case(switch_DebugPlugin_l256)
         6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
+          if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
         end
@@ -7977,35 +9199,110 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
+  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
+  assign when_Pipeline_l124_3 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_4 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_5 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_6 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_7 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_8 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_9 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_SRC1_CTRL_1 = decode_SRC1_CTRL;
+  assign _zz_decode_SRC1_CTRL = _zz_decode_SRC1_CTRL_1;
+  assign when_Pipeline_l124_10 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC1_CTRL = decode_to_execute_SRC1_CTRL;
+  assign when_Pipeline_l124_11 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_12 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_13 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_14 = (! writeBack_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
+  assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
+  assign when_Pipeline_l124_15 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
+  assign _zz_decode_to_execute_SRC2_CTRL_1 = decode_SRC2_CTRL;
+  assign _zz_decode_SRC2_CTRL = _zz_decode_SRC2_CTRL_1;
+  assign when_Pipeline_l124_16 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SRC2_CTRL = decode_to_execute_SRC2_CTRL;
+  assign when_Pipeline_l124_17 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_18 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_19 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_20 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
+  assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
+  assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
+  assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
+  assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
+  assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
+  assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
+  assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
+  assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
+  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
+  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
+  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
+  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -8026,9 +9323,15 @@ module VexRiscv (
   assign writeBack_arbitration_isStuck = (writeBack_arbitration_haltItself || writeBack_arbitration_isStuckByOthers);
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
-  always @ (*) begin
+  assign when_Pipeline_l151 = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
+  assign when_Pipeline_l154 = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
+  assign when_Pipeline_l151_1 = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
+  assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
+  assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
+  always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_572)
+    case(switch_Fetcher_l362)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -8037,489 +9340,347 @@ module VexRiscv (
     endcase
   end
 
-  always @ (*) begin
-    _zz_573 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_573[12 : 0] = 13'h1000;
-      _zz_573[25 : 20] = 6'h20;
+  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
+  always @(*) begin
+    execute_PmpPlugin_fsm_stateNext = execute_PmpPlugin_fsm_stateReg;
+    case(execute_PmpPlugin_fsm_stateReg)
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
+        if(execute_PmpPlugin_fsmPending) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite;
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
+        if(execute_PmpPlugin_pmpcfgCsr_) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg;
+        end
+        if(execute_PmpPlugin_pmpaddrCsr_) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr;
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
+        if(when_PmpPlugin_l229) begin
+          execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle;
+        end
+      end
+      `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
+        execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle;
+      end
+      default : begin
+      end
+    endcase
+    if(execute_PmpPlugin_fsm_wantStart) begin
+      execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle;
+    end
+    if(execute_PmpPlugin_fsm_wantKill) begin
+      execute_PmpPlugin_fsm_stateNext = `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT;
     end
   end
 
-  always @ (*) begin
-    _zz_574 = 32'h0;
-    if(execute_CsrPlugin_csr_944)begin
-      _zz_574[31 : 0] = _zz_92;
+  assign _zz_PmpPlugin_pmpcfg_0 = execute_PmpPlugin_writeData_[7 : 0];
+  assign _zz_PmpPlugin_pmpcfg_0_1 = execute_PmpPlugin_writeData_[15 : 8];
+  assign _zz_PmpPlugin_pmpcfg_0_2 = execute_PmpPlugin_writeData_[23 : 16];
+  assign _zz_PmpPlugin_pmpcfg_0_3 = execute_PmpPlugin_writeData_[31 : 24];
+  assign when_PmpPlugin_l209 = (! _zz_when_PmpPlugin_l209[7]);
+  assign _zz_11 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b00});
+  assign when_PmpPlugin_l209_1 = (! _zz_when_PmpPlugin_l209_1_1[7]);
+  assign _zz_12 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b01});
+  assign when_PmpPlugin_l209_2 = (! _zz_when_PmpPlugin_l209_2[7]);
+  assign _zz_13 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b10});
+  assign when_PmpPlugin_l209_3 = (! _zz_when_PmpPlugin_l209_3[7]);
+  assign _zz_14 = ({15'd0,1'b1} <<< {execute_PmpPlugin_pmpcfgN_,2'b11});
+  assign when_PmpPlugin_l216 = (! _zz_when_PmpPlugin_l216[7]);
+  assign when_PmpPlugin_l229 = (execute_PmpPlugin_fsm_fsmCounter[1 : 0] == 2'b11);
+  assign when_StateMachine_l214 = ((execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite) && (! (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite)));
+  assign when_StateMachine_l230 = ((! (execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle)) && (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle));
+  assign when_StateMachine_l230_1 = ((! (execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg)) && (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg));
+  assign when_StateMachine_l230_2 = ((! (execute_PmpPlugin_fsm_stateReg == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr)) && (execute_PmpPlugin_fsm_stateNext == `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr));
+  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
+    if(execute_CsrPlugin_csr_3264) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[25 : 20] = 6'h20;
     end
   end
 
-  always @ (*) begin
-    _zz_575 = 32'h0;
-    if(execute_CsrPlugin_csr_945)begin
-      _zz_575[31 : 0] = _zz_111;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
+    if(execute_CsrPlugin_csr_3857) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_3[0 : 0] = 1'b1;
     end
   end
 
-  always @ (*) begin
-    _zz_576 = 32'h0;
-    if(execute_CsrPlugin_csr_946)begin
-      _zz_576[31 : 0] = _zz_130;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
+    if(execute_CsrPlugin_csr_3858) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_4[1 : 0] = 2'b10;
     end
   end
 
-  always @ (*) begin
-    _zz_577 = 32'h0;
-    if(execute_CsrPlugin_csr_947)begin
-      _zz_577[31 : 0] = _zz_149;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
+    if(execute_CsrPlugin_csr_3859) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_5[1 : 0] = 2'b11;
     end
   end
 
-  always @ (*) begin
-    _zz_578 = 32'h0;
-    if(execute_CsrPlugin_csr_948)begin
-      _zz_578[31 : 0] = _zz_168;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
+    if(execute_CsrPlugin_csr_769) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_6[31 : 30] = CsrPlugin_misa_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_6[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
-  always @ (*) begin
-    _zz_579 = 32'h0;
-    if(execute_CsrPlugin_csr_949)begin
-      _zz_579[31 : 0] = _zz_187;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
+    if(execute_CsrPlugin_csr_768) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
-  always @ (*) begin
-    _zz_580 = 32'h0;
-    if(execute_CsrPlugin_csr_950)begin
-      _zz_580[31 : 0] = _zz_206;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
+    if(execute_CsrPlugin_csr_836) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_CsrPlugin_csrMapping_readDataInit_8[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
-  always @ (*) begin
-    _zz_581 = 32'h0;
-    if(execute_CsrPlugin_csr_951)begin
-      _zz_581[31 : 0] = _zz_225;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
+    if(execute_CsrPlugin_csr_772) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_9[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_9[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
-  always @ (*) begin
-    _zz_582 = 32'h0;
-    if(execute_CsrPlugin_csr_952)begin
-      _zz_582[31 : 0] = _zz_244;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
+    if(execute_CsrPlugin_csr_773) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_CsrPlugin_csrMapping_readDataInit_10[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  always @ (*) begin
-    _zz_583 = 32'h0;
-    if(execute_CsrPlugin_csr_953)begin
-      _zz_583[31 : 0] = _zz_263;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
+    if(execute_CsrPlugin_csr_833) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mepc;
     end
   end
 
-  always @ (*) begin
-    _zz_584 = 32'h0;
-    if(execute_CsrPlugin_csr_954)begin
-      _zz_584[31 : 0] = _zz_282;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
+    if(execute_CsrPlugin_csr_832) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
-  always @ (*) begin
-    _zz_585 = 32'h0;
-    if(execute_CsrPlugin_csr_955)begin
-      _zz_585[31 : 0] = _zz_301;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
+    if(execute_CsrPlugin_csr_834) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_CsrPlugin_csrMapping_readDataInit_13[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  always @ (*) begin
-    _zz_586 = 32'h0;
-    if(execute_CsrPlugin_csr_956)begin
-      _zz_586[31 : 0] = _zz_320;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
+    if(execute_CsrPlugin_csr_835) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mtval;
     end
   end
 
-  always @ (*) begin
-    _zz_587 = 32'h0;
-    if(execute_CsrPlugin_csr_957)begin
-      _zz_587[31 : 0] = _zz_339;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
+    if(execute_CsrPlugin_csr_2816) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_588 = 32'h0;
-    if(execute_CsrPlugin_csr_958)begin
-      _zz_588[31 : 0] = _zz_358;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
+    if(execute_CsrPlugin_csr_2944) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_589 = 32'h0;
-    if(execute_CsrPlugin_csr_959)begin
-      _zz_589[31 : 0] = _zz_377;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
+    if(execute_CsrPlugin_csr_2818) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_590 = 32'h0;
-    if(execute_CsrPlugin_csr_928)begin
-      _zz_590[31 : 31] = _zz_147;
-      _zz_590[23 : 23] = _zz_128;
-      _zz_590[15 : 15] = _zz_109;
-      _zz_590[7 : 7] = _zz_90;
-      _zz_590[28 : 27] = _zz_148;
-      _zz_590[26 : 26] = _zz_146;
-      _zz_590[25 : 25] = _zz_145;
-      _zz_590[24 : 24] = _zz_144;
-      _zz_590[20 : 19] = _zz_129;
-      _zz_590[18 : 18] = _zz_127;
-      _zz_590[17 : 17] = _zz_126;
-      _zz_590[16 : 16] = _zz_125;
-      _zz_590[12 : 11] = _zz_110;
-      _zz_590[10 : 10] = _zz_108;
-      _zz_590[9 : 9] = _zz_107;
-      _zz_590[8 : 8] = _zz_106;
-      _zz_590[4 : 3] = _zz_91;
-      _zz_590[2 : 2] = _zz_89;
-      _zz_590[1 : 1] = _zz_88;
-      _zz_590[0 : 0] = _zz_87;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
+    if(execute_CsrPlugin_csr_2946) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_591 = 32'h0;
-    if(execute_CsrPlugin_csr_929)begin
-      _zz_591[31 : 31] = _zz_223;
-      _zz_591[23 : 23] = _zz_204;
-      _zz_591[15 : 15] = _zz_185;
-      _zz_591[7 : 7] = _zz_166;
-      _zz_591[28 : 27] = _zz_224;
-      _zz_591[26 : 26] = _zz_222;
-      _zz_591[25 : 25] = _zz_221;
-      _zz_591[24 : 24] = _zz_220;
-      _zz_591[20 : 19] = _zz_205;
-      _zz_591[18 : 18] = _zz_203;
-      _zz_591[17 : 17] = _zz_202;
-      _zz_591[16 : 16] = _zz_201;
-      _zz_591[12 : 11] = _zz_186;
-      _zz_591[10 : 10] = _zz_184;
-      _zz_591[9 : 9] = _zz_183;
-      _zz_591[8 : 8] = _zz_182;
-      _zz_591[4 : 3] = _zz_167;
-      _zz_591[2 : 2] = _zz_165;
-      _zz_591[1 : 1] = _zz_164;
-      _zz_591[0 : 0] = _zz_163;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
+    if(execute_CsrPlugin_csr_3072) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_592 = 32'h0;
-    if(execute_CsrPlugin_csr_930)begin
-      _zz_592[31 : 31] = _zz_299;
-      _zz_592[23 : 23] = _zz_280;
-      _zz_592[15 : 15] = _zz_261;
-      _zz_592[7 : 7] = _zz_242;
-      _zz_592[28 : 27] = _zz_300;
-      _zz_592[26 : 26] = _zz_298;
-      _zz_592[25 : 25] = _zz_297;
-      _zz_592[24 : 24] = _zz_296;
-      _zz_592[20 : 19] = _zz_281;
-      _zz_592[18 : 18] = _zz_279;
-      _zz_592[17 : 17] = _zz_278;
-      _zz_592[16 : 16] = _zz_277;
-      _zz_592[12 : 11] = _zz_262;
-      _zz_592[10 : 10] = _zz_260;
-      _zz_592[9 : 9] = _zz_259;
-      _zz_592[8 : 8] = _zz_258;
-      _zz_592[4 : 3] = _zz_243;
-      _zz_592[2 : 2] = _zz_241;
-      _zz_592[1 : 1] = _zz_240;
-      _zz_592[0 : 0] = _zz_239;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
+    if(execute_CsrPlugin_csr_3200) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_593 = 32'h0;
-    if(execute_CsrPlugin_csr_931)begin
-      _zz_593[31 : 31] = _zz_375;
-      _zz_593[23 : 23] = _zz_356;
-      _zz_593[15 : 15] = _zz_337;
-      _zz_593[7 : 7] = _zz_318;
-      _zz_593[28 : 27] = _zz_376;
-      _zz_593[26 : 26] = _zz_374;
-      _zz_593[25 : 25] = _zz_373;
-      _zz_593[24 : 24] = _zz_372;
-      _zz_593[20 : 19] = _zz_357;
-      _zz_593[18 : 18] = _zz_355;
-      _zz_593[17 : 17] = _zz_354;
-      _zz_593[16 : 16] = _zz_353;
-      _zz_593[12 : 11] = _zz_338;
-      _zz_593[10 : 10] = _zz_336;
-      _zz_593[9 : 9] = _zz_335;
-      _zz_593[8 : 8] = _zz_334;
-      _zz_593[4 : 3] = _zz_319;
-      _zz_593[2 : 2] = _zz_317;
-      _zz_593[1 : 1] = _zz_316;
-      _zz_593[0 : 0] = _zz_315;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
+    if(execute_CsrPlugin_csr_3074) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
-  always @ (*) begin
-    _zz_594 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_594[0 : 0] = 1'b1;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
+    if(execute_CsrPlugin_csr_3202) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
-  always @ (*) begin
-    _zz_595 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_595[1 : 0] = 2'b10;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
+    if(execute_CsrPlugin_csr_3008) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
-  always @ (*) begin
-    _zz_596 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_596[1 : 0] = 2'b11;
+  always @(*) begin
+    _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
+    if(execute_CsrPlugin_csr_4032) begin
+      _zz_CsrPlugin_csrMapping_readDataInit_24[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit_1;
     end
   end
 
-  always @ (*) begin
-    _zz_597 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_597[31 : 30] = CsrPlugin_misa_base;
-      _zz_597[25 : 0] = CsrPlugin_misa_extensions;
-    end
-  end
-
-  always @ (*) begin
-    _zz_598 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_598[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_598[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_598[3 : 3] = CsrPlugin_mstatus_MIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_599 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_599[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_599[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_599[3 : 3] = CsrPlugin_mip_MSIP;
-    end
-  end
-
-  always @ (*) begin
-    _zz_600 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_600[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_600[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_600[3 : 3] = CsrPlugin_mie_MSIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_601 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_601[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_601[1 : 0] = CsrPlugin_mtvec_mode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_602 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_602[31 : 0] = CsrPlugin_mepc;
-    end
-  end
-
-  always @ (*) begin
-    _zz_603 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_603[31 : 0] = CsrPlugin_mscratch;
-    end
-  end
-
-  always @ (*) begin
-    _zz_604 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_604[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_604[3 : 0] = CsrPlugin_mcause_exceptionCode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_605 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_605[31 : 0] = CsrPlugin_mtval;
-    end
-  end
-
-  always @ (*) begin
-    _zz_606 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_606[31 : 0] = CsrPlugin_mcycle[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_607 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_607[31 : 0] = CsrPlugin_mcycle[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_608 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_608[31 : 0] = CsrPlugin_minstret[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_609 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_609[31 : 0] = CsrPlugin_minstret[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_610 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_610[31 : 0] = CsrPlugin_mcycle[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_611 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_611[31 : 0] = CsrPlugin_mcycle[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_612 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_612[31 : 0] = CsrPlugin_minstret[31 : 0];
-    end
-  end
-
-  always @ (*) begin
-    _zz_613 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_613[31 : 0] = CsrPlugin_minstret[63 : 32];
-    end
-  end
-
-  always @ (*) begin
-    _zz_614 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_614[31 : 0] = _zz_569;
-    end
-  end
-
-  always @ (*) begin
-    _zz_615 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_615[31 : 0] = _zz_570;
-    end
-  end
-
-  assign execute_CsrPlugin_readData = (((((_zz_1178 | _zz_1179) | (_zz_1180 | _zz_1181)) | ((_zz_1182 | _zz_1183) | (_zz_1184 | _zz_1185))) | (((_zz_1186 | _zz_1187) | (_zz_1188 | _zz_1189)) | ((_zz_1190 | _zz_1191) | (_zz_1192 | _zz_1193)))) | ((((_zz_604 | _zz_605) | (_zz_606 | _zz_607)) | ((_zz_608 | _zz_609) | (_zz_610 | _zz_611))) | ((_zz_612 | _zz_613) | (_zz_614 | _zz_615))));
-  assign iBusWishbone_ADR = {_zz_958,_zz_616};
-  assign iBusWishbone_CTI = ((_zz_616 == 3'b111) ? 3'b111 : 3'b010);
+  assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
+  assign when_PmpPlugin_l155 = (CsrPlugin_privilege == 2'b11);
+  assign when_PmpPlugin_l172 = ((execute_PmpPlugin_pmpcfgCsr || execute_PmpPlugin_pmpaddrCsr) && (CsrPlugin_privilege == 2'b11));
+  assign when_PmpPlugin_l175 = ((! execute_PmpPlugin_fsmPending) && CsrPlugin_csrMapping_hazardFree);
+  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
+  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
-  assign iBusWishbone_DAT_MOSI = 32'h0;
-  always @ (*) begin
+  assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+  always @(*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_708)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_708)begin
+    if(when_InstructionCache_l239) begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_617;
+  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_623 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_619 = dBus_cmd_valid;
-  assign _zz_621 = dBus_cmd_payload_wr;
-  assign _zz_622 = (_zz_618 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_620 && (_zz_621 || _zz_622));
-  assign dBusWishbone_ADR = ((_zz_623 ? {{dBus_cmd_payload_address[31 : 5],_zz_618},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_623 ? (_zz_622 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_dBus_cmd_ready_5 = (dBus_cmd_payload_size == 3'b101);
+  assign _zz_dBus_cmd_ready_1 = dBus_cmd_valid;
+  assign _zz_dBus_cmd_ready_3 = dBus_cmd_payload_wr;
+  assign _zz_dBus_cmd_ready_4 = ((! _zz_dBus_cmd_ready_5) || (_zz_dBus_cmd_ready == 3'b111));
+  assign dBus_cmd_ready = (_zz_dBus_cmd_ready_2 && (_zz_dBus_cmd_ready_3 || _zz_dBus_cmd_ready_4));
+  assign when_DataCache_l345 = (_zz_dBus_cmd_ready_1 && _zz_dBus_cmd_ready_2);
+  assign dBusWishbone_ADR = ((_zz_dBus_cmd_ready_5 ? {{dBus_cmd_payload_address[31 : 5],_zz_dBus_cmd_ready},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_dBus_cmd_ready_5 ? (_zz_dBus_cmd_ready_4 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_621 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_621;
+  assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_3 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_dBus_cmd_ready_3;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_620 = (_zz_619 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_619;
-  assign dBusWishbone_STB = _zz_619;
-  assign dBus_rsp_valid = _zz_624;
+  assign _zz_dBus_cmd_ready_2 = (_zz_dBus_cmd_ready_1 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_dBus_cmd_ready_1;
+  assign dBusWishbone_STB = _zz_dBus_cmd_ready_1;
+  assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65 <= 1'b0;
-      _zz_67 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80;
+      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_90 <= 1'b0;
-      _zz_91 <= 2'b00;
-      _zz_109 <= 1'b0;
-      _zz_110 <= 2'b00;
-      _zz_128 <= 1'b0;
-      _zz_129 <= 2'b00;
-      _zz_147 <= 1'b0;
-      _zz_148 <= 2'b00;
-      _zz_166 <= 1'b0;
-      _zz_167 <= 2'b00;
-      _zz_185 <= 1'b0;
-      _zz_186 <= 2'b00;
-      _zz_204 <= 1'b0;
-      _zz_205 <= 2'b00;
-      _zz_223 <= 1'b0;
-      _zz_224 <= 2'b00;
-      _zz_242 <= 1'b0;
-      _zz_243 <= 2'b00;
-      _zz_261 <= 1'b0;
-      _zz_262 <= 2'b00;
-      _zz_280 <= 1'b0;
-      _zz_281 <= 2'b00;
-      _zz_299 <= 1'b0;
-      _zz_300 <= 2'b00;
-      _zz_318 <= 1'b0;
-      _zz_319 <= 2'b00;
-      _zz_337 <= 1'b0;
-      _zz_338 <= 2'b00;
-      _zz_356 <= 1'b0;
-      _zz_357 <= 2'b00;
-      _zz_375 <= 1'b0;
-      _zz_376 <= 2'b00;
-      _zz_521 <= 1'b1;
-      _zz_533 <= 1'b0;
-      _zz_558 <= 2'b11;
+      PmpPlugin_pmpcfg_0 <= 8'h0;
+      PmpPlugin_pmpcfg_1 <= 8'h0;
+      PmpPlugin_pmpcfg_2 <= 8'h0;
+      PmpPlugin_pmpcfg_3 <= 8'h0;
+      PmpPlugin_pmpcfg_4 <= 8'h0;
+      PmpPlugin_pmpcfg_5 <= 8'h0;
+      PmpPlugin_pmpcfg_6 <= 8'h0;
+      PmpPlugin_pmpcfg_7 <= 8'h0;
+      PmpPlugin_pmpcfg_8 <= 8'h0;
+      PmpPlugin_pmpcfg_9 <= 8'h0;
+      PmpPlugin_pmpcfg_10 <= 8'h0;
+      PmpPlugin_pmpcfg_11 <= 8'h0;
+      PmpPlugin_pmpcfg_12 <= 8'h0;
+      PmpPlugin_pmpcfg_13 <= 8'h0;
+      PmpPlugin_pmpcfg_14 <= 8'h0;
+      PmpPlugin_pmpcfg_15 <= 8'h0;
+      execute_PmpPlugin_fsmPending <= 1'b0;
+      execute_PmpPlugin_pmpcfgCsr_ <= 1'b0;
+      execute_PmpPlugin_pmpaddrCsr_ <= 1'b0;
+      execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
+      execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
+      _zz_10 <= 1'b1;
+      HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
+      _zz_CsrPlugin_privilege <= 2'b11;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0101064;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -8540,225 +9701,165 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_569 <= 32'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_572 <= 3'b000;
-      _zz_616 <= 3'b000;
-      _zz_617 <= 1'b0;
-      _zz_618 <= 3'b000;
-      _zz_624 <= 1'b0;
+      switch_Fetcher_l362 <= 3'b000;
+      execute_PmpPlugin_fsm_stateReg <= `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_BOOT;
+      _zz_iBusWishbone_ADR <= 3'b000;
+      _zz_iBus_rsp_valid <= 1'b0;
+      _zz_dBus_cmd_ready <= 3'b000;
+      _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction)begin
+      if(IBusCachedPlugin_fetchPc_correction) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l127) begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if((IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate))begin
+      if(when_Fetcher_l131) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready))begin
+      if(when_Fetcher_l131_2) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if((IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate)))begin
+      if(when_Fetcher_l158) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= 1'b0;
       end
-      if(_zz_63)begin
-        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready_2 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+      if(IBusCachedPlugin_iBusRsp_flush) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+      if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+        _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_valid <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready)))begin
+      if(when_Fetcher_l329) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if((! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready)))begin
+      if(when_Fetcher_l329_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_Fetcher_l329_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_Fetcher_l329_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_Fetcher_l329_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
-      if(IBusCachedPlugin_fetchPc_flushed)begin
+      if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(iBus_rsp_valid)begin
+      if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_709)begin
+      if(when_Stream_l365) begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid_1 <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
-      if(dBus_rsp_valid)begin
+      if(dBus_rsp_valid) begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(_zz_710)begin
-        _zz_90 <= _zz_96;
-        _zz_91 <= _zz_97;
+      if(when_PmpPlugin_l138) begin
+        execute_PmpPlugin_fsmPending <= 1'b0;
       end
-      if(_zz_711)begin
-        _zz_109 <= _zz_115;
-        _zz_110 <= _zz_116;
-      end
-      if(_zz_712)begin
-        _zz_128 <= _zz_134;
-        _zz_129 <= _zz_135;
-      end
-      if(_zz_713)begin
-        _zz_147 <= _zz_153;
-        _zz_148 <= _zz_154;
-      end
-      if(_zz_714)begin
-        _zz_166 <= _zz_172;
-        _zz_167 <= _zz_173;
-      end
-      if(_zz_715)begin
-        _zz_185 <= _zz_191;
-        _zz_186 <= _zz_192;
-      end
-      if(_zz_716)begin
-        _zz_204 <= _zz_210;
-        _zz_205 <= _zz_211;
-      end
-      if(_zz_717)begin
-        _zz_223 <= _zz_229;
-        _zz_224 <= _zz_230;
-      end
-      if(_zz_718)begin
-        _zz_242 <= _zz_248;
-        _zz_243 <= _zz_249;
-      end
-      if(_zz_719)begin
-        _zz_261 <= _zz_267;
-        _zz_262 <= _zz_268;
-      end
-      if(_zz_720)begin
-        _zz_280 <= _zz_286;
-        _zz_281 <= _zz_287;
-      end
-      if(_zz_721)begin
-        _zz_299 <= _zz_305;
-        _zz_300 <= _zz_306;
-      end
-      if(_zz_722)begin
-        _zz_318 <= _zz_324;
-        _zz_319 <= _zz_325;
-      end
-      if(_zz_723)begin
-        _zz_337 <= _zz_343;
-        _zz_338 <= _zz_344;
-      end
-      if(_zz_724)begin
-        _zz_356 <= _zz_362;
-        _zz_357 <= _zz_363;
-      end
-      if(_zz_725)begin
-        _zz_375 <= _zz_381;
-        _zz_376 <= _zz_382;
-      end
-      _zz_521 <= 1'b0;
-      _zz_533 <= (_zz_41 && writeBack_arbitration_isFiring);
-      if((! decode_arbitration_isStuck))begin
+      _zz_10 <= 1'b0;
+      HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
+      if(when_CsrPlugin_l909) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if((! execute_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if((! memory_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if((! writeBack_arbitration_isStuck))begin
+      if(when_CsrPlugin_l909_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_726)begin
-        if(_zz_727)begin
+      if(when_CsrPlugin_l946) begin
+        if(when_CsrPlugin_l952) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_728)begin
+        if(when_CsrPlugin_l952_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_729)begin
+        if(when_CsrPlugin_l952_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-      if(CsrPlugin_pipelineLiberator_active)begin
-        if((! execute_arbitration_isStuck))begin
+      if(CsrPlugin_pipelineLiberator_active) begin
+        if(when_CsrPlugin_l980) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if((! memory_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if((! writeBack_arbitration_isStuck))begin
+        if(when_CsrPlugin_l980_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt))begin
+      if(when_CsrPlugin_l985) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       end
-      if(CsrPlugin_interruptJump)begin
+      if(CsrPlugin_interruptJump) begin
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_688)begin
-        _zz_558 <= CsrPlugin_targetPrivilege;
+      if(when_CsrPlugin_l1019) begin
+        _zz_CsrPlugin_privilege <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -8769,272 +9870,513 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_689)begin
-        case(_zz_691)
+      if(when_CsrPlugin_l1064) begin
+        case(switch_CsrPlugin_l1068)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_558 <= CsrPlugin_mstatus_MPP;
+            _zz_CsrPlugin_privilege <= CsrPlugin_mstatus_MPP;
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_561,{_zz_560,_zz_559}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
+      if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
-      if(((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt)))begin
+      if(when_Pipeline_l154) begin
         execute_arbitration_isValid <= decode_arbitration_isValid;
       end
-      if(((! memory_arbitration_isStuck) || memory_arbitration_removeIt))begin
+      if(when_Pipeline_l151_1) begin
         memory_arbitration_isValid <= 1'b0;
       end
-      if(((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_1) begin
         memory_arbitration_isValid <= execute_arbitration_isValid;
       end
-      if(((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt))begin
+      if(when_Pipeline_l151_2) begin
         writeBack_arbitration_isValid <= 1'b0;
       end
-      if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
+      if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_572)
+      case(switch_Fetcher_l362)
         3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_572 <= 3'b001;
+          if(IBusCachedPlugin_injectionPort_valid) begin
+            switch_Fetcher_l362 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_572 <= 3'b010;
+          switch_Fetcher_l362 <= 3'b010;
         end
         3'b010 : begin
-          _zz_572 <= 3'b011;
+          switch_Fetcher_l362 <= 3'b011;
         end
         3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_572 <= 3'b100;
+          if(when_Fetcher_l378) begin
+            switch_Fetcher_l362 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_572 <= 3'b000;
+          switch_Fetcher_l362 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_769)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
-          CsrPlugin_misa_extensions <= execute_CsrPlugin_writeData[25 : 0];
+      execute_PmpPlugin_fsm_stateReg <= execute_PmpPlugin_fsm_stateNext;
+      case(execute_PmpPlugin_fsm_stateReg)
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateIdle : begin
+        end
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateWrite : begin
+          if(execute_PmpPlugin_pmpcfgCsr_) begin
+            if(when_PmpPlugin_l209) begin
+              if(_zz_11[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+              if(_zz_11[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0;
+              end
+            end
+            if(when_PmpPlugin_l209_1) begin
+              if(_zz_12[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+              if(_zz_12[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_1;
+              end
+            end
+            if(when_PmpPlugin_l209_2) begin
+              if(_zz_13[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+              if(_zz_13[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_2;
+              end
+            end
+            if(when_PmpPlugin_l209_3) begin
+              if(_zz_14[0]) begin
+                PmpPlugin_pmpcfg_0 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[1]) begin
+                PmpPlugin_pmpcfg_1 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[2]) begin
+                PmpPlugin_pmpcfg_2 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[3]) begin
+                PmpPlugin_pmpcfg_3 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[4]) begin
+                PmpPlugin_pmpcfg_4 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[5]) begin
+                PmpPlugin_pmpcfg_5 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[6]) begin
+                PmpPlugin_pmpcfg_6 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[7]) begin
+                PmpPlugin_pmpcfg_7 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[8]) begin
+                PmpPlugin_pmpcfg_8 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[9]) begin
+                PmpPlugin_pmpcfg_9 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[10]) begin
+                PmpPlugin_pmpcfg_10 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[11]) begin
+                PmpPlugin_pmpcfg_11 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[12]) begin
+                PmpPlugin_pmpcfg_12 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[13]) begin
+                PmpPlugin_pmpcfg_13 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[14]) begin
+                PmpPlugin_pmpcfg_14 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+              if(_zz_14[15]) begin
+                PmpPlugin_pmpcfg_15 <= _zz_PmpPlugin_pmpcfg_0_3;
+              end
+            end
+          end
+        end
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateCfg : begin
+          execute_PmpPlugin_fsm_fsmCounter <= (execute_PmpPlugin_fsm_fsmCounter + 4'b0001);
+        end
+        `execute_PmpPlugin_fsm_enumDefinition_defaultEncoding_execute_PmpPlugin_fsm_stateAddr : begin
+        end
+        default : begin
+        end
+      endcase
+      if(when_StateMachine_l214) begin
+        execute_PmpPlugin_fsm_fsmEnable <= 1'b1;
+      end
+      if(when_StateMachine_l230) begin
+        execute_PmpPlugin_fsmPending <= 1'b0;
+        execute_PmpPlugin_fsm_fsmEnable <= 1'b0;
+        execute_PmpPlugin_fsm_fsmCounter <= 4'b0000;
+      end
+      if(when_StateMachine_l230_1) begin
+        execute_PmpPlugin_fsm_fsmCounter <= {execute_PmpPlugin_pmpcfgN_,2'b00};
+      end
+      if(when_StateMachine_l230_2) begin
+        execute_PmpPlugin_fsm_fsmCounter <= execute_PmpPlugin_pmpNcfg_;
+      end
+      if(execute_CsrPlugin_csr_769) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_misa_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 30];
+          CsrPlugin_misa_extensions <= CsrPlugin_csrMapping_writeDataSignal[25 : 0];
         end
       end
-      if(execute_CsrPlugin_csr_768)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_951[0];
-          CsrPlugin_mstatus_MIE <= _zz_952[0];
+      if(execute_CsrPlugin_csr_768) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
+          CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_772)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_954[0];
-          CsrPlugin_mie_MTIE <= _zz_955[0];
-          CsrPlugin_mie_MSIE <= _zz_956[0];
+      if(execute_CsrPlugin_csr_772) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
+          CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
+          CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
         end
       end
-      if(execute_CsrPlugin_csr_3008)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_569 <= execute_CsrPlugin_writeData[31 : 0];
+      if(execute_CsrPlugin_csr_3008) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(_zz_708)begin
-        if(iBusWishbone_ACK)begin
-          _zz_616 <= (_zz_616 + 3'b001);
+      if(execute_CsrPlugin_writeInstruction) begin
+        if(when_PmpPlugin_l172) begin
+          if(when_PmpPlugin_l175) begin
+            execute_PmpPlugin_fsmPending <= 1'b1;
+            execute_PmpPlugin_pmpcfgCsr_ <= execute_PmpPlugin_pmpcfgCsr;
+            execute_PmpPlugin_pmpaddrCsr_ <= execute_PmpPlugin_pmpaddrCsr;
+          end
         end
       end
-      _zz_617 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_619 && _zz_620))begin
-        _zz_618 <= (_zz_618 + 3'b001);
-        if(_zz_622)begin
-          _zz_618 <= 3'b000;
+      if(when_InstructionCache_l239) begin
+        if(iBusWishbone_ACK) begin
+          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_624 <= ((_zz_619 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(when_DataCache_l345) begin
+        _zz_dBus_cmd_ready <= (_zz_dBus_cmd_ready + 3'b001);
+        if(_zz_dBus_cmd_ready_4) begin
+          _zz_dBus_cmd_ready <= 3'b000;
+        end
+      end
+      _zz_dBus_rsp_valid <= ((_zz_dBus_cmd_ready_1 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
-  always @ (posedge clk) begin
-    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+  always @(posedge clk) begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_output_ready) begin
+      _zz_IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
+    if(IBusCachedPlugin_iBusRsp_stages_2_input_ready) begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_709)begin
+    if(when_Stream_l365) begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
       dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
       dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size <= dataCache_1_io_mem_cmd_payload_size;
       dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready) begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_size_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_size;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last_1 <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(_zz_710)begin
-      _zz_87 <= _zz_93;
-      _zz_88 <= _zz_94;
-      _zz_89 <= _zz_95;
-      _zz_92 <= _zz_98;
+    if(when_PmpPlugin_l246) begin
+      if(_zz_8[0]) begin
+        PmpPlugin_base_0 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[1]) begin
+        PmpPlugin_base_1 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[2]) begin
+        PmpPlugin_base_2 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[3]) begin
+        PmpPlugin_base_3 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[4]) begin
+        PmpPlugin_base_4 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[5]) begin
+        PmpPlugin_base_5 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[6]) begin
+        PmpPlugin_base_6 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[7]) begin
+        PmpPlugin_base_7 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[8]) begin
+        PmpPlugin_base_8 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[9]) begin
+        PmpPlugin_base_9 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[10]) begin
+        PmpPlugin_base_10 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[11]) begin
+        PmpPlugin_base_11 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[12]) begin
+        PmpPlugin_base_12 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[13]) begin
+        PmpPlugin_base_13 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[14]) begin
+        PmpPlugin_base_14 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_8[15]) begin
+        PmpPlugin_base_15 <= PmpPlugin_setter_io_base;
+      end
+      if(_zz_9[0]) begin
+        PmpPlugin_mask_0 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[1]) begin
+        PmpPlugin_mask_1 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[2]) begin
+        PmpPlugin_mask_2 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[3]) begin
+        PmpPlugin_mask_3 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[4]) begin
+        PmpPlugin_mask_4 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[5]) begin
+        PmpPlugin_mask_5 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[6]) begin
+        PmpPlugin_mask_6 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[7]) begin
+        PmpPlugin_mask_7 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[8]) begin
+        PmpPlugin_mask_8 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[9]) begin
+        PmpPlugin_mask_9 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[10]) begin
+        PmpPlugin_mask_10 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[11]) begin
+        PmpPlugin_mask_11 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[12]) begin
+        PmpPlugin_mask_12 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[13]) begin
+        PmpPlugin_mask_13 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[14]) begin
+        PmpPlugin_mask_14 <= PmpPlugin_setter_io_mask;
+      end
+      if(_zz_9[15]) begin
+        PmpPlugin_mask_15 <= PmpPlugin_setter_io_mask;
+      end
     end
-    if(_zz_711)begin
-      _zz_106 <= _zz_112;
-      _zz_107 <= _zz_113;
-      _zz_108 <= _zz_114;
-      _zz_111 <= _zz_117;
-    end
-    if(_zz_712)begin
-      _zz_125 <= _zz_131;
-      _zz_126 <= _zz_132;
-      _zz_127 <= _zz_133;
-      _zz_130 <= _zz_136;
-    end
-    if(_zz_713)begin
-      _zz_144 <= _zz_150;
-      _zz_145 <= _zz_151;
-      _zz_146 <= _zz_152;
-      _zz_149 <= _zz_155;
-    end
-    if(_zz_714)begin
-      _zz_163 <= _zz_169;
-      _zz_164 <= _zz_170;
-      _zz_165 <= _zz_171;
-      _zz_168 <= _zz_174;
-    end
-    if(_zz_715)begin
-      _zz_182 <= _zz_188;
-      _zz_183 <= _zz_189;
-      _zz_184 <= _zz_190;
-      _zz_187 <= _zz_193;
-    end
-    if(_zz_716)begin
-      _zz_201 <= _zz_207;
-      _zz_202 <= _zz_208;
-      _zz_203 <= _zz_209;
-      _zz_206 <= _zz_212;
-    end
-    if(_zz_717)begin
-      _zz_220 <= _zz_226;
-      _zz_221 <= _zz_227;
-      _zz_222 <= _zz_228;
-      _zz_225 <= _zz_231;
-    end
-    if(_zz_718)begin
-      _zz_239 <= _zz_245;
-      _zz_240 <= _zz_246;
-      _zz_241 <= _zz_247;
-      _zz_244 <= _zz_250;
-    end
-    if(_zz_719)begin
-      _zz_258 <= _zz_264;
-      _zz_259 <= _zz_265;
-      _zz_260 <= _zz_266;
-      _zz_263 <= _zz_269;
-    end
-    if(_zz_720)begin
-      _zz_277 <= _zz_283;
-      _zz_278 <= _zz_284;
-      _zz_279 <= _zz_285;
-      _zz_282 <= _zz_288;
-    end
-    if(_zz_721)begin
-      _zz_296 <= _zz_302;
-      _zz_297 <= _zz_303;
-      _zz_298 <= _zz_304;
-      _zz_301 <= _zz_307;
-    end
-    if(_zz_722)begin
-      _zz_315 <= _zz_321;
-      _zz_316 <= _zz_322;
-      _zz_317 <= _zz_323;
-      _zz_320 <= _zz_326;
-    end
-    if(_zz_723)begin
-      _zz_334 <= _zz_340;
-      _zz_335 <= _zz_341;
-      _zz_336 <= _zz_342;
-      _zz_339 <= _zz_345;
-    end
-    if(_zz_724)begin
-      _zz_353 <= _zz_359;
-      _zz_354 <= _zz_360;
-      _zz_355 <= _zz_361;
-      _zz_358 <= _zz_364;
-    end
-    if(_zz_725)begin
-      _zz_372 <= _zz_378;
-      _zz_373 <= _zz_379;
-      _zz_374 <= _zz_380;
-      _zz_377 <= _zz_383;
-    end
-    _zz_534 <= _zz_40[11 : 7];
-    _zz_535 <= _zz_50;
+    HazardSimplePlugin_writeBackBuffer_payload_address <= HazardSimplePlugin_writeBackWrites_payload_address;
+    HazardSimplePlugin_writeBackBuffer_payload_data <= HazardSimplePlugin_writeBackWrites_payload_data;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
     CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring)begin
+    if(writeBack_arbitration_isFiring) begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_684)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_563 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_563 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_when) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
+    if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(BranchPlugin_branchExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
     end
-    if(DBusCachedPlugin_exceptionBus_valid)begin
+    if(DBusCachedPlugin_exceptionBus_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_726)begin
-      if(_zz_727)begin
+    if(when_CsrPlugin_l946) begin
+      if(when_CsrPlugin_l952) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_728)begin
+      if(when_CsrPlugin_l952_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_729)begin
+      if(when_CsrPlugin_l952_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_688)begin
+    if(when_CsrPlugin_l1019) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
           CsrPlugin_mcause_exceptionCode <= CsrPlugin_trapCause;
           CsrPlugin_mepc <= writeBack_PC;
-          if(CsrPlugin_hadException)begin
+          if(CsrPlugin_hadException) begin
             CsrPlugin_mtval <= CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
           end
         end
@@ -9042,455 +10384,415 @@ module VexRiscv (
         end
       endcase
     end
-    if((memory_DivPlugin_div_counter_value == 6'h20))begin
+    if(when_MulDivIterativePlugin_l126) begin
       memory_DivPlugin_div_done <= 1'b1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_MulDivIterativePlugin_l126_1) begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_679)begin
-      if(_zz_705)begin
+    if(when_MulDivIterativePlugin_l128) begin
+      if(when_MulDivIterativePlugin_l132) begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
-        if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_878[31:0];
+        if(when_MulDivIterativePlugin_l151) begin
+          memory_DivPlugin_div_result <= _zz_memory_DivPlugin_div_result_1[31:0];
         end
       end
     end
-    if(_zz_706)begin
+    if(when_MulDivIterativePlugin_l162) begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_567 ? (~ _zz_568) : _zz_568) + _zz_884);
-      memory_DivPlugin_rs2 <= ((_zz_566 ? (~ execute_RS2) : execute_RS2) + _zz_886);
-      memory_DivPlugin_div_needRevert <= ((_zz_567 ^ (_zz_566 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
+      memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124) begin
       decode_to_execute_PC <= decode_PC;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+    if(when_Pipeline_l124_1) begin
+      execute_to_memory_PC <= _zz_execute_SRC2;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+    if(when_Pipeline_l124_2) begin
       memory_to_writeBack_PC <= memory_PC;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_3) begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_4) begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_5) begin
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+    if(when_Pipeline_l124_6) begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_decode_to_execute_FORMAL_PC_NEXT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_7) begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+    if(when_Pipeline_l124_8) begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_memory_to_writeBack_FORMAL_PC_NEXT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_9) begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+    if(when_Pipeline_l124_10) begin
+      decode_to_execute_SRC1_CTRL <= _zz_decode_to_execute_SRC1_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_11) begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_12) begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_13) begin
       execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_14) begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+    if(when_Pipeline_l124_15) begin
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+    if(when_Pipeline_l124_16) begin
+      decode_to_execute_SRC2_CTRL <= _zz_decode_to_execute_SRC2_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_17) begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_18) begin
       execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_19) begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_20) begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_21) begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_22) begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_23) begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_24) begin
       execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_25) begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    if(when_Pipeline_l124_28) begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    if(when_Pipeline_l124_29) begin
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    if(when_Pipeline_l124_30) begin
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    if(when_Pipeline_l124_31) begin
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+    if(when_Pipeline_l124_33) begin
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+    if(when_Pipeline_l124_34) begin
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    if(when_Pipeline_l124_35) begin
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_37) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_38) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_41) begin
       decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_42) begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_43) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_44) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_45) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_46) begin
       decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_47) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_48) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_Pipeline_l124_49) begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_50) begin
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    if(when_Pipeline_l124_51) begin
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    if(when_Pipeline_l124_52) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    if(when_Pipeline_l124_53) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_54) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_55) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_56) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_57) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_58) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_59) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if((! memory_arbitration_isStuck))begin
+    if(when_Pipeline_l124_60) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! writeBack_arbitration_isStuck))begin
+    if(when_Pipeline_l124_62) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_944 <= (decode_INSTRUCTION[31 : 20] == 12'h3b0);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_945 <= (decode_INSTRUCTION[31 : 20] == 12'h3b1);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_946 <= (decode_INSTRUCTION[31 : 20] == 12'h3b2);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_947 <= (decode_INSTRUCTION[31 : 20] == 12'h3b3);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_948 <= (decode_INSTRUCTION[31 : 20] == 12'h3b4);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_949 <= (decode_INSTRUCTION[31 : 20] == 12'h3b5);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_950 <= (decode_INSTRUCTION[31 : 20] == 12'h3b6);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_951 <= (decode_INSTRUCTION[31 : 20] == 12'h3b7);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_952 <= (decode_INSTRUCTION[31 : 20] == 12'h3b8);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_953 <= (decode_INSTRUCTION[31 : 20] == 12'h3b9);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_954 <= (decode_INSTRUCTION[31 : 20] == 12'h3ba);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_955 <= (decode_INSTRUCTION[31 : 20] == 12'h3bb);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_956 <= (decode_INSTRUCTION[31 : 20] == 12'h3bc);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_957 <= (decode_INSTRUCTION[31 : 20] == 12'h3bd);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_958 <= (decode_INSTRUCTION[31 : 20] == 12'h3be);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_959 <= (decode_INSTRUCTION[31 : 20] == 12'h3bf);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_928 <= (decode_INSTRUCTION[31 : 20] == 12'h3a0);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_929 <= (decode_INSTRUCTION[31 : 20] == 12'h3a1);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_930 <= (decode_INSTRUCTION[31 : 20] == 12'h3a2);
-    end
-    if((! execute_arbitration_isStuck))begin
-      execute_CsrPlugin_csr_931 <= (decode_INSTRUCTION[31 : 20] == 12'h3a3);
-    end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if((! execute_arbitration_isStuck))begin
+    if(when_CsrPlugin_l1264_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_836)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_953[0];
+    if(execute_CsrPlugin_csr_836) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mip_MSIP <= CsrPlugin_csrMapping_writeDataSignal[3];
       end
     end
-    if(execute_CsrPlugin_csr_773)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtvec_base <= execute_CsrPlugin_writeData[31 : 2];
-        CsrPlugin_mtvec_mode <= execute_CsrPlugin_writeData[1 : 0];
+    if(execute_CsrPlugin_csr_773) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtvec_base <= CsrPlugin_csrMapping_writeDataSignal[31 : 2];
+        CsrPlugin_mtvec_mode <= CsrPlugin_csrMapping_writeDataSignal[1 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_833)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mepc <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_833) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mepc <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_832)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mscratch <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_832) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mscratch <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_834)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_957[0];
-        CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
+    if(execute_CsrPlugin_csr_834) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcause_interrupt <= CsrPlugin_csrMapping_writeDataSignal[31];
+        CsrPlugin_mcause_exceptionCode <= CsrPlugin_csrMapping_writeDataSignal[3 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_835)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mtval <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_835) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2816) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcycle[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2944) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2818)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[31 : 0] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2818) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_minstret[63 : 32] <= execute_CsrPlugin_writeData[31 : 0];
+    if(execute_CsrPlugin_csr_2946) begin
+      if(execute_CsrPlugin_writeEnable) begin
+        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+      end
+    end
+    if(execute_CsrPlugin_writeInstruction) begin
+      if(when_PmpPlugin_l172) begin
+        if(when_PmpPlugin_l175) begin
+          execute_PmpPlugin_writeData_ <= CsrPlugin_csrMapping_writeDataSignal;
+          execute_PmpPlugin_pmpNcfg_ <= execute_PmpPlugin_pmpNcfg;
+          execute_PmpPlugin_pmpcfgN_ <= execute_PmpPlugin_pmpcfgN;
+        end
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
+    if(debug_bus_cmd_ready) begin
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
+    if(writeBack_arbitration_isValid) begin
+      DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
-    _zz_571 <= debug_bus_cmd_payload_address[2];
-    if(_zz_686)begin
+    _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
+    if(when_DebugPlugin_l284) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(debugReset) begin
       DebugPlugin_resetIt <= 1'b0;
       DebugPlugin_haltIt <= 1'b0;
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
+      DebugPlugin_debugUsed <= 1'b0;
+      DebugPlugin_disableEbreak <= 1'b0;
     end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
+      if(when_DebugPlugin_l225) begin
         DebugPlugin_godmode <= 1'b1;
       end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_707)
+      if(debug_bus_cmd_valid) begin
+        DebugPlugin_debugUsed <= 1'b1;
+      end
+      if(debug_bus_cmd_valid) begin
+        case(switch_DebugPlugin_l256)
           6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
+            if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
+              if(when_DebugPlugin_l260) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[24])begin
+              if(when_DebugPlugin_l260_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[17])begin
+              if(when_DebugPlugin_l261) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l261_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l262) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(debug_bus_cmd_payload_data[25])begin
+              if(when_DebugPlugin_l263) begin
                 DebugPlugin_godmode <= 1'b0;
+              end
+              if(when_DebugPlugin_l264) begin
+                DebugPlugin_disableEbreak <= 1'b1;
+              end
+              if(when_DebugPlugin_l264_1) begin
+                DebugPlugin_disableEbreak <= 1'b0;
               end
             end
           end
@@ -9498,14 +10800,14 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_686)begin
-        if(_zz_687)begin
+      if(when_DebugPlugin_l284) begin
+        if(when_DebugPlugin_l287) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_690)begin
-        if(decode_arbitration_isValid)begin
+      if(when_DebugPlugin_l300) begin
+        if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
@@ -9518,9 +10820,8 @@ endmodule
 module DataCache (
   input               io_cpu_execute_isValid,
   input      [31:0]   io_cpu_execute_address,
-  output              io_cpu_execute_haltIt,
+  output reg          io_cpu_execute_haltIt,
   input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
   input      [1:0]    io_cpu_execute_args_size,
   input               io_cpu_execute_args_totalyConsistent,
   output              io_cpu_execute_refilling,
@@ -9542,6 +10843,7 @@ module DataCache (
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
+  input      [31:0]   io_cpu_writeBack_storeData,
   output reg [31:0]   io_cpu_writeBack_data,
   input      [31:0]   io_cpu_writeBack_address,
   output              io_cpu_writeBack_mmuException,
@@ -9557,9 +10859,10 @@ module DataCache (
   input               io_cpu_writeBack_fence_PO,
   input               io_cpu_writeBack_fence_PI,
   input      [3:0]    io_cpu_writeBack_fence_FM,
+  output              io_cpu_writeBack_exclusiveOk,
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
+  output              io_cpu_flush_ready,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -9567,7 +10870,7 @@ module DataCache (
   output reg [31:0]   io_mem_cmd_payload_address,
   output     [31:0]   io_mem_cmd_payload_data,
   output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
+  output reg [2:0]    io_mem_cmd_payload_size,
   output              io_mem_cmd_payload_last,
   input               io_mem_rsp_valid,
   input               io_mem_rsp_payload_last,
@@ -9576,24 +10879,15 @@ module DataCache (
   input               clk,
   input               reset
 );
-  reg        [21:0]   _zz_10;
-  reg        [31:0]   _zz_11;
-  wire                _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire                _zz_15;
-  wire                _zz_16;
-  wire                _zz_17;
-  wire                _zz_18;
-  wire       [0:0]    _zz_19;
-  wire       [0:0]    _zz_20;
-  wire       [9:0]    _zz_21;
-  wire       [9:0]    _zz_22;
-  wire       [0:0]    _zz_23;
-  wire       [0:0]    _zz_24;
-  wire       [2:0]    _zz_25;
-  wire       [1:0]    _zz_26;
-  wire       [21:0]   _zz_27;
+  reg        [21:0]   _zz_ways_0_tags_port0;
+  reg        [31:0]   _zz_ways_0_data_port0;
+  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [9:0]    _zz_stage0_dataColisions;
+  wire       [9:0]    _zz__zz_stageA_dataColisions;
+  wire       [0:0]    _zz_when;
+  wire       [2:0]    _zz_loader_counter_valueNext;
+  wire       [0:0]    _zz_loader_counter_valueNext_1;
+  wire       [1:0]    _zz_loader_waysAllocator;
   reg                 _zz_1;
   reg                 _zz_2;
   wire                haltCpu;
@@ -9618,40 +10912,48 @@ module DataCache (
   reg        [9:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3;
+  wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
   wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4;
-  wire                _zz_5;
+  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
+  wire                when_DataCache_l634;
+  wire                when_DataCache_l637;
+  wire                when_DataCache_l656;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
-  reg        [3:0]    _zz_6;
+  wire                when_DataCache_l678;
+  wire                when_DataCache_l678_1;
+  reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
+  wire                when_DataCache_l763;
   reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
+  wire                when_DataCache_l763_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire       [0:0]    _zz_7;
+  wire                when_DataCache_l763_2;
   reg        [0:0]    stageA_wayInvalidate;
+  wire                when_DataCache_l763_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
-  wire       [0:0]    _zz_8;
+  wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
+  wire                when_DataCache_l814;
   reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
+  wire                when_DataCache_l816;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -9661,23 +10963,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
+  wire                when_DataCache_l813;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
+  wire                when_DataCache_l813_1;
   reg        [31:0]   stageB_dataReadRsp_0;
+  wire                when_DataCache_l812;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
+  wire                when_DataCache_l812_1;
   reg        [0:0]    stageB_dataColisions;
+  wire                when_DataCache_l812_2;
   reg                 stageB_unaligned;
+  wire                when_DataCache_l812_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
+  wire                when_DataCache_l812_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
-  reg                 stageB_flusher_valid;
+  reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
+  reg        [7:0]    stageB_flusher_counter;
+  wire                when_DataCache_l842;
+  wire                when_DataCache_l848;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -9685,10 +10997,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
+  wire                when_DataCache_l911;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire       [0:0]    _zz_9;
+  wire                when_DataCache_l980;
+  wire                when_DataCache_l989;
+  wire                when_DataCache_l994;
+  wire                when_DataCache_l1005;
+  wire                when_DataCache_l1017;
+  wire                when_DataCache_l976;
+  wire                when_DataCache_l1051;
+  wire                when_DataCache_l1060;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -9700,59 +11020,54 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
+  wire                when_DataCache_l1075;
   wire                loader_done;
+  wire                when_DataCache_l1103;
   reg                 loader_valid_regNext;
+  wire                when_DataCache_l1107;
+  wire                when_DataCache_l1110;
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
   (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_28;
-  reg [7:0] _zz_29;
-  reg [7:0] _zz_30;
-  reg [7:0] _zz_31;
+  reg [7:0] _zz_ways_0_datasymbol_read;
+  reg [7:0] _zz_ways_0_datasymbol_read_1;
+  reg [7:0] _zz_ways_0_datasymbol_read_2;
+  reg [7:0] _zz_ways_0_datasymbol_read_3;
 
-  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
-  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
-  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign _zz_17 = (! stageB_flusher_hold);
-  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_19 = _zz_4[0 : 0];
-  assign _zz_20 = _zz_4[1 : 1];
-  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
-  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
-  assign _zz_23 = 1'b1;
-  assign _zz_24 = loader_counter_willIncrement;
-  assign _zz_25 = {2'd0, _zz_24};
-  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3) begin
-      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+  assign _zz_stage0_dataColisions = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz__zz_stageA_dataColisions = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_when = 1'b1;
+  assign _zz_loader_counter_valueNext_1 = loader_counter_willIncrement;
+  assign _zz_loader_counter_valueNext = {2'd0, _zz_loader_counter_valueNext_1};
+  assign _zz_loader_waysAllocator = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @(posedge clk) begin
+    if(_zz_ways_0_tagsReadRsp_valid) begin
+      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (*) begin
-    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  always @(*) begin
+    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+  always @(posedge clk) begin
+    if(_zz_ways_0_dataReadRspMem) begin
+      _zz_ways_0_datasymbol_read <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_1 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_2 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_ways_0_datasymbol_read_3 <= ways_0_data_symbol3[dataReadCmd_payload];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(dataWriteCmd_payload_mask[0] && _zz_1) begin
       ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
     end
@@ -9767,274 +11082,293 @@ module DataCache (
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l637) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+    if(when_DataCache_l634) begin
       _zz_2 = 1'b1;
     end
   end
 
   assign haltCpu = 1'b0;
-  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4 = _zz_10;
-  assign ways_0_tagsReadRsp_valid = _zz_19[0];
-  assign ways_0_tagsReadRsp_error = _zz_20[0];
-  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
-  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_11;
+  assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
+  assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  always @ (*) begin
+  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    tagsReadCmd_payload = 7'bxxxxxxx;
+    if(when_DataCache_l656) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(_zz_12)begin
+    if(when_DataCache_l656) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12)begin
+  always @(*) begin
+    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    if(when_DataCache_l656) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_valid = 1'b1;
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       tagsWriteCmd_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+  always @(*) begin
+    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    if(when_DataCache_l842) begin
+      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
+    if(when_DataCache_l842) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_done)begin
+    if(loader_done) begin
       tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
     end
   end
 
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_done)begin
+  always @(*) begin
+    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    if(loader_done) begin
       tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_valid = 1'b0;
-    if(stageB_cpuWriteToCache)begin
-      if((stageB_request_wr && stageB_waysHit))begin
+    if(stageB_cpuWriteToCache) begin
+      if(when_DataCache_l911) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_way = 1'bx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
 
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(stageB_cpuWriteToCache)begin
+  always @(*) begin
+    dataWriteCmd_payload_data = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     dataWriteCmd_payload_mask = 4'bxxxx;
-    if(stageB_cpuWriteToCache)begin
+    if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_mask = 4'b0000;
-      if(_zz_23[0])begin
+      if(_zz_when[0]) begin
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign io_cpu_execute_haltIt = 1'b0;
+  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  always @(*) begin
+    io_cpu_execute_haltIt = 1'b0;
+    if(when_DataCache_l842) begin
+      io_cpu_execute_haltIt = 1'b1;
+    end
+  end
+
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
-  always @ (*) begin
+  assign when_DataCache_l678 = (io_mem_cmd_valid && io_mem_cmd_ready);
+  assign when_DataCache_l678_1 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
+    _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
       2'b00 : begin
-        _zz_6 = 4'b0001;
+        _zz_stage0_mask = 4'b0001;
       end
       2'b01 : begin
-        _zz_6 = 4'b0011;
+        _zz_stage0_mask = 4'b0011;
+      end
+      2'b10 : begin
+        _zz_stage0_mask = 4'b1111;
       end
       default : begin
-        _zz_6 = 4'b1111;
       end
     endcase
   end
 
-  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
+  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
-  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign stageA_wayHits = _zz_7;
-  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
-  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
-  always @ (*) begin
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
+  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
+    if(when_DataCache_l1110) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
+  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
+  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
   assign stageB_waysHit = (stageB_waysHits != 1'b0);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
+  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  always @(*) begin
     stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
-            if(io_mem_cmd_ready)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       stageB_loaderValid = 1'b0;
     end
   end
 
   assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
-          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+  always @(*) begin
+    io_cpu_writeBack_haltIt = 1'b1;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
+          if(when_DataCache_l980) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(_zz_16)begin
-            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l994) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
+  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
   assign stageB_isExternalLsrc = 1'b0;
   assign stageB_isExternalAmo = 1'b0;
-  assign stageB_requestDataBypass = stageB_request_data;
-  always @ (*) begin
+  assign stageB_requestDataBypass = io_cpu_writeBack_storeData;
+  always @(*) begin
     stageB_cpuWriteToCache = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -10042,89 +11376,73 @@ module DataCache (
     end
   end
 
+  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
-  always @ (*) begin
+  always @(*) begin
     io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(when_DataCache_l989) begin
+            if(when_DataCache_l1005) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+    if(when_DataCache_l1060) begin
       io_cpu_redo = 1'b1;
     end
-    if((loader_valid && (! loader_valid_regNext)))begin
+    if(when_DataCache_l1107) begin
       io_cpu_redo = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_bypassCache)begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
     end else begin
-      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+      io_cpu_writeBack_accessError = (((stageB_waysHits & stageB_tagsReadRsp_0_error) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
     end
   end
 
   assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
   assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
   assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(_zz_15)begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(when_DataCache_l976) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(_zz_16)begin
-            if(stageB_request_wr)begin
+          if(when_DataCache_l989) begin
+            if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if((! memCmdSent))begin
+            if(when_DataCache_l1017) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(_zz_13)begin
+    if(when_DataCache_l1051) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
 
-  always @ (*) begin
-    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
-          end else begin
-            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-          end
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = 3'b000;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(_zz_16)begin
-            io_mem_cmd_payload_length = 3'b000;
-          end else begin
-            io_mem_cmd_payload_length = 3'b111;
+  always @(*) begin
+    io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -10132,12 +11450,12 @@ module DataCache (
   end
 
   assign io_mem_cmd_payload_last = 1'b1;
-  always @ (*) begin
+  always @(*) begin
     io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_isExternalAmo) begin
-        if(! _zz_15) begin
-          if(! _zz_16) begin
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -10148,20 +11466,40 @@ module DataCache (
   assign io_mem_cmd_payload_mask = stageB_mask;
   assign io_mem_cmd_payload_data = stageB_requestDataBypass;
   assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  always @(*) begin
+    io_mem_cmd_payload_size = {1'd0, stageB_request_size};
+    if(io_cpu_writeBack_isValid) begin
+      if(!stageB_isExternalAmo) begin
+        if(!when_DataCache_l976) begin
+          if(!when_DataCache_l989) begin
+            io_mem_cmd_payload_size = 3'b101;
+          end
+        end
+      end
+    end
+  end
+
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  always @ (*) begin
-    if(stageB_bypassCache)begin
+  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1017 = (! memCmdSent);
+  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  always @(*) begin
+    if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
     end else begin
       io_cpu_writeBack_data = stageB_dataMux;
     end
   end
 
-  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
+  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(_zz_14)begin
+    if(when_DataCache_l1075) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -10169,45 +11507,47 @@ module DataCache (
   assign loader_counter_willClear = 1'b0;
   assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
   assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_25);
-    if(loader_counter_willClear)begin
+  always @(*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_loader_counter_valueNext);
+    if(loader_counter_willClear) begin
       loader_counter_valueNext = 3'b000;
     end
   end
 
   assign loader_kill = 1'b0;
+  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
+  assign when_DataCache_l1103 = (! loader_valid);
+  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  always @ (posedge clk) begin
+  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
     tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_1) begin
       stageA_mask <= stage0_mask;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if((! io_cpu_memory_isStuck))begin
+    if(when_DataCache_l763_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l814) begin
       stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+    if(when_DataCache_l816) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -10218,46 +11558,37 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l813_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    if(when_DataCache_l812_2) begin
+      stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if((! io_cpu_writeBack_isStuck))begin
+    if(when_DataCache_l812_4) begin
       stageB_mask <= stageA_mask;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_17)begin
-        if(_zz_18)begin
-          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-        end
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
     end
     loader_valid_regNext <= loader_valid;
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(reset) begin
       memCmdSent <= 1'b0;
-      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_waitDone <= 1'b0;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       loader_valid <= 1'b0;
       loader_counter_value <= 3'b000;
@@ -10265,50 +11596,51 @@ module DataCache (
       loader_error <= 1'b0;
       loader_killReg <= 1'b0;
     end else begin
-      if(io_mem_cmd_ready)begin
+      if(when_DataCache_l678) begin
         memCmdSent <= 1'b1;
       end
-      if((! io_cpu_writeBack_isStuck))begin
+      if(when_DataCache_l678_1) begin
         memCmdSent <= 1'b0;
       end
-      if(stageB_flusher_valid)begin
-        if(_zz_17)begin
-          if(! _zz_18) begin
-            stageB_flusher_valid <= 1'b0;
-          end
+      if(io_cpu_flush_ready) begin
+        stageB_flusher_waitDone <= 1'b0;
+      end
+      if(when_DataCache_l842) begin
+        if(when_DataCache_l848) begin
+          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
         end
       end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
+      stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start) begin
+        stageB_flusher_waitDone <= 1'b1;
+        stageB_flusher_counter <= 8'h0;
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
           assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("FAILURE writeBack stuck by another plugin is not allowed");
-            $finish;
+            $display("ERROR writeBack stuck by another plugin is not allowed");
           end
         `endif
       `endif
-      if(stageB_loaderValid)begin
+      if(stageB_loaderValid) begin
         loader_valid <= 1'b1;
       end
       loader_counter_value <= loader_counter_valueNext;
-      if(loader_kill)begin
+      if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_DataCache_l1075) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
-      if(loader_done)begin
+      if(loader_done) begin
         loader_valid <= 1'b0;
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_26[0:0];
+      if(when_DataCache_l1103) begin
+        loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
   end
@@ -10355,18 +11687,14 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
+  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [21:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [21:0]   _zz_17;
+  reg        [31:0]   _zz_banks_0_port1;
+  reg        [21:0]   _zz_ways_0_tags_port1;
+  wire       [21:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -10375,8 +11703,13 @@ module InstructionCache (
   reg                 lineLoader_hadError;
   reg                 lineLoader_flushPending;
   reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3;
+  wire                when_InstructionCache_l338;
+  reg                 _zz_when_InstructionCache_l342;
+  wire                when_InstructionCache_l342;
+  wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
+  wire                when_InstructionCache_l358;
+  wire                when_Utils_l357;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -10390,22 +11723,25 @@ module InstructionCache (
   wire                lineLoader_write_data_0_valid;
   wire       [9:0]    lineLoader_write_data_0_payload_address;
   wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire       [9:0]    _zz_4;
-  wire                _zz_5;
+  wire                when_InstructionCache_l401;
+  wire       [9:0]    _zz_fetchStage_read_banksValue_0_dataMem;
+  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
   wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
   wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [6:0]    _zz_6;
-  wire                _zz_7;
+  wire       [6:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
+  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
   wire                fetchStage_read_waysValues_0_tag_valid;
   wire                fetchStage_read_waysValues_0_tag_error;
   wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_8;
+  wire       [21:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
   wire                fetchStage_hit_hits_0;
   wire                fetchStage_hit_valid;
   wire                fetchStage_hit_error;
   wire       [31:0]   fetchStage_hit_data;
   wire       [31:0]   fetchStage_hit_word;
+  wire                when_InstructionCache_l435;
   reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  wire                when_InstructionCache_l459;
   reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
   reg                 decodeStage_mmuRsp_isIoAccess;
   reg                 decodeStage_mmuRsp_isPaging;
@@ -10415,82 +11751,86 @@ module InstructionCache (
   reg                 decodeStage_mmuRsp_exception;
   reg                 decodeStage_mmuRsp_refilling;
   reg                 decodeStage_mmuRsp_bypassTranslation;
+  wire                when_InstructionCache_l459_1;
   reg                 decodeStage_hit_valid;
+  wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
+  wire                when_Fetcher_l398;
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_13 = (! lineLoader_flushCounter[7]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
+  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @(posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
+      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
-  always @ (posedge clk) begin
+  always @(posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
     end
   end
 
-  always @ (posedge clk) begin
-    if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+  always @(posedge clk) begin
+    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
+      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
+    if(lineLoader_write_data_0_valid) begin
       _zz_1 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
+    if(lineLoader_write_tag_0_valid) begin
       _zz_2 = 1'b1;
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == 3'b111))begin
+    if(io_mem_rsp_valid) begin
+      if(when_InstructionCache_l401) begin
         lineLoader_fire = 1'b1;
       end
     end
   end
 
-  always @ (*) begin
+  always @(*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if((! _zz_3))begin
+    if(when_InstructionCache_l342) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
-    if(io_flush)begin
+    if(io_flush) begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
   end
 
+  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[7]);
+  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
+  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign when_InstructionCache_l358 = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  always @ (*) begin
+  assign when_Utils_l357 = (! lineLoader_valid);
+  always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
+    if(when_Utils_l357) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -10506,30 +11846,36 @@ module InstructionCache (
   assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
   assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
+  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
   assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign when_InstructionCache_l435 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
   assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign when_InstructionCache_l459 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_1 = (! io_cpu_decode_isStuck);
+  assign when_InstructionCache_l459_2 = (! io_cpu_decode_isStuck);
   assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
   assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
+  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
       lineLoader_hadError <= 1'b0;
@@ -10537,51 +11883,51 @@ module InstructionCache (
       lineLoader_cmdSent <= 1'b0;
       lineLoader_wordIndex <= 3'b000;
     end else begin
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_valid <= 1'b0;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_hadError <= 1'b0;
       end
-      if(io_cpu_fill_valid)begin
+      if(io_cpu_fill_valid) begin
         lineLoader_valid <= 1'b1;
       end
-      if(io_flush)begin
+      if(io_flush) begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(when_InstructionCache_l351) begin
         lineLoader_flushPending <= 1'b0;
       end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+      if(when_InstructionCache_l358) begin
         lineLoader_cmdSent <= 1'b1;
       end
-      if(lineLoader_fire)begin
+      if(lineLoader_fire) begin
         lineLoader_cmdSent <= 1'b0;
       end
-      if(io_mem_rsp_valid)begin
+      if(io_mem_rsp_valid) begin
         lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error)begin
+        if(io_mem_rsp_payload_error) begin
           lineLoader_hadError <= 1'b1;
         end
       end
     end
   end
 
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
+  always @(posedge clk) begin
+    if(io_cpu_fill_valid) begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(when_InstructionCache_l338) begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
-    _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_14)begin
+    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[7];
+    if(when_InstructionCache_l351) begin
       lineLoader_flushCounter <= 8'h0;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l435) begin
       io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459) begin
       decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
       decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
       decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
@@ -10592,16 +11938,31 @@ module InstructionCache (
       decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
       decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_1) begin
       decodeStage_hit_valid <= fetchStage_hit_valid;
     end
-    if((! io_cpu_decode_isStuck))begin
+    if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
+    if(when_Fetcher_l398) begin
+      io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end
 
+
+endmodule
+
+module PmpSetter (
+  input      [31:0]   io_addr,
+  output     [24:0]   io_base,
+  output     [24:0]   io_mask
+);
+  wire       [31:0]   _zz_ones;
+  wire       [31:0]   ones;
+
+  assign _zz_ones = (io_addr + 32'h00000001);
+  assign ones = (io_addr & (~ _zz_ones));
+  assign io_base = (io_addr[29 : 5] ^ ones[29 : 5]);
+  assign io_mask = (~ ones[30 : 6]);
 
 endmodule

--- a/pythondata_cpu_vexriscv/verilog/build.sbt
+++ b/pythondata_cpu_vexriscv/verilog/build.sbt
@@ -1,4 +1,4 @@
-val spinalVersion = "1.4.3"
+val spinalVersion = "1.5.0"
 
 lazy val root = (project in file(".")).
   settings(

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -23,7 +23,8 @@ case class ArgConfig(
   debug : Boolean = false,
   iCacheSize : Int = 4096,
   dCacheSize : Int = 4096,
-  pmp : Boolean = false,
+  pmpRegions : Int = 0,
+  pmpGranularity : Int = 256,
   mulDiv : Boolean = true,
   cfu : Boolean = false,
   atomics: Boolean = false,
@@ -61,7 +62,8 @@ object GenCoreDefault{
       opt[Int]("iCacheSize")     action { (v, c) => c.copy(iCacheSize = v) } text("Set instruction cache size, 0 mean no cache")
       // ex : -dCacheSize=XXX
       opt[Int]("dCacheSize")     action { (v, c) => c.copy(dCacheSize = v) } text("Set data cache size, 0 mean no cache")
-      opt[Boolean]("pmp")    action { (v, c) => c.copy(pmp = v)   } text("Enable physical memory protection")
+      opt[Int]("pmpRegions")    action { (v, c) => c.copy(pmpRegions = v)   } text("Number of PMP regions, 0 disables PMP")
+      opt[Int]("pmpGranularity")    action { (v, c) => c.copy(pmpGranularity = v)   } text("Granularity of PMP regions (in bytes)")
       opt[Boolean]("mulDiv")    action { (v, c) => c.copy(mulDiv = v)   } text("set RV32IM")
       opt[Boolean]("cfu")       action { (v, c) => c.copy(cfu = v)   } text("If true, add SIMD ADD custom function unit")
       opt[Boolean]("atomics")    action { (v, c) => c.copy(atomics = v)   } text("set RV32I[A]")
@@ -152,8 +154,8 @@ object GenCoreDefault{
         },
         if (linux) new MmuPlugin(
           ioRange = (x => x(31 downto 28) === 0xB || x(31 downto 28) === 0xE || x(31 downto 28) === 0xF)
-        ) else if (argConfig.pmp) new PmpPlugin(
-          regions = 16, ioRange = _.msb
+        ) else if (argConfig.pmpRegions > 0) new PmpPlugin(
+          regions = argConfig.pmpRegions, granularity = argConfig.pmpGranularity, ioRange = _.msb
         ) else new StaticMemoryTranslatorPlugin(
           ioRange      = _.msb
         ),


### PR DESCRIPTION
The PMP plugin has been heavily optimized for FPGAs since the last LiteX update (see https://github.com/SpinalHDL/VexRiscv/pull/174). Thank you @kgugala @Dolu1990 for the help.