### PR TITLE
Add build check to make sure that VexRiscv source is present.

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/Makefile
+++ b/pythondata_cpu_vexriscv/verilog/Makefile
@@ -2,6 +2,10 @@ SRC := ${shell find . -type f -name \*.scala}
 
 all: VexRiscv.v VexRiscv_Debug.v VexRiscv_Lite.v VexRiscv_LiteDebug.v VexRiscv_LiteDebugHwBP.v VexRiscv_IMAC.v VexRiscv_IMACDebug.v VexRiscv_Min.v VexRiscv_MinDebug.v VexRiscv_MinDebugHwBP.v VexRiscv_Full.v VexRiscv_FullDebug.v VexRiscv_FullCfu.v VexRiscv_FullCfuDebug.v VexRiscv_Linux.v VexRiscv_LinuxDebug.v VexRiscv_LinuxNoDspFmax.v VexRiscv_Secure.v VexRiscv_SecureDebug.v
 
+ifeq (,$(wildcard ext/VexRiscv/.github))
+$(error Must init/update submodule to get VexRiscv source. Run "git submodule update --init")
+endif
+
 VexRiscv.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault"
 


### PR DESCRIPTION
If the source submodule is not loaded, the Scala error is confusing.  This gives a more useful error with instructions.

(an alternative would be to have the Makefile just go ahead and load the submodule dependency...I could do that instead.)

Signed-off-by: Tim Callahan <tcal@google.com>